### PR TITLE
FISH-10142 FISH-10279 Metro 4.0.4 and Woodstox 7.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <com.ibm.jbatch.spi.version>2.1.1</com.ibm.jbatch.spi.version>
         <webservices.version>4.0.4</webservices.version>
         <santuario.version>4.0.0</santuario.version>
-        <woodstox.version>6.6.2</woodstox.version>
+        <woodstox.version>7.1.0</woodstox.version>
         <woodstock-jsf.version>5.0.0</woodstock-jsf.version>
         <woodstock-jsf-suntheme.version>5.0.0.payara-p1</woodstock-jsf-suntheme.version>
         <angus-activation.version>2.0.2</angus-activation.version>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <openmq.version>6.3.0.payara-p3</openmq.version>
         <com.ibm.jbatch.container.version>2.1.1</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>2.1.1</com.ibm.jbatch.spi.version>
-        <webservices.version>4.0.3.payara-p1</webservices.version>
+        <webservices.version>4.0.4</webservices.version>
         <santuario.version>4.0.0</santuario.version>
         <woodstox.version>6.6.2</woodstox.version>
         <woodstock-jsf.version>5.0.0</woodstock-jsf.version>


### PR DESCRIPTION
## Description
Upgrades Metro to 4.0.4 and Woodstox 7.1.0, for compliance with EE11 artefacts (currently requires the shim to work).
At some point we will need to review if our existing patches need reapplying to Metro.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Loaded the admin console and clicked around - no explosions

### Testing Environment
Windows 11, Zulu JDK 21.0.5, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
None
