### PR TITLE
FISH-10585 Update Concurro to 3.1.0-M5

### DIFF
--- a/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
+++ b/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
@@ -418,7 +418,7 @@ public class ComponentEnvManagerImpl
                     _logger.severe(() -> "Unexpected Concurrency type! Expected ConcurrencyQualifiedDescriptor, got " + desc);
                 }
             }
-            jndiBindings.add(new CompEnvBinding(ConcurrencyManagedCDIBeans.JDNI_NAME, setup));
+            jndiBindings.add(new CompEnvBinding(ConcurrencyManagedCDIBeans.JNDI_NAME, setup));
         }
     }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -160,7 +160,7 @@
         <bouncycastle-jdk15on.version>1.70</bouncycastle-jdk15on.version>
         <jsftemplating.version>3.0.0</jsftemplating.version>
         <jakarta.faces-api.version>4.1.0</jakarta.faces-api.version>
-        <concurro.version>3.1.0-SNAPSHOT</concurro.version>
+        <concurro.version>3.1.0-M5</concurro.version>
 
         <!-- build versions -->
         <jdk.version>21</jdk.version>


### PR DESCRIPTION
## Description
Updates Concurro to 3.1.0-M5, fixing the inherited typo 

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran against Concurrency TCK, passed: https://jenkins.payara.fish/view/TCKs/job/JakartaEE-11-TCK/129/

### Testing Environment
Jenkins

## Documentation
N/A

## Notes for Reviewers
None
