### PR TITLE
Revert Parsson Upgrade (Release)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,7 +71,7 @@
         <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <expressly.version>6.0.0-M1</expressly.version>
         <microprofile-config.version>3.1</microprofile-config.version>
-        <parsson.version>1.1.7</parsson.version>
+        <parsson.version>1.1.5.payara-p1</parsson.version>
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
         <jaxb-api.version>4.0.2</jaxb-api.version>
         <jackson.version>2.18.2</jackson.version>


### PR DESCRIPTION
## Description
This reverts commit 18f394ae3f6f014d2d01f9833f4c5a762431a541, reversing changes made to de796c9744ca69aa6c075c35f86e34535088c8b4.

Upgrading to Parsson 1.1.7 breaks the JSON-P TCK.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the JSON-P TCK - passed

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
None
