### PR TITLE
FISH-8302 Virtual Threads Configuration

### DIFF
--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2022-2025 Payara Foundation and/or its affiliates -->
 
 <!-- concurrent/managedExecutorService.inc -->
 
@@ -83,6 +84,10 @@
        
        <sun:property id="longrunningtasks"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.longRunningTasks}">
             <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['longRunningTasks']}" selectedValue="true"  />
+       </sun:property>
+
+       <sun:property id="usevirtualthreads" rendered="#{pageSession.showVirtualThreads}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.usevirtualthreads}">
+            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['useVirtualThreads']}" selectedValue="true"  />
        </sun:property>
 
        <sun:property id="useforkjoinpool" rendered="#{pageSession.showForkJoin}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.useforkjoinpool}">

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceEdit.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceEdit.jsf
@@ -74,6 +74,7 @@
     setPageSessionAttribute(key="convertToFalseList2" value={"enabled"});
     setPageSessionAttribute(key="showMaxPoolSize" value="#{true}");
     setPageSessionAttribute(key="showForkJoin" value="#{true}");
+    setPageSessionAttribute(key="showVirtualThreads" value="#{true}");
     setPageSessionAttribute(key="showTaskQueue" value="#{true}");
     setPageSessionAttribute(key="listCommand" value="list-managed-executor-services");
     setPageSessionAttribute(key="logicalJndiMapKey" value="managedExecutorServices");

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceEdit.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceEdit.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2022-2025 Payara Foundation and/or its affiliates -->
 
 <!-- concurrent/managedExecutorServiceEdit.jsf -->
 <!initPage
@@ -63,7 +64,7 @@
 
     gf.buildResourceUrl(base="#{pageSession.parentUrl}/#{pageSession.childType}", resourceName="#{pageSession.Name}", url="#{pageSession.selfUrl}");
     gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}", valueMap="#{pageSession.valueMap}");
-    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useForkJoinPool" });
+    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useVirtualThreads", "useForkJoinPool" });
     setPageSessionAttribute(key="skipAttrsList", value={"jndiName"});
     
     gf.restRequest(endpoint="#{pageSession.selfUrl}/property" method="GET" result="#{requestScope.propTable}");

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceNew.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceNew.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2022-2025 Payara Foundation and/or its affiliates -->
 
 <!-- concurent/managedExecutorServiceNew.jsf -->
 
@@ -55,7 +56,7 @@
         setPageSessionAttribute(key="parentPage" value="#{request.contextPath}/concurrent/managedExecutorServices.jsf");
         setPageSessionAttribute(key="childType" value="managed-executor-service");
         setPageSessionAttribute(key="isConcurrent" value="true");
-        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useForkJoinPool" });
+        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useVirtualThreads", "useForkJoinPool" });
         setPageSessionAttribute(key="parentUrl", value="#{sessionScope.REST_URL}/resources");
         gf.getDefaultValues(endpoint="#{pageSession.parentUrl}/#{pageSession.childType}", valueMap="#{pageSession.valueMap}");
         setPageSessionAttribute(key="edit" value="#{false}" );
@@ -64,6 +65,7 @@
         mapPut(map="#{pageSession.valueMap2}" key="enabled" value="true");
         setPageSessionAttribute(key="showMaxPoolSize" value="#{true}");
         setPageSessionAttribute(key="showTaskQueue" value="#{true}");
+        setPageSessionAttribute(key="showVirtualThreads" value="#{true}");
         setPageSessionAttribute(key="showForkJoin" value="#{true}");
     />
     </event>

--- a/appserver/admingui/concurrent/src/main/resources/managedScheduledExecutorServiceEdit.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedScheduledExecutorServiceEdit.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- concurrent/managedScheduledExecutorServiceEdit.jsf -->
 <!initPage
@@ -63,7 +64,7 @@
 
     gf.buildResourceUrl(base="#{pageSession.parentUrl}/#{pageSession.childType}", resourceName="#{pageSession.Name}", url="#{pageSession.selfUrl}");
     gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}", valueMap="#{pageSession.valueMap}");
-    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks" });
+    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useVirtualThreads" });
     setPageSessionAttribute(key="skipAttrsList", value={"jndiName"});
     
     gf.restRequest(endpoint="#{pageSession.selfUrl}/property" method="GET" result="#{requestScope.propTable}");
@@ -74,6 +75,7 @@
     setPageSessionAttribute(key="showMaxPoolSize" value="#{false}");
     setPageSessionAttribute(key="showTaskQueue" value="#{false}");
     setPageSessionAttribute(key="showForkJoin" value="#{false}");
+    setPageSessionAttribute(key="showVirtualThreads" value="#{true}");
     setPageSessionAttribute(key="listCommand" value="list-managed-scheduled-executor-services");
     setPageSessionAttribute(key="logicalJndiMapKey" value="managedScheduledExecutorServices");
 

--- a/appserver/admingui/concurrent/src/main/resources/managedScheduledExecutorServiceNew.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedScheduledExecutorServiceNew.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- concurent/managedScheduledExecutorServiceNew.jsf -->
 
@@ -55,7 +56,7 @@
         setPageSessionAttribute(key="parentPage" value="#{request.contextPath}/concurrent/managedScheduledExecutorServices.jsf");
         setPageSessionAttribute(key="childType" value="managed-scheduled-executor-service");
         setPageSessionAttribute(key="isConcurrent" value="true");
-        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks" });
+        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "longRunningTasks", "useVirtualThreads" });
         setPageSessionAttribute(key="parentUrl", value="#{sessionScope.REST_URL}/resources");
         gf.getDefaultValues(endpoint="#{pageSession.parentUrl}/#{pageSession.childType}", valueMap="#{pageSession.valueMap}");
         setPageSessionAttribute(key="edit" value="#{false}" );
@@ -66,6 +67,7 @@
         setPageSessionAttribute(key="showMaxPoolSize" value="#{false}");
         setPageSessionAttribute(key="showTaskQueue" value="#{false}");
         setPageSessionAttribute(key="showForkJoin" value="#{false}");
+        setPageSessionAttribute(key="showVirtualThreads" value="#{true}");
     />
     </event>
     "    <script type="text/javascript">admingui.nav.selectTreeNodeById(admingui.nav.TREE_ID+":resources:concurrent:managedScheduledExecutorServices");</script>

--- a/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryAttr.inc
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- concurrent/managedThreadFactoryAttr.inc -->
 
@@ -81,6 +82,10 @@
                 
        <sun:property id="threadPriorityProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.threadPriorityLabel}"  helpText="$resource{i18ncon.threadPriorityLabelHelp}">
             <sun:textField id="threadPriorityProp" styleClass="integer" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['threadPriority']}" />
+       </sun:property>
+
+       <sun:property id="usevirtualthreads" rendered="#{pageSession.showVirtualThreads}" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.usevirtualthreads}">
+            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['useVirtualThreads']}" selectedValue="true"  />
        </sun:property>
 
        <sun:property id="deploymentOrder" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}"  rendered="#{edit}" label="$resource{i18n.common.resource.deploymentOrder}" helpText="$resource{i18n.common.resource.deploymentOrderHelp}" >

--- a/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryEdit.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryEdit.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- concurrent/managedThreadFactoryEdit.jsf -->
 <!initPage
@@ -63,12 +64,13 @@
 
     gf.buildResourceUrl(base="#{pageSession.parentUrl}/#{pageSession.childType}", resourceName="#{pageSession.Name}", url="#{pageSession.selfUrl}");
     gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}", valueMap="#{pageSession.valueMap}");
