### PR TITLE
FISH-9145 Add Jakarta Data API

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -138,6 +138,12 @@
                 <type>pom</type>
             </dependency>
 
+            <dependency>
+                <groupId>jakarta.data</groupId>
+                <artifactId>jakarta.data-api</artifactId>
+                <version>${jakarta.data-api.version}</version>
+            </dependency>
+
             <!-- Microprofile API release aggregate. Can also be used as a BOM -->
             <dependency>
                 <groupId>org.eclipse.microprofile</groupId>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
-  ~    Copyright (c) 2019-2024 Payara Foundation and/or its affiliates. All rights reserved.
+  ~    Copyright (c) 2019-2025 Payara Foundation and/or its affiliates. All rights reserved.
   ~
   ~    The contents of this file are subject to the terms of either the GNU
   ~    General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -451,5 +451,13 @@
             <type>zip</type>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>data</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -389,5 +389,13 @@
             <type>zip</type>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>data</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) [2016-2021] Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2016-2025 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-distribution/pom.xml
@@ -492,5 +492,13 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>data</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 </project>

--- a/appserver/featuresets/payara-web/pom.xml
+++ b/appserver/featuresets/payara-web/pom.xml
@@ -240,5 +240,12 @@
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
+
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>data</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/featuresets/payara-web/pom.xml
+++ b/appserver/featuresets/payara-web/pom.xml
@@ -40,7 +40,7 @@
     holder.
 -->
 
