### PR TITLE
Sanitise Repackaged Module Versions for Payara Samples

### DIFF
--- a/appserver/tests/payara-samples/pom.xml
+++ b/appserver/tests/payara-samples/pom.xml
@@ -68,6 +68,12 @@
 
         <!-- Exclude unstable tests by default-->
         <excludedGroups>fish.payara.samples.Unstable</excludedGroups>
+
+        <!-- Repackaged versions -->
+        <http-matchers.version>1.1</http-matchers.version>
+        <smallrye-config.version>3.10.1</smallrye-config.version>
+        <smallrye-common.version>2.8.0</smallrye-common.version>
+        <jacc-provider.version>0.3</jacc-provider.version>
     </properties>
 
     <modules>
@@ -328,7 +334,7 @@
             <dependency>
                 <groupId>org.omnifaces</groupId>
                 <artifactId>jacc-provider-repackaged</artifactId>
-                <version>0.3</version>
+                <version>${project.version}</version>
                 <classifier>jakartaee9</classifier>
             </dependency>
             <!-- JSON Web Token implementation -->
@@ -347,7 +353,7 @@
             <dependency>
                 <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config-repackaged</artifactId>
-                <version>3.10.1</version>
+                <version>${project.version}</version>
                 <classifier>jakartaee9</classifier>
                 <scope>test</scope>
                 <exclusions>
@@ -395,7 +401,7 @@
             <dependency>
                 <groupId>org.valid4j</groupId>
                 <artifactId>http-matchers-repackaged</artifactId>
-                <version>1.1</version>
+                <version>${project.version}</version>
                 <classifier>jakartaee9</classifier>
                 <scope>test</scope>
             </dependency>

--- a/appserver/tests/payara-samples/repackaged/http-matchers-repackaged/pom.xml
+++ b/appserver/tests/payara-samples/repackaged/http-matchers-repackaged/pom.xml
@@ -47,7 +47,7 @@
     </parent>
     <groupId>org.valid4j</groupId>
     <artifactId>http-matchers-repackaged</artifactId>
-    <version>1.1</version>
+
     <name>Payara Samples - Payara - http-matchers repackaged as a module</name>
 
     <build>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.valid4j</groupId>
             <artifactId>http-matchers</artifactId>
-            <version>${project.version}</version>
+            <version>${http-matchers.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/appserver/tests/payara-samples/repackaged/jacc-provider-repackaged/pom.xml
+++ b/appserver/tests/payara-samples/repackaged/jacc-provider-repackaged/pom.xml
@@ -48,7 +48,6 @@
     </parent>
     <groupId>org.omnifaces</groupId>
     <artifactId>jacc-provider-repackaged</artifactId>
-    <version>0.3</version>
     <name>Payara Samples - Payara - jacc-provider repackaged as a module</name>
 
     <build>
@@ -73,7 +72,7 @@
                         <Embed-Dependency>
                             *;scope=compile;inline=true
                         </Embed-Dependency>
-                        <Export-Package>*;version=${http-matchers.version}</Export-Package>
+                        <Export-Package>*;version=${jacc-provider.version}</Export-Package>
                         <Private-Package>!*</Private-Package>
                     </instructions>
                     <unpackBundle>true</unpackBundle>
@@ -117,21 +116,8 @@
         <dependency>
             <groupId>org.omnifaces</groupId>
             <artifactId>jacc-provider</artifactId>
-            <version>${project.version}</version>
+            <version>${jacc-provider.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>payara-nexus-artifacts</id>
-            <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/appserver/tests/payara-samples/repackaged/pom.xml
+++ b/appserver/tests/payara-samples/repackaged/pom.xml
@@ -41,9 +41,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples</artifactId>
+        <version>6.2024.12-SNAPSHOT</version>
+    </parent>
+
     <groupId>fish.payara.server.internal.tests</groupId>
     <artifactId>repackaged</artifactId>
-    <version>6.2024.12-SNAPSHOT</version>
     <name>Payara Samples - Payara - repackaged libs as a module</name>
     
     <packaging>pom</packaging>

--- a/appserver/tests/payara-samples/repackaged/smallrye-config-repackaged/pom.xml
+++ b/appserver/tests/payara-samples/repackaged/smallrye-config-repackaged/pom.xml
@@ -47,12 +47,7 @@
     </parent>
     <groupId>io.smallrye.config</groupId>
     <artifactId>smallrye-config-repackaged</artifactId>
-    <version>3.10.1</version>
     <name>Payara Samples - Payara - smallrye-config repackaged as a module</name>
-
-    <properties>
-        <smallrye-common.version>2.8.0</smallrye-common.version>
-    </properties>
 
     <build>
         <plugins>
@@ -76,7 +71,7 @@
                         <Embed-Dependency>
                             *;scope=compile;inline=true
                         </Embed-Dependency>
-                        <Export-Package>*;version=${project.version}</Export-Package>
+                        <Export-Package>*;version=${smallrye-config.version}</Export-Package>
                         <Private-Package>!*</Private-Package>
                     </instructions>
                     <unpackBundle>true</unpackBundle>
@@ -120,19 +115,19 @@
         <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
-            <version>${project.version}</version>
+            <version>${smallrye-config.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config-core</artifactId>
-            <version>${project.version}</version>
+            <version>${smallrye-config.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config-common</artifactId>
-            <version>${project.version}</version>
+            <version>${smallrye-config.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description
Has the repackaged modules pull from the parent so plugin versions are defined. Also aligns the versions of these with a property, because otherwise payara-bom would end up getting resolved as the project.version of the repackaged modules

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built locally (skipped tests) - everything resolved

### Testing Environment
Windows 11, Maven 3.9.9, Zulu JDK 11.0.25

## Documentation
N/A

## Notes for Reviewers
None