-    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled"});
+    setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "useVirtualThreads"});
     setPageSessionAttribute(key="skipAttrsList", value={"jndiName"});
     
     gf.restRequest(endpoint="#{pageSession.selfUrl}/property" method="GET" result="#{requestScope.propTable}");
     setPageSessionAttribute(key="tableList" value="#{requestScope.propTable.data.extraProperties.properties}");
     setPageSessionAttribute(key="edit" value="#{true}" );
+    setPageSessionAttribute(key="showVirtualThreads" value="#{true}");
 
     setPageSessionAttribute(key="convertToFalseList2" value={"enabled"});
     />

--- a/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryNew.jsf
+++ b/appserver/admingui/concurrent/src/main/resources/managedThreadFactoryNew.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- concurent/managedThreadFactoryNew.jsf -->
 
@@ -55,10 +56,11 @@
         setPageSessionAttribute(key="parentPage" value="#{request.contextPath}/concurrent/managedThreadFactories.jsf");
         setPageSessionAttribute(key="childType" value="managed-thread-factory");
         setPageSessionAttribute(key="isConcurrent" value="true");
-        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled"});
+        setPageSessionAttribute(key="convertToFalseList" value={"enabled", "contextInfoEnabled", "useVirtualThreads"});
         setPageSessionAttribute(key="parentUrl", value="#{sessionScope.REST_URL}/resources");
         gf.getDefaultValues(endpoint="#{pageSession.parentUrl}/#{pageSession.childType}", valueMap="#{pageSession.valueMap}");
         setPageSessionAttribute(key="edit" value="#{false}" );
+        setPageSessionAttribute(key="showVirtualThreads" value="#{true}");
         createMap(result="#{pageSession.valueMap2}")
         mapPut(map="#{pageSession.valueMap}" key="enabled" value="true");
         mapPut(map="#{pageSession.valueMap2}" key="enabled" value="true");

--- a/appserver/admingui/concurrent/src/main/resources/org/glassfish/concurrent/admingui/Strings.properties
+++ b/appserver/admingui/concurrent/src/main/resources/org/glassfish/concurrent/admingui/Strings.properties
@@ -37,6 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright 2022-2025 Payara Foundation and/or affiliates
 
 ## Concurrent
 
@@ -114,6 +115,7 @@ contextInfoLabelHelp=Container contexts to propagate to other threads. If disabl
 threadPriorityLabel=Thread Priority:
 threadPriorityLabelHelp=Priority to assign to created threads
 longRunningTasks=Long-Running Tasks:
+usevirtualthreads=Use Virtual Threads:
 useforkjoinpool=Use ForkJoinPool:
 longRunningTasksHelp=Use the resource for long-running tasks. If enabled, long-running tasks are not reported as stuck. 
 hungAfterSeconds=Hung After:

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
@@ -125,21 +125,6 @@ public interface ManagedExecutorService extends ConfigBeanProxy, Resource,
      */
     void setUseForkJoinPool(String value) throws PropertyVetoException;
 
