### PR TITLE
FISH-10141 Parsson 1.1.7

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
         <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <expressly.version>6.0.0-M1</expressly.version>
         <microprofile-config.version>3.1</microprofile-config.version>
-        <parsson.version>1.1.5.payara-p1</parsson.version>
+        <parsson.version>1.1.7</parsson.version>
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
         <jaxb-api.version>4.0.2</jaxb-api.version>
         <jackson.version>2.18.1</jackson.version>


### PR DESCRIPTION
## Description
Upgrades Parsson to 1.1.7, for compliance with EE11 artefacts (currently requires the shim to work)

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Loaded the admin console and clicked around - no explosions

### Testing Environment
Windows 11, Zulu JDK 21.0.5, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
None
