### PR TITLE
FISH-10286 Enhancement: Use <domain_dir>/lib/warlibs to enable fast deployments

### DIFF
--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/archivist/WebArchivist.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/archivist/WebArchivist.java
@@ -41,13 +41,19 @@
 
 package org.glassfish.web.deployment.archivist;
 
+import com.sun.enterprise.deploy.shared.ArchiveFactory;
 import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.EarType;
+import org.glassfish.deployment.common.InstalledLibrariesResolver;
 import org.glassfish.deployment.common.RootDeploymentDescriptor;
 import com.sun.enterprise.deployment.EjbBundleDescriptor;
 import com.sun.enterprise.deployment.EjbDescriptor;
 import com.sun.enterprise.deployment.WebComponentDescriptor;
 import com.sun.enterprise.deployment.annotation.impl.ModuleScanner;
+import org.glassfish.hk2.classmodel.reflect.Parser;
+import org.glassfish.hk2.classmodel.reflect.Type;
+import org.glassfish.hk2.classmodel.reflect.Types;
+import org.glassfish.internal.deployment.Deployment;
 import org.glassfish.web.deployment.annotation.impl.WarScanner;
 import com.sun.enterprise.deployment.archivist.Archivist;
 import com.sun.enterprise.deployment.archivist.ArchivistFor;
@@ -73,6 +79,7 @@ import org.xml.sax.SAXParseException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -83,6 +90,7 @@ import java.util.Set;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 
 /**
@@ -105,6 +113,10 @@ public class WebArchivist extends Archivist<WebBundleDescriptorImpl> {
     private ServerEnvironment env;
 
     private WebBundleDescriptorImpl defaultWebXmlBundleDescriptor = null;
+    @Inject
+    private ArchiveFactory archiveFactory;
+    @Inject
+    private Deployment deployment;
 
     /**
      * @return the  module type handled by this archivist
@@ -307,6 +319,10 @@ public class WebArchivist extends Archivist<WebBundleDescriptorImpl> {
             // EAR shared libraries
             extractLibraries(parentArchive.getSubArchive("lib"), false, libraries);
         }
+        // Webapp shared libraries
+        if(DeploymentUtils.useWarLibraries(deployment.getCurrentDeploymentContext())) {
+            InstalledLibrariesResolver.getWarLibraries().forEach(warLibrary -> libraries.add(warLibrary.toString()));
+        }
         return libraries;
     }
 
@@ -344,10 +360,27 @@ public class WebArchivist extends Archivist<WebBundleDescriptorImpl> {
                 // all web fragment metadata-complete
                 // should be overridden and be true also
                 if (descriptor.isFullAttribute()) {
-                  wfDesc.setFullAttribute(
-                      String.valueOf(descriptor.isFullAttribute()));
+                    wfDesc.setFullAttribute(
+                            String.valueOf(descriptor.isFullAttribute()));
                 }
-                super.readAnnotations(archive, wfDesc, localExtensions);
+                if (wfDesc.isWarLibrary()) {
+                    if (!DeploymentUtils.getWarLibraryCache().containsKey(wfDesc.getWarLibraryPath())) {
+                        ReadableArchive warArchive = null;
+                        try {
+                            warArchive = archiveFactory.openArchive(new File(wfDesc.getWarLibraryPath()));
+                            warArchive.setExtraData(Parser.class, archive.getExtraData(Parser.class));
+                            super.readAnnotations(warArchive, wfDesc, localExtensions);
+                        } finally {
+                            if (warArchive != null) {
+                                warArchive.close();
+                            }
+                        }
+                        DeploymentUtils.getWarLibraryCache().putIfAbsent(wfDesc.getWarLibraryPath(),
+                                new DeploymentUtils.WarLibraryDescriptor(wfDesc, filterTypesByWarLibrary(wfDesc)));
+                    }
+                } else {
+                    super.readAnnotations(archive, wfDesc, localExtensions);
+                }
             }
 
             // scan manifest classpath
@@ -385,6 +418,15 @@ public class WebArchivist extends Archivist<WebBundleDescriptorImpl> {
         descriptor.addDefaultWebBundleDescriptor(defaultWebBundleDescriptor);
     }
 
+    private List<Type> filterTypesByWarLibrary(WebFragmentDescriptor wfDesc) {
+        Types types = deployment.getCurrentDeploymentContext().getTransientAppMetaData(Types.class.getName(), Types.class);
+        if (types == null) {
+            return List.of();
+        }
+        return types.getAllTypes().stream().filter(key -> key.wasDefinedIn(
+                List.of(Path.of(wfDesc.getWarLibraryPath()).toUri()))).collect(Collectors.toList());
+    }
+
     /**
      * This method will return the list of web fragment in the desired order.
      */
