### PR TITLE
FISH-10042 Dont strip cookie of quotes

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
@@ -3157,17 +3157,9 @@ public class Request implements HttpRequest, HttpServletRequest {
             }
         }
 
-        return new Cookie(name, sanitizeCookieValue(value));
+        return new Cookie(name, value);
     }
     // END GlassFish 898
-
-    private String sanitizeCookieValue(String value) {
-        if (value != null && value.startsWith("\"") && value.endsWith("\"")) {
-            return value.substring(1, value.length() - 1);
-        }
-
-        return value;
-    }
 
     // START SJSAS 6346738
     /**


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This will fix the failing `getValueQuotedTest` in the servlet tck.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Ran the servlet tck
```
mvn clean verify -B -Dpayara.version=7.2024.1.Alpha3-SNAPSHOT -pl . -pl servlet-tck -Ppayara-server-managed,jakarta-staging -Dit.test=servlet.tck.api.jakarta_servlet_http.cookie.CookieTests
```
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
This will cause tags to possibly fail due to reverting the fix 