### PR TITLE
FISH-10319 Add create-jvm-option command

### DIFF
--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates] -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -99,6 +99,7 @@
                     <include>com/sun/enterprise/v3/**/statusNotDAS.html</include>
                     <include>com/sun/enterprise/v3/**/asynch-1F.gif</include>
                     <include>com/sun/enterprise/v3/**/backimage.jpg</include>
+                    <include>fish/payara/enterprise/admin/**/*.properties</include>
                 </includes>
             </resource>
             <resource>

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/CLIUtil.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/CLIUtil.java
@@ -57,9 +57,9 @@ public class CLIUtil {
         
     }
     
-    static Config updateConfigIfNeeded(final Config initConfig,
-            final Target targetUtil,
-            final String target) {
+    public static Config updateConfigIfNeeded (final Config initConfig,
+                                               final Target targetUtil,
+                                               final String target) {
         Config result = initConfig;
         Config newConfig = targetUtil.getConfig(target);
         if (newConfig!=null) {

--- a/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/CreateSystemProperty.java
+++ b/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/CreateSystemProperty.java
@@ -46,7 +46,6 @@ import com.sun.enterprise.config.serverbeans.SystemPropertyBag;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.v3.admin.CLIUtil;
-import com.sun.enterprise.v3.admin.CreateSystemProperties;
 import jakarta.inject.Inject;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
@@ -74,7 +73,7 @@ import java.util.Collection;
     CommandTarget.CONFIG, CommandTarget.DAS, CommandTarget.DOMAIN, CommandTarget.STANDALONE_INSTANCE,CommandTarget.CLUSTERED_INSTANCE})
 @I18n("create.system.property")
 public class CreateSystemProperty implements AdminCommand, AdminCommandSecurity.Preauthorization, AdminCommandSecurity.AccessCheckProvider {
-    final private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(CreateSystemProperties.class);
+    final private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(CreateSystemProperty.class);
 
     @Param(optional=true, defaultValue=SystemPropertyConstants.DAS_SERVER_NAME)
     String target;

--- a/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/commands/CreateJvmOption.java
+++ b/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/commands/CreateJvmOption.java
@@ -1,0 +1,275 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package fish.payara.enterprise.admin.commands;
+
+import com.sun.enterprise.config.serverbeans.Config;
+import com.sun.enterprise.config.serverbeans.JavaConfig;
+import com.sun.enterprise.config.serverbeans.JvmOptionBag;
+import com.sun.enterprise.universal.xml.MiniXmlParser;
+import com.sun.enterprise.util.SystemPropertyConstants;
+import com.sun.enterprise.util.i18n.StringManager;
+import com.sun.enterprise.v3.admin.commands.CLIUtil;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.I18n;
+import org.glassfish.api.Param;
+import org.glassfish.api.UnknownOptionsAreOperands;
+import org.glassfish.api.admin.AccessRequired;
+import org.glassfish.api.admin.AdminCommand;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.AdminCommandSecurity;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.api.admin.ServerEnvironment;
+import org.glassfish.config.support.CommandTarget;
+import org.glassfish.config.support.TargetType;
+import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.internal.api.Target;
+import org.jvnet.hk2.annotations.Service;
+import org.jvnet.hk2.config.ConfigSupport;
+import org.jvnet.hk2.config.SingleConfigCode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Service(name="create-jvm-option")
+@PerLookup
+@I18n("create.jvm.option")
+@ExecuteOn({RuntimeType.DAS, RuntimeType.INSTANCE})
+@TargetType({CommandTarget.DAS,CommandTarget.STANDALONE_INSTANCE,CommandTarget.CLUSTER,CommandTarget.CONFIG})
+@UnknownOptionsAreOperands()
+public final class CreateJvmOption implements AdminCommand, AdminCommandSecurity.Preauthorization {
+
+    @Param(name="target", optional=true, defaultValue = SystemPropertyConstants.DEFAULT_SERVER_INSTANCE_NAME)
+    String target;
+
+    @Param(name="profiler", optional=true)
+    Boolean addToProfiler=false;
+
+    @Param(name="assignment", primary=true)
+    String jvmAssignment;
+
+    @Param(name="min-jvm", optional = true)
+    String minJVM;
+    @Param(name="max-jvm", optional = true)
+    String maxJVM;
+
+    @Inject
+    Target targetService;
+
+    @Inject @Named(ServerEnvironment.DEFAULT_INSTANCE_NAME)
+    Config config;
+
+    private static final StringManager lsm = StringManager.getManager(CreateJvmOption.class);
+
+    @AccessRequired.To("update")
+    private JavaConfig javaConfig;
+
+    @Override
+    public boolean preAuthorization(AdminCommandContext context) {
+        config = CLIUtil.updateConfigIfNeeded(config, targetService, target);
+        javaConfig = config.getJavaConfig();
+        return true;
+    }
+
+
+    @Override
+    public void execute(AdminCommandContext context) {
+        final ActionReport report = context.getActionReport();
+        try {
+            JvmOptionBag bag;
+            if (addToProfiler) { //make sure profiler element exists before creating a JVM option for profiler
+                if (javaConfig.getProfiler() == null) {
+                    report.setMessage(lsm.getString("create.profiler.first"));
+                    report.setActionExitCode(ActionReport.ExitCode.FAILURE);
+                    return;
+                }
+                bag = javaConfig.getProfiler();
+            }
+            else {
+                bag = javaConfig;
+            }
+
+            ActionReport.MessagePart part = report.getTopMessagePart().addChild();
+            String validOption = (new MiniXmlParser.JvmOption(jvmAssignment)).option;
+            validate(bag, validOption, report);
+            validateHeapSize(bag, validOption, report);
+            add(bag, jvmAssignment, part);
+        }
+        catch (IllegalArgumentException iae) {
+            report.setMessage(iae.getMessage());
+            report.setActionExitCode(ActionReport.ExitCode.FAILURE);
+            return;
+        }
+        catch (Exception e) {
+            String msg = e.getMessage() != null ? e.getMessage() :
+                lsm.getStringWithDefault("create.jvm.options.failed",
+                    "Command: create-jvm-options failed", new String[]{e.getMessage()});
+            report.setMessage(msg);
+            report.setActionExitCode(ActionReport.ExitCode.FAILURE);
+            report.setFailureCause(e);
+            return;
+        }
+        report.setActionExitCode(ActionReport.ExitCode.SUCCESS);
+    }
+
+    private void validateHeapSize (JvmOptionBag bag, String option, ActionReport report) {
+        validateMax(bag, option, report);
+        validateMin(bag, option, report);
+    }
+
+    private void validateMax (JvmOptionBag bag, String option, ActionReport report) throws IllegalArgumentException {
+        if (!option.startsWith("-Xmx")) {
+            return;
+        }
+
+        //now, opt is something like -Xmx512m or -Xmx2g, or -Xmx=12 i.e. it may contain illegal characters
+        Pattern regex = Pattern.compile("-Xmx((\\d)+[m|g|k|M|G|K]?)+");
+        boolean matches = regex.matcher(option).matches();
+        if (!matches) {
+            String msg = lsm.getString("soft.invalid.xmx", option);
+            report.getTopMessagePart().addChild().setMessage(msg);
+            throw new IllegalArgumentException();
+        }
+
+
+        String existingXmx = bag.getStartingWith("-Xmx");
+        if (existingXmx != null) {
+            //maybe a different Xmx was given
+            String msg = lsm.getString("soft.xmx.exists.singular", existingXmx, option);
+            report.getTopMessagePart().addChild().setMessage(msg);
+        }
+
+        String existingXms = bag.getStartingWith("-Xms");
+        if (existingXms != null) {
+            int xmsInConfig = JvmOptionBag.Duck.toMeg(existingXms, "-Xms");
+            int xmxGiven    = JvmOptionBag.Duck.toMeg(option, "-Xmx");
+            if (xmsInConfig > xmxGiven) { //i.e. domain.xml contains -Xms1g and you ask -Xmx512m to be set
+                String msg = lsm.getString("soft.xmx.smaller.than.xms", xmxGiven + " MB", xmsInConfig + " MB");
+                report.getTopMessagePart().addChild().setMessage(msg);
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+
+    private void validateMin (JvmOptionBag bag, String option, ActionReport report) throws IllegalArgumentException {
+        if (!option.startsWith("-Xms")) {
+            return;
+        }
+
+        //now, opt is something like -Xms512m or -Xms2g, or -Xms=12 i.e. it may contain illegal characters
+        Pattern regex = Pattern.compile("-Xms((\\d)+[m|g|k|M|G|K]?)+");
+        boolean matches = regex.matcher(option).matches();
+        if (!matches) {
+            String msg = lsm.getString("soft.invalid.xms", option);
+            report.getTopMessagePart().addChild().setMessage(msg);
+            throw new IllegalArgumentException();
+        }
+
+        String existingXms = bag.getStartingWith("-Xms");
+        if (existingXms != null) {
+            String msg = lsm.getString("soft.xms.exists.singular", existingXms, option);
+            report.getTopMessagePart().addChild().setMessage(msg);
+        }
+        String existingXmx = bag.getStartingWith("-Xmx");
+        if (existingXmx != null) {
+            int xmxInConfig = JvmOptionBag.Duck.toMeg(existingXmx, "-Xmx");
+            int xmsGiven = JvmOptionBag.Duck.toMeg(option, "-Xms");
+            if (xmsGiven > xmxInConfig) { //i.e. domain.xml contains -Xms1g and you ask -Xmx512m to be set
+                String msg = lsm.getString("soft.xms.larger.than.xmx", xmsGiven + " MB", xmxInConfig + " MB");
+                report.getTopMessagePart().addChild().setMessage(msg);
+                throw new IllegalArgumentException();
+            }
+        }
+    }
+
+    /**
+     * Validates a JVM option that it is a valid option.
+     * <p>
+     * Valid options must either start with a {@code -} or <code>${ENV=}</code>
+     * @param bag Bag of JVM options that already exist
+     * @param option Option being added.
+     * @param report ignored
+     * @throws IllegalArgumentException If an invalid options is given
+     */
+    private void validate(JvmOptionBag bag, String option, ActionReport report) throws IllegalArgumentException {
+        if (!option.startsWith("-") && !option.startsWith("${ENV=")) {
+            String msg = lsm.getString("joe.invalid.start", option);
+            throw new IllegalArgumentException(msg);
+        }
+        if (bag.contains(option)) {
+            // setting an option that already exists is considered an error
+            String msg = lsm.getString("joe.exists", option);
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
+    private void add (final JvmOptionBag bag, final String option, final ActionReport.MessagePart part) throws Exception {
+        SingleConfigCode<JvmOptionBag> scc = bag1 -> {
+            List<String> unversionedCurrentOptions = bag1.getJvmOptions();
+
+            if (!unversionedCurrentOptions.contains(new MiniXmlParser.JvmOption(option).option)) {
+                List<String> jvmopts = new ArrayList<>(bag1.getJvmRawOptions());
+                if (option.startsWith("-Xms") && bag1.getStartingWith("-Xms") != null) {
+                    jvmopts.removeIf(entry -> entry.startsWith("-Xms"));
+                }
+                else if (option.startsWith("-Xmx") && bag1.getStartingWith("-Xmx") != null) {
+                    jvmopts.removeIf(entry -> entry.startsWith("-Xmx"));
+                }
+
+                jvmopts.add(
+                    MiniXmlParser.JvmOption.hasVersionPattern(option) ?
+                        new MiniXmlParser.JvmOption(option).toString() :
+                        new MiniXmlParser.JvmOption(option, minJVM, maxJVM).toString()
+                );
+                bag1.setJvmOptions(jvmopts);
+                part.setMessage(lsm.getString("jvm.option.created", option));
+            }
+            else {
+                part.setMessage(lsm.getString("no.option.created"));
+            }
+            return true;
+        };
+        ConfigSupport.apply(scc, bag);
+    }
+}

--- a/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/commands/LocalStrings.properties
+++ b/nucleus/core/kernel/src/main/java/fish/payara/enterprise/admin/commands/LocalStrings.properties
@@ -1,0 +1,53 @@
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/main/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at glassfish/legal/LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+
+create.profiler.first=No profiler configured yet. Create a profiler first.
+joe.exists=JVM option {0} already exists in the configuration.
+joe.invalid.start=JVM option {0} is invalid because it does not start with a ''-''
+joe.invalid.cmd.syntax=The command line:{0} does not satisfy the syntax.\nIn a nutshell, all options should start with a ''-'', multiple options are separated by a '':''.\nA '':'' inside an option should be escaped with a ''\\''.\nSince shell interprets command arguments, make sure you quote it.\n
+soft.invalid.xmx=It appears that given JVM option {0} represents invalid maximum heap for the JVM. Ensure that it is valid, by doing list-jvm-options.
+soft.xmx.exists.singular=The previously configured maximum heap size ({0}) will be replaced by the new configuration: {1}
+soft.xmx.smaller.than.xms=It appears that the maximum heap size specified: {0} is smaller than the minimum heap size in the configuration: {1}. JVM might not start. Ensure that this is valid, by doing doing list-jvm-options.
+soft.invalid.xms=It appears that given JVM option {0} represents invalid initial heap for the JVM. Ensure that it is valid, by doing list-jvm-options.
+soft.xms.exists.singular=The previously configured initial heap size ({0}) will be replaced by the new configuration: {1}
+soft.xms.larger.than.xmx=It appears that the initial heap size specified: {0} is larger than the maximum heap size in the configuration: {1}. JVM might not start. Ensure that this is valid, by doing doing list-jvm-options.
+jvm.option.created=Successfully added JVM option: {0}
+no.option.created=No jvm-options were created (perhaps they were already present)
+create.jvm.options.failed=Command: create-jvm-options failed. {0}

--- a/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/commands/create-jvm-option.1
+++ b/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/commands/create-jvm-option.1
@@ -1,17 +1,18 @@
-create-jvm-options(1)     asadmin Utility Subcommands    create-jvm-options(1)
+create-jvm-option(1)     asadmin Utility Subcommands    create-jvm-option(1)
 
 NAME
-       create-jvm-options - creates options for the Java application launcher
+       create-jvm-option - creates a single option for the Java application launcher
 
 SYNOPSIS
-           create-jvm-options [--help] [--target target] [--profiler={true|false}]
-           (jvm-option-name=jvm-option-value) [:jvm-option-name=jvm-option-value*]
+           create-jvm-option [--help] [--target target] [--profiler={true|false}]
+           (assignment=jvm-option)
 
 DESCRIPTION
-       The create-jvm-options subcommand creates command-line options that are
-       passed to the Java application launcher when GlassFish Server is
+       The create-jvm-option subcommand is a singular version of the
+       create-jvm-options(1) subcommand and creates command-line options that
+       are passed to the Java application launcher when Payara Server is
        started. The options that this subcommand creates are in addition to
-       the options that are preset with GlassFish Server. Java application
+       the options that are preset with Payara Server. Java application
        launcher options are stored in the Java configuration java—config
        element or the profiler profiler element of the domain.xml file. The
        options are sent to the command line in the order they appear in the
@@ -114,14 +115,14 @@ OPTIONS
                Specifies a named configuration.
 
        --profiler
-           Indicates whether the Java application launcher options are for the
+           Indicates whether the Java application launcher option is for the
            profiler. The profiler must exist for this option to be true.
            Default is false.
 
 OPERANDS
-       jvm-option-name
-           One or more options delimited by a colon (:). The format of an
-           option depends on the following:
+       assignment
+           A single option assignment. The format of an option depends
+           on the following:
 
            *   If the option has a name and a value, the format is
                option-name=value.
@@ -135,57 +136,45 @@ OPERANDS
                misinterpreted as -se, the asadmin short forms for --secure and
                --echo:
 
-                   create-jvm-options -server
+                   create-jvm-option -server
                To create the JVM option -server, instead use the command:
 
-                   create-jvm-options -- -server
+                   create-jvm-option -- -server
 
                Note
-               +----------------------------------------+
-               |If an option name or option value       |
-               |contains a colon, the backslash (\)     |
-               |must be used to escape the colon in the |
-               |name or value. Other characters might   |
-               |also require an escape character. For   |
-               |more information about escape           |
-               |characters in subcommand options, see   |
-               |the asadmin(1M) man page.               |
-               +----------------------------------------+
+               +-----------------------------------------+
+               | If an option name or option value       |
+               | contains a colon, the backslash (\)     |
+               | must be used to escape the colon in the |
+               | name or value. Other characters might   |
+               | also require an escape character. For   |
+               | more information about escape           |
+               | characters in subcommand options, see   |
+               | the asadmin(1M) man page.               |
+               +-----------------------------------------+
 
 EXAMPLES
-       Example 1, Setting Java System Properties
-           This example sets multiple Java system properties.
+       Example 1, Setting system property
 
-               asadmin> create-jvm-options -Dunixlocation=/root/example:
-               -Dvariable=\$HOME:-Dwindowslocation=d\:\\sun\\appserver:-Doption1=-value1
-               created 4 option(s)
-               Command create-jvm-options executed successfully.
+               asadmin> create-jvm-option -Dunixlocation=/root/example
+               Successfully added JVM option: -Dunixlocation=/root/example
+               Command create-jvm-option executed successfully.
 
        Example 2, Setting a Startup Parameter for the Java Application
        Launcher
            This example sets the maximum available heap size to 1024.
 
-               asadmin> create-jvm-options -Xmx1024m
-               created 1 option(s)
-               Command create-jvm-options executed successfully.
+               asadmin> create-jvm-option -Xmx1024m
+               Successfully added JVM option: -Xmx1024m
+               The previously configured maximum heap size (-Xmx512m) will be replaced by the new configuration: -Xmx1024m
+               Command create-jvm-option executed successfully.
 
-       Example 3, Setting Multiple Startup Parameters for the Java Application
-       Launcher
-           This example sets the maximum available heap size to 1024 and
-           requests details about garbage collection.
-
-               asadmin> create-jvm-options "-Xmx1024m:-XX\:+PrintGCDetails"
-               created 1 option(s)
-               Command create-jvm-options executed successfully.
-           In this case, one of the two parameters already exists, so the
-           subcommand reports that only one option was set.
-
-       Example 4, Setting a JVM Startup Parameter for the Profiler
+       Example 3, Setting a JVM Startup Parameter for the Profiler
            This example sets a JVM startup parameter for the profiler.
 
-               asadmin> create-jvm-options --profiler=true -XX\:MaxPermSize=192m
-               created 1 option(s)
-               Command create-jvm-options executed successfully.
+               asadmin> create-jvm-option --profiler=true -XX\:MaxPermSize=192m
+               Successfully added JVM option: -XX\:MaxPermSize=192m
+               Command create-jvm-option executed successfully.
 
 EXIT STATUS
        0
@@ -196,7 +185,7 @@ EXIT STATUS
 
 SEE ALSO
        delete-jvm-options(1), list-jvm-options(1), create-profiler(1),
-       restart-domain(1), create-jvm-option(1)
+       restart-domain(1), create-jvm-options(1)
 
        asadmin(1M)
 
@@ -209,4 +198,4 @@ SEE ALSO
        *   Windows: java - the Java application launcher
            (http://docs.oracle.com/javase/6/docs/technotes/tools/windows/java.html)
 
-Java EE 8                         18 Dec 2024            create-jvm-options(1)
+Java EE 8                         19 Dec 2024            create-jvm-option(1)

--- a/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/commands/create-jvm-option.1
+++ b/nucleus/core/kernel/src/main/manpages/fish/payara/enterprise/admin/commands/create-jvm-option.1
@@ -172,8 +172,8 @@ EXAMPLES
        Example 3, Setting a JVM Startup Parameter for the Profiler
            This example sets a JVM startup parameter for the profiler.
 
-               asadmin> create-jvm-option --profiler=true -XX\:MaxPermSize=192m
-               Successfully added JVM option: -XX\:MaxPermSize=192m
+               asadmin> create-jvm-option --profiler=true -XX:MaxPermSize=192m
+               Successfully added JVM option: -XX:MaxPermSize=192m
                Command create-jvm-option executed successfully.
 
 EXIT STATUS


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-10319
  - Adds `create-jvm-option` asadmin command.
  - Adds relevant manpage.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Used the command to create a new JVM option, verified the existence of the new option via the `list-jvm-options` command.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