@@ -400,18 +442,29 @@ public class WebArchivist extends Archivist<WebBundleDescriptorImpl> {
             wfArchivist.setAnnotationProcessingRequested(false);
 
             WebFragmentDescriptor wfDesc = null;
-            ReadableArchive embeddedArchive = lib.startsWith("WEB-INF")
-                    ? archive.getSubArchive(lib) : archive.getParentArchive().getSubArchive("lib").getSubArchive(lib);
+            ReadableArchive embeddedArchive = null;
+            boolean isWarLibrary = false;
+            if (lib.startsWith("WEB-INF")) {
+                embeddedArchive = archive.getSubArchive(lib);
+            } else if (archive.getParentArchive() != null) {
+                embeddedArchive = archive.getParentArchive().getSubArchive("lib").getSubArchive(lib);
+            } else if (!DeploymentUtils.getWarLibraryCache().containsKey(lib) && lib.startsWith("/")
+                    && lib.contains(DeploymentUtils.WAR_LIBRARIES)) {
+                embeddedArchive = archiveFactory.openArchive(new File(lib));
+                isWarLibrary = true;
+            }
             try {
                 if (embeddedArchive != null &&
                         wfArchivist.hasStandardDeploymentDescriptor(embeddedArchive)) {
                     try {
-                        wfDesc = (WebFragmentDescriptor)wfArchivist.open(embeddedArchive);
-                    } catch(SAXParseException ex) {
+                        wfDesc = (WebFragmentDescriptor) wfArchivist.open(embeddedArchive);
+                    } catch (SAXParseException ex) {
                         IOException ioex = new IOException();
                         ioex.initCause(ex);
                         throw ioex;
                     }
+                } else if (DeploymentUtils.getWarLibraryCache().containsKey(lib)) {
+                    wfDesc = (WebFragmentDescriptor) DeploymentUtils.getWarLibraryCache().get(lib).getDescriptor();
                 } else {
                     wfDesc = new WebFragmentDescriptor();
                     wfDesc.setExists(false);
@@ -422,6 +475,12 @@ public class WebArchivist extends Archivist<WebBundleDescriptorImpl> {
                 }
             }
             wfDesc.setJarName(lib.substring(lib.lastIndexOf('/') + 1));
+            if (isWarLibrary) {
+                if (wfDesc.getClassLoader() != null) {
+                    wfDesc.setClassLoader(wfDesc.getClassLoader().getParent());
+                }
+                wfDesc.setWarLibraryPath(lib);
+            }
             wfList.add(wfDesc);
 
             descriptor.putJarNameWebFragmentNamePair(wfDesc.getJarName(), wfDesc.getName());

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/descriptor/WebFragmentDescriptor.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/descriptor/WebFragmentDescriptor.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2014-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2014-2024] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.web.deployment.descriptor;
 
@@ -60,6 +60,7 @@ public class WebFragmentDescriptor extends WebBundleDescriptorImpl
     private String jarName = null;
     private OrderingDescriptor ordering = null;
     private boolean exists = true;
+    private String warLibraryPath;
 
     /**
      * Constrct an empty web app [{0}].
@@ -91,6 +92,18 @@ public class WebFragmentDescriptor extends WebBundleDescriptorImpl
 
     public void setExists(boolean exists) {
         this.exists = exists;
+    }
+
+    public boolean isWarLibrary() {
+        return warLibraryPath != null;
+    }
+
+    public String getWarLibraryPath() {
+        return warLibraryPath;
+    }
+
+    public void setWarLibraryPath(String warLibraryPath) {
+        this.warLibraryPath = warLibraryPath;
     }
 
     @Override

--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/WebDirContext.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/WebDirContext.java
@@ -55,6 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// Portions Copyright [2024] Payara Foundation and/or affiliates
 
 package org.apache.naming.resources;
 
@@ -322,6 +323,9 @@ public class WebDirContext extends FileDirContext {
             String jeName = getAbsoluteJarResourceName(name);
             for (JarFile jarFile : jarFiles) {
                 JarEntry jarEntry = null;
+                if (jarFile == null) {
+                    return null;
+                }
                 if (jeName.charAt(jeName.length() - 1) != '/') {
                     jarEntry = jarFile.getJarEntry(jeName + '/');
                     if (jarEntry != null) {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -57,6 +57,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
@@ -70,6 +71,7 @@ import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.cdi.CDILoggerInfo;
 import org.glassfish.common.util.ObjectInputStreamWithLoader;
 import org.glassfish.deployment.common.DeploymentContextImpl;
+import org.glassfish.deployment.common.DeploymentUtils;
 import org.glassfish.deployment.common.InstalledLibrariesResolver;
 import org.glassfish.hk2.classmodel.reflect.Types;
 import org.glassfish.internal.data.ApplicationInfo;
@@ -794,28 +796,16 @@ public class DeploymentImpl implements CDI11Deployment, Serializable {
                 for ( URI oneAppLib : appLibs ) {
                     for ( String oneInstalledLibrary : installedLibraries ) {
                         if ( oneAppLib.getPath().endsWith( oneInstalledLibrary ) ) {
-                            ReadableArchive libArchive = null;
-                            try {
-                                libArchive = archiveFactory.openArchive(oneAppLib);
-                                if ( libArchive.exists( WeldUtils.META_INF_BEANS_XML ) ) {
-                                    String bdaId = archive.getName() + "_" + libArchive.getName();
-                                    RootBeanDeploymentArchive rootBda =
-                                        new RootBeanDeploymentArchive(libArchive,
-                                                                      Collections.emptyList(),
-                                                                      context,
-                                                                      bdaId );
-                                    libBdas.add(rootBda);
-                                }
-                            } finally {
-                                if ( libArchive != null ) {
-                                    try {
-                                        libArchive.close();
-                                    } catch ( Exception ignore ) {}
-                                }
-                            }
+                            addLibBDA(archive, context, oneAppLib, libBdas);
                             break;
                         }
                     }
+                }
+            }
+
+            if (DeploymentUtils.useWarLibraries(context)) {
+                for (Path warLibrary : InstalledLibrariesResolver.getWarLibraries()) {
+                    addLibBDA(archive, context, warLibrary.toUri(), libBdas);
                 }
             }
         } catch (URISyntaxException | IOException e) {
@@ -824,6 +814,28 @@ public class DeploymentImpl implements CDI11Deployment, Serializable {
 
         for ( RootBeanDeploymentArchive oneBda : libBdas ) {
             createLibJarBda(oneBda );
+        }
+    }
+
+    private void addLibBDA(ReadableArchive archive, DeploymentContext context, URI oneAppLib, List<RootBeanDeploymentArchive> libBdas) throws IOException {
+        ReadableArchive libArchive = null;
+        try {
+            libArchive = archiveFactory.openArchive(oneAppLib);
+            if ( libArchive.exists( WeldUtils.META_INF_BEANS_XML ) || WeldUtils.isImplicitBeanArchive(context, libArchive) ) {
+                String bdaId = archive.getName() + "_" + libArchive.getName();
+                RootBeanDeploymentArchive rootBda =
+                        new RootBeanDeploymentArchive(libArchive,
+                                Collections.emptyList(),
+                                context,
+                                bdaId );
+                libBdas.add(rootBda);
+            }
+        } finally {
+            if ( libArchive != null ) {
+                try {
+                    libArchive.close();
+                } catch ( Exception ignore ) {}
+            }
         }
     }
 

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
@@ -72,8 +72,6 @@ import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.io.FileUtils;
 import fish.payara.nucleus.hotdeploy.ApplicationState;
 import fish.payara.nucleus.hotdeploy.HotDeployService;
-import java.io.Closeable;
-import java.util.logging.Level;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINEST;
 import org.glassfish.api.deployment.DeployCommandParameters;

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentUtils.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentUtils.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2024] Payara Foundation and/or affiliates
 
 package org.glassfish.deployment.common;
 
@@ -54,6 +54,9 @@ import com.sun.enterprise.util.LocalStringManagerImpl;
 import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.classmodel.reflect.Type;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.deployment.Deployment;
 import org.glassfish.loader.util.ASClassLoaderUtil;
 
 
@@ -62,7 +65,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.BufferedInputStream;
+import java.nio.file.Path;
 import java.util.Enumeration;
+import java.util.Map;
 import java.util.Properties;
 import java.net.URI;
 import java.net.URL;
@@ -70,6 +75,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.zip.Adler32;
 import java.util.jar.Manifest;
 import java.util.jar.JarFile;
@@ -79,8 +86,6 @@ import java.util.logging.Level;
 
 
 import org.glassfish.logging.annotation.LogMessageInfo;
-import org.glassfish.logging.annotation.LoggerInfo;
-import org.glassfish.logging.annotation.LogMessagesResourceBundle;
 
 /** 
  * Utility methods for deployment. 
@@ -94,7 +99,8 @@ public class DeploymentUtils {
     private static final String EXCEPTION_CAUGHT = "NCLS-DEPLOYMENT-00010";
 
     public static final String DEPLOYMENT_PROPERTY_JAVA_WEB_START_ENABLED = "java-web-start-enabled";
-    
+    public static final String WAR_LIBRARIES = "warlibs";
+
     final private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(DeploymentUtils.class);
 
     private static final String V2_COMPATIBILITY = "v2";
@@ -106,6 +112,26 @@ public class DeploymentUtils {
 
     private final static String DOWNLOADABLE_ARTIFACTS_KEY_PREFIX = "downloadable";
     private final static String GENERATED_ARTIFACTS_KEY_PREFIX = "generated";
+
+    private static final Map<String, WarLibraryDescriptor> warLibraryCache = new ConcurrentHashMap<>();
+
+    public static class WarLibraryDescriptor {
+        private final Descriptor descriptor;
+        private final List<Type> types;
+
+        public WarLibraryDescriptor(Descriptor descriptor, List<Type> types) {
+            this.descriptor = descriptor;
+            this.types = types;
+        }
+
+        public Descriptor getDescriptor() {
+            return descriptor;
+        }
+
+        public List<Type> getTypes() {
+            return types;
+        }
+    }
 
     public static boolean isDASTarget(final String targetName) {
         return DAS_TARGET_NAME.equals(targetName);
@@ -436,7 +462,34 @@ public class DeploymentUtils {
         } catch (Exception e) {
             Logger.getAnonymousLogger().log(Level.WARNING, e.getMessage(), e);
         }
+        externalLibURIs.addAll(getWarLibraryURIs(getCurrentDeploymentContext()));
         return externalLibURIs;
+    }
+
+    public static DeploymentContext getCurrentDeploymentContext() {
+        try {
+            return Globals.getDefaultHabitat().getService(Deployment.class).getCurrentDeploymentContext();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static List<URI> getWarLibraryURIs(DeploymentContext context) {
+        if(useWarLibraries(context)) {
+            return InstalledLibrariesResolver.getWarLibraries().stream()
+                    .filter(key -> !warLibraryCache.containsKey(key.toString()))
+                    .map(Path::toUri).collect(Collectors.toList());
+        } else {
+            return List.of();
+        }
+    }
+
+    public static boolean useWarLibraries(DeploymentContext context) {
+        return context != null && Boolean.parseBoolean(context.getAppProps().getProperty(WAR_LIBRARIES));
+    }
+
+    public static Map<String, WarLibraryDescriptor> getWarLibraryCache() {
+        return warLibraryCache;
     }
 
     /**


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Dependencies can be copied to `<domain_dir>/lib/warlibs/` and use no-dependency skinny-war
for deployments, significantly improving deployment times.
This can be done by layered docker deployment as well.
This will reduce application redeployment times by orders of magnitude 

## Orders-of-magnitude performance improvement achieved
Able to deploy real applications in half a second on my machine that used to take 15+ seconds

Fixes #6405 

## Important info
PR #7165 depends on this PR

## Documentation updates
Applications need to be deployed with the following snippet to `asadmin`: `--properties warlibs=true` to take advantage of shared WAR libraries. This is to prevent unnecessary loading of shared libraries with non-development applications, such as admin console or other applications that will fail if shared WAR libraries are loaded.

## Testing
Tested skinny WAR deployment
See https://gist.github.com/lprimak/167ff6d0e82f51f42abde57f17758026
