### PR TITLE
Fish 10036 class cast ex deserializing validation instance p6

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -77,7 +77,8 @@
         <jackson.version>2.18.1</jackson.version>
         <jersey.version>3.1.7.payara-p1</jersey.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
-        <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
+        <hibernate.validator.version>8.0.1.Final.payara-p1</hibernate.validator.version>
+        <hibernate.validator.osgi.version>8.0.1.Final</hibernate.validator.osgi.version>
         <jaxb-impl.version>4.0.1</jaxb-impl.version>
         <jsonp-api.version>2.1.0</jsonp-api.version>
         <jakarta.security.auth.message-api.version>3.0.0</jakarta.security.auth.message-api.version>

--- a/nucleus/hk2/hk2-config/pom.xml
+++ b/nucleus/hk2/hk2-config/pom.xml
@@ -130,7 +130,7 @@
                     <instructions>
                         <Import-Package>
                             jakarta.validation.*;resolution:=optional;version="${range;[==,${jakarta.validation.version.upperbound});${jakarta.validation.version}}",
-                            org.hibernate.validator.*;resolution:=optional;version="${range;[==,${hibernate.validator.version.upperbound});${hibernate.validator.version}}",
+                            org.hibernate.validator.*;resolution:=optional;version="${range;[==,${hibernate.validator.version.upperbound});${hibernate.validator.osgi.version}}",
                             *
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
## Description
When attempting to serialize and deserialize an instance of the jakarta.validation.ConstraintViolation class on a Jakarta application, the server runtime will trigger a java.lang.ClassCastException mentioning that an instance of org.hibernate.validator.constraints.CompositionType cannot be assigned to a field of the same class. 

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. Build Payara Community
2. Start Payara Server domain and deploy the WAR artefact (**manual-validator-app-p6.war**) attached at: https://payara.atlassian.net/browse/FISH-10036
3. Test the application’s REST endpoint:
`curl "http://localhost:8080/manual-validator-app/api/vehicle?name=Lewis"`

**The operation should work correctly and print 200 http code with the results**

### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.9.0

## Documentation
None

## Notes for Reviewers
None