### PR TITLE
FISH-10146 FISH-9875 Deployment Group Nullpointer

### DIFF
--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXmlPreParser.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXmlPreParser.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2023] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2024] Payara Foundation and/or affiliates
 
 package org.glassfish.config.support;
 
@@ -91,7 +91,7 @@ class DomainXmlPreParser {
     private List<String> configNames = new LinkedList<>();
     private Map<String, String> mapServerConfig = new HashMap<>();
     private ClusterData cluster;
-    private DeploymentGroupData deploymentGroup;
+    private DeploymentGroupData deploymentGroup; // Refers to the FIRST deployment group for this instance.
     private String instanceName;
     private String serverConfigRef;
     private boolean valid = false;
@@ -129,14 +129,6 @@ class DomainXmlPreParser {
         return cluster.name;
     }
 
-
-    final String getDeploymentGroupName() {
-        if(!validDG) {
-            return null;
-        }
-        return deploymentGroup.name;
-    }
-
     final List<String> getServerNames() {
         if(!valid) {
             return null;
@@ -146,9 +138,16 @@ class DomainXmlPreParser {
 
     final List<String> getDGServerNames() {
         if(!validDG) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
-        return deploymentGroup.dgServerRefs;
+
+        Set<String> deploymentGroupNeighbours = new HashSet<>();
+        deploymentGroups.forEach(groupData -> {
+            if (groupData.dgServerRefs.contains(instanceName)) {
+                deploymentGroupNeighbours.addAll(groupData.dgServerRefs);
+            }
+        });
+        return new ArrayList<>(deploymentGroupNeighbours);
     }
 
     public Map<String, String> getMapServerConfig() {

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXmlPreParser.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXmlPreParser.java
@@ -48,6 +48,7 @@ import java.net.URL;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -141,13 +142,11 @@ class DomainXmlPreParser {
             return Collections.emptyList();
         }
 
-        Set<String> deploymentGroupNeighbours = new HashSet<>();
-        deploymentGroups.forEach(groupData -> {
-            if (groupData.dgServerRefs.contains(instanceName)) {
-                deploymentGroupNeighbours.addAll(groupData.dgServerRefs);
-            }
-        });
-        return new ArrayList<>(deploymentGroupNeighbours);
+        return deploymentGroups
+            .stream()
+            .filter(groupData -> groupData.dgServerRefs.contains(instanceName))
+            .flatMap(groupData -> groupData.dgServerRefs.stream())
+            .collect(Collectors.toList());
     }
 
     public Map<String, String> getMapServerConfig() {

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/InstanceReaderFilter.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/InstanceReaderFilter.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2023] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2024] Payara Foundation and/or affiliates
 
 package org.glassfish.config.support;
 
@@ -98,10 +98,6 @@ class InstanceReaderFilter extends ServerReaderFilter {
             if (elementName.equals(CLUSTER)){
                 return handleCluster(reader);
             }
-
-            if (elementName.equals(DEPLOYMENT_GROUP)){
-                return handleDeploymentGroup(reader);
-            }
             
             // keep everything else
             return false;
@@ -158,19 +154,6 @@ class InstanceReaderFilter extends ServerReaderFilter {
         String myCluster = dxpp.getClusterName();
 
         return !(StringUtils.ok(myCluster) && myCluster.equals(name));
-    }
-
-    /**
-     * Note that dxpp.getClusterName() will definitely return null
-     * for stand-alone instances.  This is normal.
-     *
-     * @return true if we want to filter out this DEPLOYMENT GROUP element
-     */
-    private boolean handleDeploymentGroup(XMLStreamReader reader) {
-        String name = reader.getAttributeValue(null, NAME);
-        String myDG = dxpp.getDeploymentGroupName();
-
-        return !(StringUtils.ok(myDG) && myDG.equals(name));
     }
 
     private final DomainXmlPreParser dxpp;


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-10146
  - Instances no longer strip data from the `<deployment-groups>` block of the domain xml.
  - Instances have improved checking for deciding whether or not to discard a config from their own domain xml.
    - Previously instances would discard any config for instances not in their _first_ deployment group. They now check all of their deployment groups.
 - Resolves FISH-9875
   - Deployment groups that share instances no longer exhibit inconsistent behaviour.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Tested using a modified reproducer for FISH-10146:

The following batch file was used for testing.
```
@ECHO OFF
CALL asadmin start-domain
echo.
CALL asadmin create-local-instance instance1
echo.
CALL asadmin start-local-instance instance1
echo.
CALL asadmin create-deployment-group group1
echo.
CALL asadmin add-instance-to-deployment-group --instance instance1 --deploymentgroup group1
echo.
CALL asadmin create-local-instance instance2
echo.
CALL asadmin start-local-instance instance2
echo.
CALL asadmin add-instance-to-deployment-group --instance instance2 --deploymentgroup group1
echo.
CALL asadmin stop-local-instance instance1
echo.
CALL asadmin stop-local-instance instance2
echo.
CALL asadmin stop-domain
```

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
