### PR TITLE
FISH-61 : only checking if response was commited

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Response.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Response.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2019-2023] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2024] Payara Foundation and/or affiliates
 
 package org.apache.catalina.connector;
 
@@ -901,14 +901,11 @@ public class Response
      */
     @Override
     public void setBufferSize(int size) {
-
-        if (isCommitted() || !outputBuffer.isNew())
+        if (isCommitted()) {
             throw new IllegalStateException(rb.getString(LogFacade.CANNOT_CHANGE_BUFFER_SIZE_EXCEPTION));
-
+        }
         outputBuffer.setBufferSize(size);
-
     }
-
 
     /**
      * Set the content length (in bytes) for this Response.


### PR DESCRIPTION
## Description
`java.lang.IllegalStateException: Cannot change buffer size after data has been written` when buffer size needs to be incremented

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. Start the Payara server and make sure HTTP/2 and HTTP/2 push are enabled.
2. Deploy the war file from [web1-0.0.1-SNAPSHOT-p6.war](https://github.com/luiseufrasio/fish-61/blob/main/web1-0.0.1-SNAPSHOT-p6.war)
3. Quickly hard reload the index page (https) in the browser (CTRL + F5).
4. No more errors in the log

### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.9.0

## Documentation
None

