### PR TITLE
FISH-10318 Add create-system-property command

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CLIUtil.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CLIUtil.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2024 Payara Foundation and/or affiliates
 package com.sun.enterprise.v3.admin;
 
 import com.sun.enterprise.config.serverbeans.Config;
@@ -61,7 +62,7 @@ public class CLIUtil {
         return config;
     }
     
-    static SystemPropertyBag chooseTarget(final Domain domain, final String target) {
+    public static SystemPropertyBag chooseTarget (final Domain domain, final String target) {
         SystemPropertyBag spb = null;
         Property domainProp = domain.getProperty("administrative.domain.name");
         String domainName = domainProp.getValue();

--- a/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/CreateSystemProperty.java
+++ b/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/CreateSystemProperty.java
@@ -1,0 +1,147 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.enterprise.admin;
+
+import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.config.serverbeans.SystemProperty;
+import com.sun.enterprise.config.serverbeans.SystemPropertyBag;
+import com.sun.enterprise.util.LocalStringManagerImpl;
+import com.sun.enterprise.util.SystemPropertyConstants;
+import com.sun.enterprise.v3.admin.CLIUtil;
+import com.sun.enterprise.v3.admin.CreateSystemProperties;
+import jakarta.inject.Inject;
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.I18n;
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.AccessRequired;
+import org.glassfish.api.admin.AdminCommand;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.AdminCommandSecurity;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.config.support.CommandTarget;
+import org.glassfish.config.support.TargetType;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
+import org.jvnet.hk2.config.ConfigSupport;
+import org.jvnet.hk2.config.Transaction;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Service(name="create-system-property")
+@PerLookup
+@ExecuteOn({RuntimeType.DAS, RuntimeType.INSTANCE})
+@TargetType(value={CommandTarget.CLUSTER,
+    CommandTarget.CONFIG, CommandTarget.DAS, CommandTarget.DOMAIN, CommandTarget.STANDALONE_INSTANCE,CommandTarget.CLUSTERED_INSTANCE})
+@I18n("create.system.property")
+public class CreateSystemProperty implements AdminCommand, AdminCommandSecurity.Preauthorization, AdminCommandSecurity.AccessCheckProvider {
+    final private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(CreateSystemProperties.class);
+
+    @Param(optional=true, defaultValue=SystemPropertyConstants.DAS_SERVER_NAME)
+    String target;
+
+    @Param(name="name")
+    String propertyName;
+
+    @Param(name="value")
+    String propertyValue;
+
+    @Inject
+    Domain domain;
+
+    private SystemPropertyBag spb;
+
+    @Override
+    public void execute (AdminCommandContext context) {
+        final ActionReport report = context.getActionReport();
+
+        try {
+            ConfigSupport.apply(propertyBag -> {
+                // update existing system property
+                for (SystemProperty property : propertyBag.getSystemProperty()) {
+                    if (property.getName().equals(propertyName)) {
+                        Transaction transaction = Transaction.getTransaction(propertyBag);
+                        property = transaction.enroll(property);
+                        property.setValue(propertyValue);
+                        return property;
+                    }
+                }
+
+                // create system-property
+                SystemProperty newSysProp = propertyBag.createChild(SystemProperty.class);
+                newSysProp.setName(propertyName);
+                newSysProp.setValue(propertyValue);
+                propertyBag.getSystemProperty().add(newSysProp);
+                return newSysProp;
+            }, spb);
+            report.setActionExitCode(ActionReport.ExitCode.SUCCESS);
+        } catch(Exception e) {
+            report.setMessage(localStrings.getLocalString("create.system.property.failed",
+                "System property {0} creation failed", propertyName));
+            report.setActionExitCode(ActionReport.ExitCode.FAILURE);
+            report.setFailureCause(e);
+        }
+    }
+
+    @Override
+    public Collection<? extends AccessRequired.AccessCheck<?>> getAccessChecks () {
+        final Collection<AccessRequired.AccessCheck<?>> result = new ArrayList<>();
+        result.add(new AccessRequired.AccessCheck<>(AccessRequired.Util.resourceNameFromConfigBeanProxy(spb), "update"));
+        return result;
+    }
+
+    @Override
+    public boolean preAuthorization (AdminCommandContext context) {
+        this.spb = CLIUtil.chooseTarget(domain, target);
+        if (this.spb == null) {
+            final ActionReport report = context.getActionReport();
+            report.setActionExitCode(ActionReport.ExitCode.FAILURE);
+            String msg = localStrings.getLocalString(
+                "invalid.target.sys.props",
+                "Invalid target:{0}. Valid targets types are domain, config, cluster, default server, clustered instance, stand alone instance", target
+            );
+            report.setMessage(msg);
+            return false;
+        }
+        return true;
+    }
+}

--- a/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/CreateSystemProperty.java
+++ b/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/CreateSystemProperty.java
@@ -79,11 +79,8 @@ public class CreateSystemProperty implements AdminCommand, AdminCommandSecurity.
     @Param(optional=true, defaultValue=SystemPropertyConstants.DAS_SERVER_NAME)
     String target;
 
-    @Param(name="name")
-    String propertyName;
-
-    @Param(name="value")
-    String propertyValue;
+    @Param(name="name_value", primary=true)
+    String propertyAssignment;
 
     @Inject
     Domain domain;
@@ -93,8 +90,13 @@ public class CreateSystemProperty implements AdminCommand, AdminCommandSecurity.
     @Override
     public void execute (AdminCommandContext context) {
         final ActionReport report = context.getActionReport();
+        String[] assignment = propertyAssignment.split("=");
+        String propertyName;
+        String propertyValue;
 
         try {
+            propertyName = assignment[0];
+            propertyValue = assignment[1];
             ConfigSupport.apply(propertyBag -> {
                 // update existing system property
                 for (SystemProperty property : propertyBag.getSystemProperty()) {
@@ -116,7 +118,7 @@ public class CreateSystemProperty implements AdminCommand, AdminCommandSecurity.
             report.setActionExitCode(ActionReport.ExitCode.SUCCESS);
         } catch(Exception e) {
             report.setMessage(localStrings.getLocalString("create.system.property.failed",
-                "System property {0} creation failed", propertyName));
+                "System property {0} creation failed", propertyAssignment));
             report.setActionExitCode(ActionReport.ExitCode.FAILURE);
             report.setFailureCause(e);
         }

--- a/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/LocalStrings.properties
+++ b/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/LocalStrings.properties
@@ -39,8 +39,7 @@
 #
 
 create.system.property=adds or updates a single system property of the domain, configuration, cluster, or server instance
-create.system.property.name=The name of the property to add or update.
-create.system.property.value=The value to assign to the named property.
+create.system.property.name_value=The system property assignment to create.
 create.system.property.existsAlready=System property {0} already exists.
 create.system.property.failed=System property {0} creation failed.
 create.system.property.success=System property {0} created successfully.

--- a/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/LocalStrings.properties
+++ b/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/LocalStrings.properties
@@ -1,0 +1,46 @@
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/main/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+
+create.system.property=adds or updates a single system property of the domain, configuration, cluster, or server instance
+create.system.property.name=The name of the property to add or update.
+create.system.property.value=The value to assign to the named property.
+create.system.property.existsAlready=System property {0} already exists.
+create.system.property.failed=System property {0} creation failed.
+create.system.property.success=System property {0} created successfully.

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/create-system-properties.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/create-system-properties.1
@@ -81,8 +81,8 @@ EXIT STATUS
            error in executing the subcommand
 
 SEE ALSO
-       delete-system-property(1), list-system-properties(1)
+       create-system-property(1), delete-system-property(1), list-system-properties(1)
 
        asadmin(1M)
 
-Java EE 8                  09 Aug 2017            create-system-properties(1)
+Java EE 8                  17 Dec 2024            create-system-properties(1)

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/delete-system-property.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/delete-system-property.1
@@ -45,8 +45,8 @@ EXIT STATUS
            error in executing the subcommand
 
 SEE ALSO
-       create-system-properties(1), list-system-properties(1)
+       create-system-property(1), create-system-properties(1), list-system-properties(1)
 
        asadmin(1M)
 
-Java EE 8                   09 Aug 2017            delete-system-property(1)
+Java EE 8                  17 Dec 2024            delete-system-property(1)

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/list-system-properties.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/list-system-properties.1
@@ -56,8 +56,8 @@ EXIT STATUS
            error in executing the subcommand
 
 SEE ALSO
-       create-system-properties(1), delete-system-property(1)
+       create-system-property(1), create-system-properties(1), delete-system-property(1)
 
        asadmin(1M)
 
-Java EE 8                  09 Aug 2017            list-system-properties(1)
+Java EE 8                  17 Dec 2024            list-system-properties(1)

--- a/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/create-system-property.1
+++ b/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/create-system-property.1
@@ -1,0 +1,92 @@
+create-system-property(1)  asadmin Utility Subcommands  create-system-property(1)
+
+NAME
+       create-system-property - adds or updates a single system property
+       of the domain, configuration, cluster, or server instance
+
+SYNOPSIS
+           create-system-property [--help]
+           [--target target]
+           [--name name] [--value value]
+
+DESCRIPTION
+       The create-system-property subcommand adds or updates a single system
+       property that can be referenced elsewhere on the server.
+
+       Payara Server provides hooks where tokens (system properties) can be
+       specified. Because Payara Server does not have multiple server
+       elements, you can specify a particular token at any level. When a
+       domain supports multiple servers, the override potential can be
+       exploited. When a domain is started or restarted, all <system-property>
+       elements are resolved and available to the Java Virtual Machine by
+       using the System.setProperty() call on each of them (with its name and
+       value derived from the corresponding attributes of the element). This
+       is analogous to sending the elements as -D parameters on the Java
+       command line.
+
+       This subcommand is supported in remote mode only.
+
+OPTIONS
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --target
+           The target on which you are creating the system property.
+
+       --name
+          The name of the property to add or update.
+
+       --value
+          The value to assign to the named property.
+
+OPERANDS
+       target
+           The valid targets for this subcommand are instance, cluster,
+           configuration, domain, and server. Server is the default option.
+           Valid values are:
+
+           server
+               Creates the property on the default server instance. This is
+               the default value.
+
+           domain
+               Creates the property for all server instances in the default
+               domain.
+
+           configuration_name
+               Creates the property in the specified configuration.
+
+           cluster_name
+               Creates the property on all server instances in the specified
+               cluster.
+
+           instance_name
+               Creates the property on a specified server instance.
+
+       name
+           The name of the property to add or update.
+
+       value
+           The value to assign to the named property.
+
+EXAMPLES
+       Example 1, Creating System Property
+           This example creates a system property associated with an HTTP
+           listener on a server instance named myserver.
+
+               asadmin> create-system-property --target myserver --name http-listener-port --value 1088
+               Command create-system-property executed successfully.
+
+EXIT STATUS
+       0
+           subcommand executed successfully
+
+       1
+           error in executing the subcommand
+
+SEE ALSO
+       create-system-properties(1), delete-system-property(1), list-system-properties(1)
+
+       asadmin(1M)
+
+Java EE 8                  17 Dec 2024            create-system-property(1)

--- a/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/create-system-property.1
+++ b/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/create-system-property.1
@@ -33,12 +33,6 @@ OPTIONS
        --target
            The target on which you are creating the system property.
 
-       --name
-          The name of the property to add or update.
-
-       --value
-          The value to assign to the named property.
-
 OPERANDS
        target
            The valid targets for this subcommand are instance, cluster,
@@ -63,18 +57,15 @@ OPERANDS
            instance_name
                Creates the property on a specified server instance.
 
-       name
-           The name of the property to add or update.
-
-       value
-           The value to assign to the named property.
+       name_value
+           The system property to assign. In the form of "PropertyName=PropertyValue"
 
 EXAMPLES
        Example 1, Creating System Property
            This example creates a system property associated with an HTTP
            listener on a server instance named myserver.
 
-               asadmin> create-system-property --target myserver --name http-listener-port --value 1088
+               asadmin> create-system-property --target myserver http-listener-port=1088
                Command create-system-property executed successfully.
 
 EXIT STATUS

--- a/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/create-system-property.1
+++ b/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/create-system-property.1
@@ -7,7 +7,7 @@ NAME
 SYNOPSIS
            create-system-property [--help]
            [--target target]
-           [--name name] [--value value]
+           [name=value]
 
 DESCRIPTION
        The create-system-property subcommand adds or updates a single system


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-10318
  - Adds a `create-system-property` asadmin command.
  - Adds an associated manpage.
  - Adjusts existing manpages for relevant commands to refer to the new one.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
- Built the server and used the command to create a new system property.  
- Verified the property exists with the `list-system-properties` command.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
