### PR TITLE
FISH-8859 FISH-10015 : design graceful shutdown of docker images community 6

### DIFF
--- a/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
+++ b/appserver/extras/docker-images/micro/src/main/docker/Dockerfile
@@ -46,7 +46,6 @@ EXPOSE 6900 8080
 ENV PAYARA_HOME=/opt/payara
 ENV HOME_DIR=${PAYARA_HOME}
 ENV PAYARA_DIR=${HOME_DIR} \
-    SCRIPT_DIR=${HOME_DIR} \
     DEPLOY_DIR=/opt/payara/deployments \
     JVM_ARGS="-Djdk.util.zip.disableZip64ExtraFieldValidation=true" \
     MEM_MAX_RAM_PERCENTAGE="70.0" \
@@ -58,7 +57,6 @@ RUN true \
     && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
     && echo payara:payara | chpasswd \
     && mkdir -p "${PAYARA_DIR}" \
-    && mkdir -p "${SCRIPT_DIR}" \
     && mkdir -p "${DEPLOY_DIR}" \
     && chown -R payara:payara ${HOME_DIR} \
     && true
@@ -66,7 +64,6 @@ RUN true \
 USER payara
 WORKDIR ${HOME_DIR}
 
-COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
 COPY --chown=payara:payara maven/artifacts/payara-micro.jar .
 
 ENTRYPOINT java -XX:MaxRAMPercentage=${MEM_MAX_RAM_PERCENTAGE} -Xss${MEM_XSS} -XX:+UseContainerSupport ${JVM_ARGS} -jar payara-micro.jar

--- a/appserver/extras/docker-images/micro/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/micro/src/main/docker/bin/entrypoint.sh
@@ -1,4 +1,4 @@
-#
+#!/bin/sh
 #    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 #    Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
@@ -37,40 +37,16 @@
 #    only if the new code is made subject to such option by the copyright
 #    holder.
 
-FROM @docker.java.image@
+set -e
 
-# Default payara ports to expose
-EXPOSE 6900 8080
+# Doing a Graceful Shutdown before container stops
+trap 'echo "Stopping Payara Micro...";
+      kill -TERM "$child" 2>/dev/null;
+      wait $child;
+      echo "Payara Micro stopped.";' SIGTERM
 
-# PAYARA_HOME is deprecated - it is here for backward compatibility
-ENV PAYARA_HOME=/opt/payara
-ENV HOME_DIR=${PAYARA_HOME}
-ENV PAYARA_DIR=${HOME_DIR} \
-    SCRIPT_DIR=${HOME_DIR} \
-    DEPLOY_DIR=/opt/payara/deployments \
-    JVM_ARGS="-Djdk.util.zip.disableZip64ExtraFieldValidation=true" \
-    MEM_MAX_RAM_PERCENTAGE="70.0" \
-    MEM_XSS="512k"
+exec java -XX:MaxRAMPercentage=${MEM_MAX_RAM_PERCENTAGE} -Xss${MEM_XSS} -XX:+UseContainerSupport ${JVM_ARGS} -jar payara-micro.jar "$@" &
+child=$!
 
-# Add Tini
-RUN apk add --no-cache tini
-
-RUN true \
-    && mkdir -p "${HOME_DIR}" \
-    && addgroup --gid 1000 payara \
-    && adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara \
-    && echo payara:payara | chpasswd \
-    && mkdir -p "${PAYARA_DIR}" \
-    && mkdir -p "${SCRIPT_DIR}" \
-    && mkdir -p "${DEPLOY_DIR}" \
-    && chown -R payara:payara ${HOME_DIR} \
-    && true
-
-USER payara
-WORKDIR ${HOME_DIR}
-
-COPY --chown=payara:payara maven/bin/* ${SCRIPT_DIR}/
-COPY --chown=payara:payara maven/artifacts/payara-micro.jar .
-
-ENTRYPOINT ["tini", "--", "/opt/payara/entrypoint.sh"]
-CMD ["--deploymentDir", "/opt/payara/deployments"]
+# Wait Payara-Micro Process before finish the container
+wait $child


### PR DESCRIPTION
## Description
Implement Docker Images Graceful Shutdown Support

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Run in WSL:
1. export JAVA_HOME=/usr/lib/jvm/zulu11-ca-amd64 && export PATH=${JAVA_HOME}/bin:${PATH}
2. cd Payara
3. mvn clean install -DskipTests
4. cd appserver/extras/docker-images/server-full
5. mvn clean package
6. cd target/docker
7. docker build -t payara/server-full:local -f ./payara/server-full/build/Dockerfile.jdk11 ./payara/server-full/tmp/docker-build/
8. docker run -it -p 8080:8080 -p 4848:4848 --name payara_docker payara/server-full:local
9. open another WSL Tab
10. docker ps -a
11. docker stop <container_id>, it works with only the id's 3 first chars
12. It should show us the logs of stop-domain with a gracefull shutdown at the ORIGINAL WSL tab

### Testing Environment
Zulu JDK 11.0.11 on Ubuntu 22 with Maven 3.9.0