-    /**
-     * Gets the value of the useVirtualThreads property.
-     *
-     * @return possible object is {@link String }
-     */
-    @Attribute(defaultValue = "false", dataType = Boolean.class)
-    String getUseVirtualThreads();
-
-    /**
-     * Sets the value of the useVirtualThreads property.
-     *
-     * @param value allowed object is {@link String }
-     */
-    void setUseVirtualThreads(String value) throws PropertyVetoException;
-
     @DuckTyped
     String getIdentity();
 

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022-2024] Payara Foundation and/or affiliates
+// Portions Copyright 2022-2025 Payara Foundation and/or affiliates
 package org.glassfish.concurrent.config;
 
 import com.sun.enterprise.config.modularity.ConfigBeanInstaller;

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorServiceBase.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorServiceBase.java
@@ -161,6 +161,21 @@ public interface ManagedExecutorServiceBase extends ConfigBeanProxy,
     void setThreadLifetimeSeconds(String value) throws PropertyVetoException;
 
     /**
+     * Gets the value of the useVirtualThreads property.
+     *
+     * @return possible object is {@link String }
+     */
+    @Attribute(defaultValue = "false", dataType = Boolean.class)
+    String getUseVirtualThreads();
+
+    /**
+     * Sets the value of the useVirtualThreads property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    void setUseVirtualThreads(String value) throws PropertyVetoException;
+
+    /**
      * Gets the value of the context property.
      *
      * @return possible object is {@link String }

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorServiceBase.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorServiceBase.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022] Payara Foundation and/or affiliates
+// Portions Copyright [2022-2025] Payara Foundation and/or affiliates
 
 package org.glassfish.concurrent.config;
 

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedThreadFactory.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedThreadFactory.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022] Payara Foundation and/or affiliates
+// Portions Copyright [2022-2025] Payara Foundation and/or affiliates
 
 package org.glassfish.concurrent.config;
 

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedThreadFactory.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedThreadFactory.java
@@ -95,6 +95,21 @@ public interface ManagedThreadFactory extends ConfigBeanProxy, Resource,
     void setThreadPriority(String value) throws PropertyVetoException;
 
     /**
+     * Gets the value of the useVirtualThreads property.
+     *
+     * @return possible object is {@link String }
+     */
+    @Attribute(defaultValue = "false", dataType = Boolean.class)
+    String getUseVirtualThreads();
+
+    /**
+     * Sets the value of the useVirtualThreads property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    void setUseVirtualThreads(String value) throws PropertyVetoException;
+
+    /**
      * Gets the value of the context property.
      *
      * @return possible object is {@link String }

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
@@ -20,7 +20,7 @@ package fish.payara.concurrent.monitoring;
 import org.glassfish.concurrent.config.ManagedScheduledExecutorService;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
 import org.glassfish.concurrent.runtime.deployer.ManagedScheduledExecutorServiceConfig;
-import org.glassfish.concurro.ManagedScheduledExecutorServiceImpl;
+import org.glassfish.concurro.AbstractManagedExecutorService;
 import org.glassfish.external.probe.provider.StatsProviderManager;
 import org.glassfish.external.statistics.CountStatistic;
 import org.glassfish.external.statistics.impl.CountStatisticImpl;
@@ -41,9 +41,8 @@ public class ManagedScheduledExecutorServiceStatsProvider
 {
     private final String name;
     private boolean registered = false;
-    private final ManagedScheduledExecutorServiceImpl 
-            managedScheduledExecutorServiceImpl;
-    
+    private final AbstractManagedExecutorService managedScheduledExecutorServiceImpl;
+
     private CountStatisticImpl completedTaskCount = new CountStatisticImpl(
             "CompletedTaskCount", "count", 
             "Number of tasks completed");

--- a/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/fish/payara/concurrent/monitoring/ManagedScheduledExecutorServiceStatsProvider.java
@@ -1,7 +1,7 @@
 /**
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright (c) 2016-2024 Payara Foundation and/or its affiliates.
+ * Copyright (c) 2016-2025 Payara Foundation and/or its affiliates.
  * All rights reserved.
  *
  * The contents of this file are subject to the terms of the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorService.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorService.java
@@ -77,9 +77,6 @@ public class CreateManagedExecutorService extends CreateManagedExecutorServiceBa
     @Param(name="taskqueuecapacity", alias="taskQueueCapacity", defaultValue=""+Integer.MAX_VALUE, optional=true)
     private Integer taskqueuecapacity;
 
-    @Param(name = "usevirtualthreads", alias = "useVirtualThreads", defaultValue = "false", optional = true)
-    protected Boolean usevirtualthreads;
-
     @Param(name = "useforkjoinpool", alias = "useForkJoinPool", defaultValue = "false", optional = true)
     protected Boolean useforkjoinpool;
 
@@ -95,8 +92,6 @@ public class CreateManagedExecutorService extends CreateManagedExecutorServiceBa
             maximumpoolsize.toString());
         attrList.put(ResourceConstants.TASK_QUEUE_CAPACITY,
             taskqueuecapacity.toString());
-        attrList.put(ResourceConstants.USE_VIRTUAL_THREADS,
-                usevirtualthreads.toString());
         attrList.put(ResourceConstants.USE_FORK_JOIN_POOL,
                 useforkjoinpool.toString());
     }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorService.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorService.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.concurrent.admin;
 
@@ -77,7 +77,10 @@ public class CreateManagedExecutorService extends CreateManagedExecutorServiceBa
     @Param(name="taskqueuecapacity", alias="taskQueueCapacity", defaultValue=""+Integer.MAX_VALUE, optional=true)
     private Integer taskqueuecapacity;
 
-    @Param(name="useforkjoinpool", alias="useForkJoinPool", defaultValue="false", optional=true)
+    @Param(name = "usevirtualthreads", alias = "useVirtualThreads", defaultValue = "false", optional = true)
+    protected Boolean usevirtualthreads;
+
+    @Param(name = "useforkjoinpool", alias = "useForkJoinPool", defaultValue = "false", optional = true)
     protected Boolean useforkjoinpool;
 
     @Inject
@@ -92,6 +95,8 @@ public class CreateManagedExecutorService extends CreateManagedExecutorServiceBa
             maximumpoolsize.toString());
         attrList.put(ResourceConstants.TASK_QUEUE_CAPACITY,
             taskqueuecapacity.toString());
+        attrList.put(ResourceConstants.USE_VIRTUAL_THREADS,
+                usevirtualthreads.toString());
         attrList.put(ResourceConstants.USE_FORK_JOIN_POOL,
                 useforkjoinpool.toString());
     }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorServiceBase.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorServiceBase.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.concurrent.admin;
 
@@ -89,7 +89,10 @@ public class CreateManagedExecutorServiceBase {
     @Param(name="threadlifetimeseconds", alias="threadLifetimeSeconds", defaultValue="0", optional=true)
     protected Integer threadlifetimeseconds;
 
-    @Param(optional=true)
+    @Param(name = "usevirtualthreads", alias = "useVirtualThreads", defaultValue = "false", optional = true)
+    protected Boolean usevirtualthreads;
+
+    @Param(optional = true)
     protected String description;
 
     @Param(name="property", optional=true, separator=':')
@@ -114,6 +117,8 @@ public class CreateManagedExecutorServiceBase {
             keepaliveseconds.toString());
         attrList.put(ResourceConstants.THREAD_LIFETIME_SECONDS, 
             threadlifetimeseconds.toString());
+        attrList.put(ResourceConstants.USE_VIRTUAL_THREADS,
+                usevirtualthreads.toString());
         attrList.put(ServerTags.DESCRIPTION, description);
         attrList.put(ResourceConstants.ENABLED, enabled.toString());
     }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedThreadFactory.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedThreadFactory.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.concurrent.admin;
 
@@ -92,7 +92,10 @@ public class CreateManagedThreadFactory implements AdminCommand {
     @Param(name="threadpriority", alias="threadPriority", defaultValue=""+Thread.NORM_PRIORITY, optional=true)
     private Integer threadpriority;
 
-    @Param(optional=true)
+    @Param(name = "usevirtualthreads", alias = "useVirtualThreads", defaultValue = "false", optional = true)
+    protected Boolean usevirtualthreads;
+
+    @Param(optional = true)
     private String description;
 
     @Param(name="property", optional=true, separator=':')
@@ -122,6 +125,8 @@ public class CreateManagedThreadFactory implements AdminCommand {
         attrList.put(ResourceConstants.CONTEXT_INFO, contextinfo);
         attrList.put(ResourceConstants.THREAD_PRIORITY, 
             threadpriority.toString());
+        attrList.put(ResourceConstants.USE_VIRTUAL_THREADS,
+                usevirtualthreads.toString());
         attrList.put(ServerTags.DESCRIPTION, description);
         attrList.put(ResourceConstants.ENABLED, enabled.toString());
         ResourceStatus rs;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation]
+// Portions Copyright [2016-2025] [Payara Foundation]
 package org.glassfish.concurrent.admin;
 
 import com.sun.appserv.connectors.internal.api.ConnectorsUtil;
@@ -87,6 +87,7 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
     protected String corePoolSize = "0";
     protected String keepAliveSeconds = "60";
     protected String threadLifetimeSeconds = "0";
+    protected String useVirtualThreads = Boolean.FALSE.toString();
     protected String enabled = Boolean.TRUE.toString();
     protected String enabledValueForTarget = Boolean.TRUE.toString();
 
@@ -173,6 +174,7 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
         corePoolSize = (String) attributes.get(CORE_POOL_SIZE);
         keepAliveSeconds = (String) attributes.get(KEEP_ALIVE_SECONDS);
         threadLifetimeSeconds = (String) attributes.get(THREAD_LIFETIME_SECONDS);
+        useVirtualThreads = (String) attributes.getOrDefault(USE_VIRTUAL_THREADS, Boolean.FALSE.toString());
         if(target != null){
             enabled = resourceUtil.computeEnabledValueForResourceBasedOnTarget((String)attributes.get(ENABLED), target);
         }else{

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceManager.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright 2022 Payara Foundation and/or its affiliates
+// Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
 package org.glassfish.concurrent.admin;
 
@@ -59,9 +59,8 @@ import java.util.Properties;
 import java.beans.PropertyVetoException;
 
 /**
- *
- * The managed executor service manager allows you to create and delete
- * the managed-executor-service config element
+ * The managed executor service manager allows you to create and delete the
+ * managed-executor-service configuration element.
  */
 @Service (name=ServerTags.MANAGED_EXECUTOR_SERVICE)
 @I18n("managed.executor.service.manager")
@@ -70,6 +69,7 @@ public class ManagedExecutorServiceManager extends ManagedExecutorServiceBaseMan
 
     private String maximumPoolSize = ""+Integer.MAX_VALUE;
     private String taskQueueCapacity = ""+Integer.MAX_VALUE;
+    private String useVirtualThreads = Boolean.FALSE.toString();
     private String useForkJoinPool = Boolean.FALSE.toString();
 
     @Override
@@ -77,37 +77,46 @@ public class ManagedExecutorServiceManager extends ManagedExecutorServiceBaseMan
         super.setAttributes(attributes, target);
         maximumPoolSize = (String) attributes.get(MAXIMUM_POOL_SIZE);
         taskQueueCapacity = (String) attributes.get(TASK_QUEUE_CAPACITY);
-        useForkJoinPool = (String) attributes.get(USE_FORK_JOIN_POOL);
+        useVirtualThreads = (String) attributes.getOrDefault(USE_VIRTUAL_THREADS, Boolean.FALSE.toString());
+        useForkJoinPool = (String) attributes.getOrDefault(USE_FORK_JOIN_POOL, Boolean.FALSE.toString());
     }
 
     @Override