-<!-- Portions Copyright [2016-2020] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">  <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/appserver/packager/data/pom.xml
+++ b/appserver/packager/data/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+   Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/main/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.server.internal.packager</groupId>
+        <artifactId>packages</artifactId>
+        <version>7.2025.1.Alpha1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>data</artifactId>
+    <name>Payara Jakarta Data Package</name>
+    <packaging>distribution-fragment</packaging>
+    <description>This pom describes how to assemble the Payara Jakarta Data package</description>
+
+    <properties>
+        <temp.dir>${project.build.directory}/dependency</temp.dir>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-step1</id>
+                    </execution>
+                    <execution>
+                        <id>process-step2</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>process-step3</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.server.internal.packager</groupId>
+            <artifactId>jakarta.data-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/appserver/packager/data/src/main/assembly/data.xml
+++ b/appserver/packager/data/src/main/assembly/data.xml
@@ -1,0 +1,64 @@
+<!--
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+   Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+
+   The contents of this file are subject to the terms of either the GNU
+   General Public License Version 2 only ("GPL") or the Common Development
+   and Distribution License("CDDL") (collectively, the "License").  You
+   may not use this file except in compliance with the License.  You can
+   obtain a copy of the License at
+   https://github.com/payara/Payara/blob/main/LICENSE.txt
+   See the License for the specific
+   language governing permissions and limitations under the License.
+
+   When distributing the software, include this License Header Notice in each
+   file and include the License file at glassfish/legal/LICENSE.txt.
+
+   GPL Classpath Exception:
+   The Payara Foundation designates this particular file as subject to the "Classpath"
+   exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+   file that accompanied this code.
+
+   Modifications:
+   If applicable, add the following below the License Header, with the fields
+   enclosed by brackets [] replaced by your own identifying information:
+   "Portions Copyright [year] [name of copyright owner]"
+
+   Contributor(s):
+   If you wish your version of this file to be governed by only the CDDL or
+   only the GPL Version 2, indicate your decision by adding "[Contributor]
+   elects to include this software in this distribution under the [CDDL or GPL
+   Version 2] license."  If you don't indicate a single choice of license, a
+   recipient has the option to distribute your version of this file under
+   either the CDDL, the GPL Version 2 or to extend the choice of license to
+   its licensees as provided above.  However, if you add GPL Version 2 code
+   and therefore, elected the GPL Version 2 license, then the option applies
+   only if the new code is made subject to such option by the copyright
+   holder.
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+    <id>stage-package</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${temp.dir}/nucleus</directory>
+            <outputDirectory>${install.dir.name}/glassfish</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${temp.dir}</directory>
+            <excludes>
+                <exclude>nucleus/**</exclude>
+                <exclude>pkg_proto.py</exclude>
+            </excludes>
+            <outputDirectory>${install.dir.name}</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>  

--- a/appserver/packager/data/src/main/resources/pkg_proto.py
+++ b/appserver/packager/data/src/main/resources/pkg_proto.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+#  Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+# 
+#  The contents of this file are subject to the terms of either the GNU
+#  General Public License Version 2 only ("GPL") or the Common Development
+#  and Distribution License("CDDL") (collectively, the "License").  You
+#  may not use this file except in compliance with the License.  You can
+#  obtain a copy of the License at
+#  https://github.com/payara/Payara/blob/main/LICENSE.txt
+#  See the License for the specific
+#  language governing permissions and limitations under the License.
+# 
+#  When distributing the software, include this License Header Notice in each
+#  file and include the License file at glassfish/legal/LICENSE.txt.
+# 
+#  GPL Classpath Exception:
+#  The Payara Foundation designates this particular file as subject to the "Classpath"
+#  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+#  file that accompanied this code.
+# 
+#  Modifications:
+#  If applicable, add the following below the License Header, with the fields
+#  enclosed by brackets [] replaced by your own identifying information:
+#  "Portions Copyright [year] [name of copyright owner]"
+# 
+#  Contributor(s):
+#  If you wish your version of this file to be governed by only the CDDL or
+#  only the GPL Version 2, indicate your decision by adding "[Contributor]
+#  elects to include this software in this distribution under the [CDDL or GPL
+#  Version 2] license."  If you don't indicate a single choice of license, a
+#  recipient has the option to distribute your version of this file under
+#  either the CDDL, the GPL Version 2 or to extend the choice of license to
+#  its licensees as provided above.  However, if you add GPL Version 2 code
+#  and therefore, elected the GPL Version 2 license, then the option applies
+#  only if the new code is made subject to such option by the copyright
+#  holder.
+#
+
+import imp
+
+conf = imp.load_source("pkg_conf", "../pkg_conf.py")
+
+pkg = {
+    "name"          : "data",
+    "version"       : conf.glassfish_version,
+    "attributes"    : {
+                        "pkg.summary" : "Jakarta Data Integration",
+                        "pkg.description" : "Jakarta Data Support modules",
+                        "info.classification" : "OSGi Service Platform Release 4",
+                      },
+    "dirtrees"      : { "glassfish/modules" : {},
+                      },
+    "licenses"      : {
+                        "../../../../CDDL+GPL.txt" : {"license" : "CDDL and GPL v2 with classpath exception"},
+                      }
+ }
+ 

--- a/appserver/packager/external/jakarta-data-api/pom.xml
+++ b/appserver/packager/external/jakarta-data-api/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.server.internal.packager</groupId>
+        <artifactId>external</artifactId>
+        <version>7.2025.1.Alpha1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta.data-api</artifactId>
+    <description>Generates an OSGi manifest for the Jakarta Data API (as it currently lacks one) and repackages it</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <skipIfEmpty>true</skipIfEmpty>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>osgi-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Embed-Dependency>*;scope=compile;inline=true</Embed-Dependency>
+                                <Export-Package>*</Export-Package>
+                                <Import-Package>*</Import-Package>
+                                <Private-Package>!*</Private-Package>
+                                <HK2-Bundle-Name>${project.groupId}:${project.artifactId}</HK2-Bundle-Name>
+                            </instructions>
+                            <unpackBundle>true</unpackBundle>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/appserver/packager/external/pom.xml
+++ b/appserver/packager/external/pom.xml
@@ -69,6 +69,7 @@
         <module>metro-xmlsec</module>
         <module>jakarta-ee9-shim</module>
         <module>jakarta-ee11-shim</module>
+        <module>jakarta-data-api</module>
     </modules>
     <build>
         <plugins>

--- a/appserver/packager/pom.xml
+++ b/appserver/packager/pom.xml
@@ -165,6 +165,7 @@
         <module>microprofile-package</module>
         <module>opentracing-jaxws-package</module>
         <module>monitoring-console</module>
+        <module>data</module>
     </modules>
     
     <properties>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -130,6 +130,8 @@
         <module>payara-appserver-modules</module>
         <module>docker</module>
         <module>monitoring-console</module>
+        <module>packager/external/jakarta-data-api</module>
+        <module>packager/data</module>
     </modules>
 
 

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -130,8 +130,6 @@
         <module>payara-appserver-modules</module>
         <module>docker</module>
         <module>monitoring-console</module>
-        <module>packager/external/jakarta-data-api</module>
-        <module>packager/data</module>
     </modules>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright 2017-2024 Payara Foundation and/or affiliates
+    Portions Copyright 2017-2025 Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
         <payara-arquillian-container.version>4.0.alpha1</payara-arquillian-container.version>
         <h2db.version>2.2.224</h2db.version>
         <concurro.version>3.1.0-SNAPSHOT</concurro.version>
+        <jakarta.data-api.version>1.0.1</jakarta.data-api.version>
 
         <monitoring-console-process.version>3.0.0-SNAPSHOT</monitoring-console-process.version>
         <monitoring-console-webapp.version>3.0.0-SNAPSHOT</monitoring-console-webapp.version>


### PR DESCRIPTION
## Description
Adds the Jakarta Data API to Payara Server.

The published API doesn't have an OSGi manifest, so I have added one.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran against https://github.com/payara/jakartaee-10-tck-runners/pull/135 - signature test passes

### Testing Environment
Windows 11, Zulu JDK 21.0.6, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
None