-    protected ResourceStatus isValid(Resources resources, boolean validateResourceRef, String target){
-        if ("false".equals(useForkJoinPool)) {
-            if (Integer.parseInt(corePoolSize) == 0 &&
-                    Integer.parseInt(maximumPoolSize) == 0) {
-                String msg = localStrings.getLocalString("coresize.maxsize.both.zero", "Options corepoolsize and maximumpoolsize cannot both have value 0.");
-                return new ResourceStatus(ResourceStatus.FAILURE, msg);
+    protected ResourceStatus isValid(Resources resources, boolean validateResourceRef, String target) {
+        String errorMsg = null;
+        boolean doUseForkJoinPool = Boolean.parseBoolean(useForkJoinPool);
+        int intCorePoolSize = Integer.parseInt(corePoolSize);
+        int intMaximumPoolSize = Integer.parseInt(maximumPoolSize);
+        if (doUseForkJoinPool == false && Boolean.parseBoolean(useVirtualThreads) == false) {
+            if (intCorePoolSize == 0 && intMaximumPoolSize == 0) {
+                errorMsg = localStrings.getLocalString("coresize.maxsize.both.zero", "Options corepoolsize and maximumpoolsize cannot both have value 0.");
             }
         }
-
-        if (Integer.parseInt(corePoolSize) >
-                Integer.parseInt(maximumPoolSize)) {
-            String msg = localStrings.getLocalString("coresize.biggerthan.maxsize", "Option corepoolsize cannot have a bigger value than option maximumpoolsize.");
-            return new ResourceStatus(ResourceStatus.FAILURE, msg);
+        if (intCorePoolSize > intMaximumPoolSize) {
+            errorMsg = localStrings.getLocalString("coresize.biggerthan.maxsize", "Option corepoolsize cannot have a bigger value than option maximumpoolsize.");
+        }
+        if (doUseForkJoinPool && intMaximumPoolSize > 0x7fff /*ForkJoinPool.MAX_CAP*/) {
+            errorMsg = localStrings.getLocalString("coresize.biggerthan.maxsize", "Option corepoolsize cannot have a bigger value than option maximumpoolsize.");
+        }
+        if (errorMsg != null) {
+            return new ResourceStatus(ResourceStatus.FAILURE, errorMsg);
         }
 
         return super.isValid(resources, validateResourceRef, target);
     }
 
+    @Override
     protected ManagedExecutorServiceBase createConfigBean(Resources param, Properties properties) throws PropertyVetoException, TransactionFailure {
         ManagedExecutorService managedExecutorService = param.createChild(ManagedExecutorService.class);
         setAttributesOnConfigBean(managedExecutorService, properties);
         managedExecutorService.setMaximumPoolSize(maximumPoolSize);
         managedExecutorService.setTaskQueueCapacity(taskQueueCapacity);
+        managedExecutorService.setUseVirtualThreads(useVirtualThreads);
         managedExecutorService.setUseForkJoinPool(useForkJoinPool);
         return managedExecutorService;
     }
 
+    @Override
     public String getResourceType () {
         return ServerTags.MANAGED_EXECUTOR_SERVICE;
     }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceManager.java
@@ -69,7 +69,6 @@ public class ManagedExecutorServiceManager extends ManagedExecutorServiceBaseMan
 
     private String maximumPoolSize = ""+Integer.MAX_VALUE;
     private String taskQueueCapacity = ""+Integer.MAX_VALUE;
-    private String useVirtualThreads = Boolean.FALSE.toString();
     private String useForkJoinPool = Boolean.FALSE.toString();
 
     @Override
@@ -77,7 +76,6 @@ public class ManagedExecutorServiceManager extends ManagedExecutorServiceBaseMan
         super.setAttributes(attributes, target);
         maximumPoolSize = (String) attributes.get(MAXIMUM_POOL_SIZE);
         taskQueueCapacity = (String) attributes.get(TASK_QUEUE_CAPACITY);
-        useVirtualThreads = (String) attributes.getOrDefault(USE_VIRTUAL_THREADS, Boolean.FALSE.toString());
         useForkJoinPool = (String) attributes.getOrDefault(USE_FORK_JOIN_POOL, Boolean.FALSE.toString());
     }
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedScheduledExecutorServiceManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedScheduledExecutorServiceManager.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2025 Payara Foundation and/or its affiliates 
 
 package org.glassfish.concurrent.admin;
 
@@ -68,6 +69,7 @@ public class ManagedScheduledExecutorServiceManager extends ManagedExecutorServi
 
     protected ManagedExecutorServiceBase createConfigBean(Resources param, Properties properties) throws PropertyVetoException, TransactionFailure {
         ManagedScheduledExecutorService managedExecutorService = param.createChild(ManagedScheduledExecutorService.class);
+        managedExecutorService.setUseVirtualThreads(useVirtualThreads);
         setAttributesOnConfigBean(managedExecutorService, properties);
         return managedExecutorService;
     }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedThreadFactoryManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedThreadFactoryManager.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2025 Payara Foundation and/or its affiliates 
 
 package org.glassfish.concurrent.admin;
 
@@ -87,6 +88,7 @@ public class ManagedThreadFactoryManager implements ResourceManager {
     private String threadPriority = ""+Thread.NORM_PRIORITY;
     private String contextInfoEnabled = Boolean.TRUE.toString();
     private String contextInfo = CONTEXT_INFO_DEFAULT_VALUE;
+    private String useVirtualThreads = Boolean.FALSE.toString();
     private String enabled = Boolean.TRUE.toString();
     private String enabledValueForTarget = Boolean.TRUE.toString();
 
@@ -152,6 +154,7 @@ public class ManagedThreadFactoryManager implements ResourceManager {
         contextInfoEnabled = (String) attributes.get(CONTEXT_INFO_ENABLED);
         contextInfo = (String) attributes.get(CONTEXT_INFO);
         threadPriority = (String) attributes.get(THREAD_PRIORITY);
+        useVirtualThreads = (String) attributes.getOrDefault(USE_VIRTUAL_THREADS, Boolean.FALSE.toString());
         if(target != null){
             enabled = resourceUtil.computeEnabledValueForResourceBasedOnTarget((String)attributes.get(ENABLED), target);
         }else{
@@ -177,6 +180,7 @@ public class ManagedThreadFactoryManager implements ResourceManager {
         managedThreadFactory.setContextInfoEnabled(contextInfoEnabled);
         managedThreadFactory.setContextInfo(contextInfo);
         managedThreadFactory.setThreadPriority(threadPriority);
+        managedThreadFactory.setUseVirtualThreads(useVirtualThreads);
         managedThreadFactory.setEnabled(enabled);
         if (properties != null) {
             for ( Map.Entry e : properties.entrySet()) {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -316,7 +316,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
 
     public AbstractManagedExecutorService createManagedScheduledExecutorService(ResourceInfo resource,
             ManagedScheduledExecutorServiceConfig config, ContextServiceImpl contextService) {
-        ManagedThreadFactoryImpl managedThreadFactory = new ThreadFactoryWrapper(
+        ManagedThreadFactoryImpl managedThreadFactory = new ThreadFactoryWrapper( // FIXME: move to the next if
                 config.getJndiName() + "-managedThreadFactory",
                 null,
                 config.getThreadPriority());

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -45,6 +45,7 @@ import com.sun.enterprise.config.serverbeans.Applications;
 import com.sun.enterprise.container.common.spi.util.ComponentEnvManager;
 import com.sun.enterprise.transaction.api.JavaEETransactionManager;
 import com.sun.enterprise.util.Utility;
+import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.concurrent.LogFacade;
 import org.glassfish.concurrent.runtime.deployer.ContextServiceConfig;
@@ -79,6 +80,8 @@ import org.glassfish.concurro.ManagedExecutorServiceImpl;
 import org.glassfish.concurro.ManagedScheduledExecutorServiceImpl;
 import org.glassfish.concurro.ManagedThreadFactoryImpl;
 import org.glassfish.concurro.virtualthreads.VirtualThreadsManagedExecutorService;
+import org.glassfish.concurro.virtualthreads.VirtualThreadsManagedScheduledExecutorService;
+import org.glassfish.concurro.virtualthreads.VirtualThreadsManagedThreadFactory;
 import org.glassfish.concurro.spi.ContextHandle;
 import org.glassfish.resourcebase.resources.naming.ResourceNamingService;
 
@@ -91,8 +94,8 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
 
     private static ConcurrentRuntime _runtime;
 
-    private Map<String, AbstractManagedExecutorService> managedExecutorServiceMap;
-    private Map<String, ManagedScheduledExecutorServiceImpl> managedScheduledExecutorServiceMap;
+    private Map<String, AbstractManagedExecutorService> managedExecutorServiceMap = new HashMap();
+    private Map<String, AbstractManagedExecutorService> managedScheduledExecutorServiceMap = new HashMap();
     private Map<String, ContextServiceImpl> contextServiceMap = new HashMap();
     private Map<String, ManagedThreadFactoryImpl> managedThreadFactoryMap;
 
@@ -208,7 +211,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
     public synchronized AbstractManagedExecutorService getManagedExecutorService(ResourceInfo resourceInfo, ManagedExecutorServiceConfig config) {
         String jndiName = config.getJndiName();
 
-        if (managedExecutorServiceMap != null && managedExecutorServiceMap.containsKey(jndiName)) {
+        if (managedExecutorServiceMap.containsKey(jndiName)) {
             return managedExecutorServiceMap.get(jndiName);
         }
 
@@ -218,10 +221,6 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
                 config.isContextInfoEnabledBoolean(), true);
 
         AbstractManagedExecutorService mes = createManagedExecutorService(resourceInfo, config, contextService);
-        if (managedExecutorServiceMap == null) {
-            managedExecutorServiceMap = new HashMap();
-        }
-
         managedExecutorServiceMap.put(jndiName, mes);
         return mes;
     }
@@ -290,57 +289,69 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
     public void shutdownManagedExecutorService(String jndiName) {
         AbstractManagedExecutorService mes = null;
         synchronized(this) {
-            if (managedExecutorServiceMap != null) {
-                mes = managedExecutorServiceMap.remove(jndiName);
-            }
+            mes = managedExecutorServiceMap.remove(jndiName);
         }
         if (mes != null) {
             mes.shutdownNow();
         }
     }
 
-    public synchronized ManagedScheduledExecutorServiceImpl getManagedScheduledExecutorService(ResourceInfo resource,
-                                                                                               ManagedScheduledExecutorServiceConfig config) {
+    public synchronized AbstractManagedExecutorService getManagedScheduledExecutorService(ResourceInfo resource,
+            ManagedScheduledExecutorServiceConfig config) {
         String jndiName = config.getJndiName();
-        if (managedScheduledExecutorServiceMap != null && managedScheduledExecutorServiceMap.containsKey(jndiName)) {
-            return managedScheduledExecutorServiceMap.get(jndiName);
-        }
-        ContextServiceImpl contextService = prepareContextService(createContextServiceName(config.getContext(), config.getJndiName()),
-                config.getContextInfo(), config.isContextInfoEnabledBoolean(), true);
+        AbstractManagedExecutorService mes = managedScheduledExecutorServiceMap.get(jndiName);
+        if (mes == null) {
+            ContextServiceImpl contextService = prepareContextService(createContextServiceName(config.getContext(), config.getJndiName()),
+                    config.getContextInfo(), config.isContextInfoEnabledBoolean(), true);
 
-        ManagedScheduledExecutorServiceImpl mes = createManagedScheduledExecutorService(resource, config, contextService);
+            mes = createManagedScheduledExecutorService(resource, config, contextService);
 
-        if (managedScheduledExecutorServiceMap == null) {
-            managedScheduledExecutorServiceMap = new HashMap();
-        }
-        managedScheduledExecutorServiceMap.put(jndiName, mes);
-        if (config.getHungAfterSeconds() > 0L && !config.isLongRunningTasks()) {
-            scheduleInternalTimer();
+            managedScheduledExecutorServiceMap.put(jndiName, mes);
+            if (config.getHungAfterSeconds() > 0L && !config.isLongRunningTasks()) {
+                scheduleInternalTimer();
+            }
         }
         return mes;
     }
 
-    public ManagedScheduledExecutorServiceImpl createManagedScheduledExecutorService(ResourceInfo resource,
-                                                                                     ManagedScheduledExecutorServiceConfig config, ContextServiceImpl contextService) {
+    public AbstractManagedExecutorService createManagedScheduledExecutorService(ResourceInfo resource,
+            ManagedScheduledExecutorServiceConfig config, ContextServiceImpl contextService) {
         ManagedThreadFactoryImpl managedThreadFactory = new ThreadFactoryWrapper(
                 config.getJndiName() + "-managedThreadFactory",
                 null,
                 config.getThreadPriority());
-        // TODO: eventually use VT base MSES
-        ManagedScheduledExecutorServiceImpl mes = new ManagedScheduledExecutorServiceImpl(config.getJndiName(),
-                managedThreadFactory,
-                config.getHungAfterSeconds() * 1000L, // in millseconds
-                config.isLongRunningTasks(),
-                config.getCorePoolSize(),
-                config.getKeepAliveSeconds(), TimeUnit.SECONDS,
-                config.getThreadLifeTimeSeconds(),
-                contextService,
-                AbstractManagedExecutorService.RejectPolicy.ABORT);
+        AbstractManagedExecutorService mes = null;
+        boolean useVirtualThread = config.getUseVirtualThread();
+        if (useVirtualThread) {
+            try {
+                mes = new VirtualThreadsManagedScheduledExecutorService(config.getJndiName(),
+                        null,
+                        config.getHungAfterSeconds() * 1_000L, // in milliseconds
+                        config.isLongRunningTasks(),
+                        Integer.MAX_VALUE,
+                        Integer.MAX_VALUE,
+                        contextService,
+                        AbstractManagedExecutorService.RejectPolicy.ABORT);
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Unable to start virtual threads managed executor service, JNDI '" + config.getJndiName() + "', fallback to " + (useVirtualThread ? "virtual threads" : "platform threads"), e);
+            }
+        }
+        if (mes == null) {
+            mes = new ManagedScheduledExecutorServiceImpl(config.getJndiName(),
+                    managedThreadFactory,
+                    config.getHungAfterSeconds() * 1000L, // in millseconds
+                    config.isLongRunningTasks(),
+                    config.getCorePoolSize(),
+                    config.getKeepAliveSeconds(), TimeUnit.SECONDS,
+                    config.getThreadLifeTimeSeconds(),
+                    contextService,
+                    AbstractManagedExecutorService.RejectPolicy.ABORT);
+        }
         return mes;
     }
 
     public void shutdownScheduledManagedExecutorService(String jndiName) {
-        ManagedScheduledExecutorServiceImpl mses = null;
+        AbstractManagedExecutorService mses = null;
         synchronized(this) {
             if (managedScheduledExecutorServiceMap != null) {
                 mses = managedScheduledExecutorServiceMap.remove(jndiName);
@@ -351,7 +362,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
         }
     }
 
-    public synchronized ManagedThreadFactoryImpl getManagedThreadFactory(ResourceInfo resource, ManagedThreadFactoryConfig config) {
+    public synchronized ManagedThreadFactory getManagedThreadFactory(ResourceInfo resource, ManagedThreadFactoryConfig config) {
         String jndiName = config.getJndiName();
         if (managedThreadFactoryMap != null && managedThreadFactoryMap.containsKey(jndiName)) {
             return managedThreadFactoryMap.get(jndiName);
@@ -370,9 +381,14 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
     }
 
     public ManagedThreadFactoryImpl createManagedThreadFactory(ResourceInfo resource, ManagedThreadFactoryConfig config, ContextServiceImpl contextService) {
-        ManagedThreadFactoryImpl managedThreadFactory = new ThreadFactoryWrapper(config.getJndiName(), contextService,
-                config.getThreadPriority());
-        return managedThreadFactory;
+        if (config.getUseVirtualThread()) {
+            ManagedThreadFactoryImpl virtFactory = new VirtualThreadsManagedThreadFactory(config.getJndiName(), contextService);
+            return virtFactory;
+        } else {
+            ManagedThreadFactoryImpl managedThreadFactory = new ThreadFactoryWrapper(config.getJndiName(), contextService,
+                    config.getThreadPriority());
+            return managedThreadFactory;
+        }
     }
 
     public void shutdownManagedThreadFactory(String jndiName) {
@@ -515,26 +531,15 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
 
         public void run() {
             ArrayList<AbstractManagedExecutorService> executorServices = new ArrayList();
-            ArrayList<ManagedScheduledExecutorServiceImpl> scheduledExecutorServices = new ArrayList();
             synchronized (ConcurrentRuntime.this) {
-                if (managedExecutorServiceMap != null) {
-                    Collection<AbstractManagedExecutorService> mesColl = managedExecutorServiceMap.values();
-                    executorServices.addAll(mesColl);
-                }
-            }
-            synchronized (ConcurrentRuntime.this) {
-                if (managedScheduledExecutorServiceMap != null) {
-                    Collection<ManagedScheduledExecutorServiceImpl> msesColl = managedScheduledExecutorServiceMap.values();
-                    scheduledExecutorServices.addAll(msesColl);
-                }
+                Collection<AbstractManagedExecutorService> mesColl = managedExecutorServiceMap.values();
+                executorServices.addAll(mesColl);
+                Collection<AbstractManagedExecutorService> msesColl = managedScheduledExecutorServiceMap.values();
+                executorServices.addAll(msesColl);
             }
             for (AbstractManagedExecutorService mes : executorServices) {
                 Collection<Thread> hungThreads = mes.getHungThreads();
                 logHungThreads(hungThreads, mes.getManagedThreadFactory(), mes.getName());
-            }
-            for (ManagedScheduledExecutorServiceImpl mses: scheduledExecutorServices) {
-                Collection<Thread> hungThreads = mses.getHungThreads();
-                logHungThreads(hungThreads, mses.getManagedThreadFactory(), mses.getName());
             }
         }
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2024] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2025] Payara Foundation and/or affiliates
 
 package org.glassfish.concurrent.runtime.deployer;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ConcurrentObjectFactory.java
@@ -42,12 +42,10 @@
 package org.glassfish.concurrent.runtime.deployer;
 
 import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
 import org.glassfish.concurro.AbstractManagedExecutorService;
 import org.glassfish.concurro.ContextServiceImpl;
-import org.glassfish.concurro.ManagedScheduledExecutorServiceAdapter;
-import org.glassfish.concurro.ManagedScheduledExecutorServiceImpl;
-import org.glassfish.concurro.ManagedThreadFactoryImpl;
 import org.glassfish.resourcebase.resources.api.ResourceInfo;
 
 import javax.naming.Context;
@@ -95,8 +93,8 @@ public class ConcurrentObjectFactory implements ObjectFactory {
         return contextService;
     }
 
-    private ManagedThreadFactoryImpl getManagedThreadFactory(ManagedThreadFactoryConfig config, ResourceInfo resourceInfo) {
-        ManagedThreadFactoryImpl managedThreadFactory = getRuntime().getManagedThreadFactory(resourceInfo, config);
+    private ManagedThreadFactory getManagedThreadFactory(ManagedThreadFactoryConfig config, ResourceInfo resourceInfo) {
+        ManagedThreadFactory managedThreadFactory = getRuntime().getManagedThreadFactory(resourceInfo, config);
         return managedThreadFactory;
     }
 
@@ -105,8 +103,8 @@ public class ConcurrentObjectFactory implements ObjectFactory {
         return mes.getAdapter();
     }
 
-    private ManagedScheduledExecutorServiceAdapter getManagedScheduledExecutorService(ManagedScheduledExecutorServiceConfig config, ResourceInfo resourceInfo) {
-        ManagedScheduledExecutorServiceImpl mes = getRuntime().getManagedScheduledExecutorService(resourceInfo, config);
+    private ManagedExecutorService getManagedScheduledExecutorService(ManagedScheduledExecutorServiceConfig config, ResourceInfo resourceInfo) {
+        AbstractManagedExecutorService mes = getRuntime().getManagedScheduledExecutorService(resourceInfo, config);
         return mes.getAdapter();
     }
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorDescriptorDeployer.java
@@ -313,7 +313,7 @@ public class ManagedExecutorDescriptorDeployer implements ResourceDeployer {
 
         @Override
         public String getDescription() {
-            return "Managed Executor Definition";
+            return managedExecutorDefinitionDescriptor.getDescription();
         }
 
         @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
@@ -62,8 +62,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Logger;
 import org.glassfish.concurrent.runtime.ConcurrentRuntime;
+import org.glassfish.concurro.AbstractManagedExecutorService;
 import org.glassfish.concurro.ContextServiceImpl;
-import org.glassfish.concurro.ManagedScheduledExecutorServiceImpl;
 
 @Service
 @ResourceDeployerInfo(ManagedScheduledExecutorDefinitionDescriptor.class)
@@ -94,7 +94,7 @@ public class ManagedScheduledExecutorDefinitionDeployer implements ResourceDeplo
                 mseDefinitionDescriptor.getName(), mseDefinitionDescriptor.getResourceType());
         ResourceInfo resourceInfo = new ResourceInfo(customNameOfResource, applicationName, moduleName);
 
-        ManagedScheduledExecutorServiceImpl managedScheduledExecutorService = concurrentRuntime.createManagedScheduledExecutorService(resourceInfo, mseConfig, contextService);
+        AbstractManagedExecutorService managedScheduledExecutorService = concurrentRuntime.createManagedScheduledExecutorService(resourceInfo, mseConfig, contextService);
         resourceNamingService.publishObject(resourceInfo, customNameOfResource, managedScheduledExecutorService, true);
     }
 
@@ -185,7 +185,7 @@ public class ManagedScheduledExecutorDefinitionDeployer implements ResourceDeplo
 
         @Override
         public String getDescription() {
-            return null;
+            return "Managed Scheduled Executor Definition";
         }
 
         @Override
@@ -241,6 +241,15 @@ public class ManagedScheduledExecutorDefinitionDeployer implements ResourceDeplo
         @Override
         public void setThreadPriority(String value) throws PropertyVetoException {
 
+        }
+
+        @Override
+        public String getUseVirtualThreads() {
+            return Boolean.toString(descriptor.getVirtual());
+        }
+
+        @Override
+        public void setUseVirtualThreads(String value) throws PropertyVetoException {
         }
 
         @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
@@ -185,7 +185,7 @@ public class ManagedScheduledExecutorDefinitionDeployer implements ResourceDeplo
 
         @Override
         public String getDescription() {
-            return "Managed Scheduled Executor Definition";
+            return descriptor.getDescription();
         }
 
         @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2025] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorDefinitionDeployer.java
@@ -245,7 +245,8 @@ public class ManagedScheduledExecutorDefinitionDeployer implements ResourceDeplo
 
         @Override
         public String getUseVirtualThreads() {
-            return Boolean.toString(descriptor.getVirtual());
+            Boolean virtualFromDefinition = descriptor.getVirtual();
+            return (virtualFromDefinition == null ? Boolean.FALSE : virtualFromDefinition).toString();
         }
 
         @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceConfig.java
@@ -49,6 +49,7 @@ public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
 
     private int hungAfterSeconds;
     private boolean longRunningTasks;
+    private boolean useVirtualThread;
     private int threadPriority;
     private int corePoolSize;
     private long keepAliveSeconds;
@@ -59,6 +60,7 @@ public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
         super(config.getJndiName(), config.getContextInfo(), config.getContextInfoEnabled());
         hungAfterSeconds = parseInt(config.getHungAfterSeconds(), 0);
         longRunningTasks = Boolean.valueOf(config.getLongRunningTasks());
+        useVirtualThread = Boolean.valueOf(config.getUseVirtualThreads());
         threadPriority = parseInt(config.getThreadPriority(), Thread.NORM_PRIORITY);
         corePoolSize = parseInt(config.getCorePoolSize(), 0);
         keepAliveSeconds = parseLong(config.getKeepAliveSeconds(), 60);
@@ -72,6 +74,10 @@ public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
 
     public boolean isLongRunningTasks() {
         return longRunningTasks;
+    }
+
+    public boolean getUseVirtualThread() {
+        return useVirtualThread;
     }
 
     public int getThreadPriority() {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceConfig.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022] Payara Foundation and/or affiliates
+// Portions Copyright [2022-2025] Payara Foundation and/or affiliates
 package org.glassfish.concurrent.runtime.deployer;
 
 import org.glassfish.concurrent.config.ManagedScheduledExecutorService;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryConfig.java
@@ -49,16 +49,22 @@ import org.glassfish.concurrent.config.ManagedThreadFactory;
 public class ManagedThreadFactoryConfig extends BaseConfig {
 
     private int threadPriority;
+    private boolean useVirtualThread;
     private String context;
 
     public ManagedThreadFactoryConfig(ManagedThreadFactory config) {
         super(config.getJndiName(), config.getContextInfo(), config.getContextInfoEnabled());
         threadPriority = parseInt(config.getThreadPriority(), Thread.NORM_PRIORITY);
+        useVirtualThread = Boolean.valueOf(config.getUseVirtualThreads());
         context = config.getContext();
     }
 
     public int getThreadPriority() {
         return threadPriority;
+    }
+
+    public boolean getUseVirtualThread() {
+        return useVirtualThread;
     }
 
     public String getContext() {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryConfig.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022] Payara Foundation and/or affiliates
+// Portions Copyright [2022-2025] Payara Foundation and/or affiliates
 
 package org.glassfish.concurrent.runtime.deployer;
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
@@ -184,7 +184,7 @@ public class ManagedThreadFactoryDescriptorDeployer implements ResourceDeployer 
 
         @Override
         public String getDescription() {
-            return null;
+            return descriptor.getDescription();
         }
 
         @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
@@ -317,6 +317,14 @@ public class ManagedThreadFactoryDescriptorDeployer implements ResourceDeployer 
             return null;
         }
 
+        @Override
+        public String getUseVirtualThreads() {
+            return Boolean.toString(descriptor.getVirtual());
+        }
+
+        @Override
+        public void setUseVirtualThreads(String value) throws PropertyVetoException {
+        }
 
     }
 }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
@@ -319,7 +319,8 @@ public class ManagedThreadFactoryDescriptorDeployer implements ResourceDeployer 
 
         @Override
         public String getUseVirtualThreads() {
-            return Boolean.toString(descriptor.getVirtual());
+            Boolean virtualFromDefinition = descriptor.getVirtual();
+            return (virtualFromDefinition == null ? Boolean.FALSE : virtualFromDefinition).toString();
         }
 
         @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedThreadFactoryDescriptorDeployer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2025] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedThreadFactoryDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedThreadFactoryDefinitionHandler.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2022-2025] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedThreadFactoryDefinitionHandler.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployment/annotation/handlers/ManagedThreadFactoryDefinitionHandler.java
@@ -95,6 +95,7 @@ public class ManagedThreadFactoryDefinitionHandler extends AbstractConcurrencyHa
         mtfdd.setMetadataSource(MetadataSource.ANNOTATION);
         mtfdd.setName(TranslatedConfigView.expandValue(managedThreadFactoryDefinition.name()));
         mtfdd.setContext(TranslatedConfigView.expandValue(managedThreadFactoryDefinition.context()));
+        mtfdd.setVirtual(managedThreadFactoryDefinition.virtual());
         if(managedThreadFactoryDefinition.priority() <= 0) {
             mtfdd.setPriority(Thread.NORM_PRIORITY);
         } else {

--- a/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-executor-service.1
+++ b/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-executor-service.1
@@ -101,12 +101,12 @@ OPTIONS
            store any number of submitted tasks.
 
        --usevirtualthreads
-           If enabled, virtual threads will be used instead of the default
-           thread pool. They provide a quick creation, minimal overhead and
-           fast thread switching, but executed on a limited "carrying threads".
-           Use virtual threads for tasks, which depend on external resources
-           like database, microservices etc. Do not use them for long
-           calculation. Available only on Java 21 and later.
+           If enabled, virtual threads will be used instead of the default platform
+           thread pool. They provide quick creation, minimal overhead, and
+           fast thread switching, but are executed on limited "carrying threads".
+           Use virtual threads for tasks which depend on external resources
+           like databases, micro-services, etc. Do not use them for long
+           calculation.
            The default value is false.
 
        --useforkjoinpool

--- a/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-executor-service.1
+++ b/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-executor-service.1
@@ -17,6 +17,7 @@ SYNOPSIS
            [--keepaliveseconds keepaliveseconds]
            [--threadlifetimeseconds threadlifetimeseconds]
            [--taskqueuecapacity taskqueuecapacity]
+           [--usevirtualthreads={false|true}]
            [--useforkjoinpool={false|true}]
            [--description description]
            [--property property]
@@ -98,6 +99,15 @@ OPTIONS
            task queue awaiting execution. The default value is 2147483647,
            which means that the task queue is essentially unbounded and can
            store any number of submitted tasks.
+
+       --usevirtualthreads
+           If enabled, virtual threads will be used instead of the default
+           thread pool. They provide a quick creation, minimal overhead and
+           fast thread switching, but executed on a limited "carrying threads".
+           Use virtual threads for tasks, which depend on external resources
+           like database, microservices etc. Do not use them for long
+           calculation. Available only on Java 21 and later.
+           The default value is false.
 
        --useforkjoinpool
            If enabled, a ForkJoinPool will be used instead of the default

--- a/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-scheduled-executor-service.1
+++ b/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-scheduled-executor-service.1
@@ -15,6 +15,7 @@ SYNOPSIS
            [--corepoolsize corepoolsize]
            [--keepaliveseconds keepaliveseconds]
            [--threadlifetimeseconds threadlifetimeseconds]
+           [--usevirtualthreads={false|true}]
            [--description description]
            [--property property]
            [--target target]
@@ -76,6 +77,15 @@ OPTIONS
            threads is greater than corepoolsize or whether the threads are
            idle. The default value is 0, which means that threads are never
            purged.
+
+       --usevirtualthreads
+           If enabled, virtual threads will be used instead of the default
+           thread pool. They provide a quick creation, minimal overhead and
+           fast thread switching, but executed on a limited "carrying threads".
+           Use virtual threads for tasks, which depend on external resources
+           like database, microservices etc. Do not use them for long
+           calculation. Available only on Java 21 and later.
+           The default value is false.
 
        --description
            Descriptive details about the resource.

--- a/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-scheduled-executor-service.1
+++ b/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-scheduled-executor-service.1
@@ -79,12 +79,12 @@ OPTIONS
            purged.
 
        --usevirtualthreads
-           If enabled, virtual threads will be used instead of the default
-           thread pool. They provide a quick creation, minimal overhead and
-           fast thread switching, but executed on a limited "carrying threads".
-           Use virtual threads for tasks, which depend on external resources
-           like database, microservices etc. Do not use them for long
-           calculation. Available only on Java 21 and later.
+           If enabled, virtual threads will be used instead of the default platform
+           thread pool. They provide quick creation, minimal overhead, and
+           fast thread switching, but are executed on limited "carrying threads".
+           Use virtual threads for tasks which depend on external resources
+           like databases, micro-services, etc. Do not use them for long
+           calculation.
            The default value is false.
 
        --description

--- a/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-thread-factory.1
+++ b/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-thread-factory.1
@@ -10,6 +10,7 @@ SYNOPSIS
            [--contextinfoenabled={false|true}]
            [--contextinfo={Classloader|JNDI|Security|WorkArea}]
            [--threadpriority threadpriority]
+           [--usevirtualthreads={false|true}]
            [--description description]
            [--property property]
            [--target target]
@@ -44,6 +45,15 @@ OPTIONS
        --threadpriority
            Specifies the priority to assign to created threads. The default
            value is 5.
+
+       --usevirtualthreads
+           If enabled, virtual threads will be used instead of the default
+           thread pool. They provide a quick creation, minimal overhead and
+           fast thread switching, but executed on a limited "carrying threads".
+           Use virtual threads for tasks, which depend on external resources
+           like database, microservices etc. Do not use them for long
+           calculation. Available only on Java 21 and later.
+           The default value is false.
 
        --description
            Descriptive details about the resource.

--- a/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-thread-factory.1
+++ b/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-thread-factory.1
@@ -47,12 +47,12 @@ OPTIONS
            value is 5.
 
        --usevirtualthreads
-           If enabled, virtual threads will be used instead of the default
-           thread pool. They provide a quick creation, minimal overhead and
-           fast thread switching, but executed on a limited "carrying threads".
-           Use virtual threads for tasks, which depend on external resources
-           like database, microservices etc. Do not use them for long
-           calculation. Available only on Java 21 and later.
+           If enabled, virtual threads will be used instead of the default platform
+           thread pool. They provide quick creation, minimal overhead, and
+           fast thread switching, but are executed on limited "carrying threads".
+           Use virtual threads for tasks which depend on external resources
+           like databases, micro-services, etc. Do not use them for long
+           calculation. 
            The default value is false.
 
        --description

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedThreadFactoryDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedThreadFactoryDefinitionDescriptor.java
@@ -50,6 +50,7 @@ public class ManagedThreadFactoryDefinitionDescriptor extends ConcurrencyQualifi
 
     private String name;
     private String context;
+    private Boolean virtual = null;
     private int priority = Thread.NORM_PRIORITY;
     private Properties properties = new Properties();
 
@@ -94,6 +95,14 @@ public class ManagedThreadFactoryDefinitionDescriptor extends ConcurrencyQualifi
 
     public void setProperties(Properties properties) {
         this.properties = properties;
+    }
+
+    public Boolean getVirtual() {
+        return virtual;
+    }
+
+    public void setVirtual(Boolean virtual) {
+        this.virtual = virtual;
     }
 
     @Override

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedThreadFactoryDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedThreadFactoryDefinitionDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2022-2024] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2017-2025 [Payara Foundation and/or its affiliates]
 
 package org.glassfish.resources.admin.cli;
 
@@ -252,6 +252,7 @@ public final class ResourceConstants {
     public static final String THREAD_PRIORITY = "thread-priority";
     public static final String LONG_RUNNING_TASKS = "long-runnings-tasks";
     public static final String USE_FORK_JOIN_POOL = "use-fork-join-pool";
+    public static final String USE_VIRTUAL_THREADS = "use-virtual-threads";
     public static final String HUNG_AFTER_SECONDS = "hung-after-seconds";
     public static final String CORE_POOL_SIZE = "core-pool-size";
     public static final String MAXIMUM_POOL_SIZE = "maximum-pool-size";


### PR DESCRIPTION
## Description
Add configuration of virtual threads for all types of Concurrency -- ManagedExecutorService, ManagedScheduledExecutorService, and ManagedThreadFactory

In all 3 cases, there are 3 ways, how to configure usage of virtual threads:

1. `*Definition with` `virtual = true`. E.g. `@ManagedExecutorDefinition(name = "java:app/VirtMES", maxAsync = 10, virtual = true)`
2. `asadmin` command with `--useVirtualThread=true`, e.g. `create-managed-thread-factory --useVirtualThreads=true --target=domain concurrent/VirtFactory`
3. Specify the same in AdminUI

## Testing
I wrote a sample application: https://github.com/aubi/samples/tree/main/jakartaee/concurrency/ConcurrencyVirtual

Compile it using Java 21. Compile this branch of Payara 7, run it and execute these commands in asadmin:
```
create-managed-thread-factory --useVirtualThreads=true --target=domain concurrent/VirtFactory
create-managed-executor-service --useVirtualThreads=true --target=domain concurrent/VirtMES
create-managed-scheduled-executor-service --useVirtualThreads=true --target=domain concurrent/VirtMSES

create-resource-ref --enabled=true --target=server concurrent/VirtFactory
create-resource-ref --enabled=true --target=server concurrent/VirtMES
create-resource-ref --enabled=true --target=server concurrent/VirtMSES
```

Then open the link (called All VT Resources Report - simpler in the main page):
localhost:8080/ConcurrencyVirtual-1.0-SNAPSHOT/rest/test/simpler

It creates 9 threads using different configurations. Application and Server-defined use virtual threads, the default ones use platform threads. Feel free to change the settings and observe the effect -- you need to reload the app to propagate the change. Default resources require server restart (they are cached).

The expected output is
```
ManagedExecutorService
======================
Application Defined ManagedExecutorService with virtual=true
------------------------------------------------------------
Thread '' => virtual

Default ManagedExecutorService (should use platform threads)
------------------------------------------------------------
Thread 'concurrent/__defaultManagedExecutorService-managedThreadFactory-Thread-7' => platform

Server-defined ManagedExecutorService from concurrent/VirtMES (should use virtual threads)
------------------------------------------------------------------------------------------
Thread '' => virtual



ManagedScheduledExecutorService
===============================
Application Defined ManagedScheduledExecutorService with virtual=true
---------------------------------------------------------------------
Thread '' => virtual

Default ManagedScheduledExecutorService (should use platform threads)
---------------------------------------------------------------------
Thread 'concurrent/__defaultManagedScheduledExecutorService-managedThreadFactory-Thread-1' => platform

Server-defined ManagedScheduledExecutorService from concurrent/VirtMSES (should use virtual threads)
----------------------------------------------------------------------------------------------------
Thread '' => virtual



ManagedThreadFactory
====================
Application Defined ManagedThreadFactory with virtual=true
----------------------------------------------------------
Thread '' => virtual

Default ManagedThreadFactory (should use platform threads)
----------------------------------------------------------
Thread 'concurrent/__defaultManagedThreadFactory-Thread-8' => platform

Server-defined ManagedThreadFactory from concurrent/VirtFactory (should use virtual threads)
--------------------------------------------------------------------------------------------
Thread '' => virtual
```


### Testing Performed
Creating MES, MSES, MTF via Admin UI or asadmin commands
Changing settings in Admin UI
Verifying the behaviour in the testing app.

### Testing Environment
Linux, Open JDK 21

## Documentation
https://github.com/payara/Payara-Documentation/pull/551

