### PR TITLE
FISH-10521 Escape HTTP Characters in REST Interface

### DIFF
--- a/appserver/admingui/common/src/main/resources/appServer/serverInstAdminPassword.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/serverInstAdminPassword.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- appServer/serverInstAdminPassword.jsf -->
 
@@ -80,7 +81,7 @@
     <!-- Text Field section -->
     <sun:propertySheetSection id="propertSectionTextField">
         <sun:property id="userIdProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.domain.Userid}">
-            <sun:staticText id="UserId" text="#{sessionScope.userName}"/>
+            <sun:staticText id="UserId" text="#{sessionScope.sanitisedUserName}"/>
         </sun:property>
         <sun:property id="groupListProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18nc.domain.GroupList}">
             <sun:staticText id="GroupList" text="#{pageSession.group}"/>

--- a/appserver/admingui/core/src/main/resources/templates/baseLayout.xhtml
+++ b/appserver/admingui/core/src/main/resources/templates/baseLayout.xhtml
@@ -40,7 +40,7 @@
 
 -->
 
-<!-- Portions Copyright [2016-2017] [Payara Foundation] -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 
 <ui:event type="initPage">
     setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
@@ -165,6 +165,8 @@
                                 </ui:event>
                                 <!-- Masthead Integration Point -->
                                 <ui:event type="afterCreate">
+                                    gf.sanitiseProperty(systemProperty="#{userName}", result="#{sanitisedVal}");
+                                    setSessionAttribute(key="sanitisedUserName", value="#{sanitisedVal}");
                                     includeFirstIntegrationPoint(type="org.glassfish.admingui:masthead" root="$this{component}");
                                     includeFirstIntegrationPoint(type="org.glassfish.admingui:favicon" root="#{view}");
                                 </ui:event>

--- a/appserver/admingui/payara-enterprise-theme/src/main/resources/branding/masthead.inc
+++ b/appserver/admingui/payara-enterprise-theme/src/main/resources/branding/masthead.inc
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-   Portions Copyright [2020] [Payara Foundation and/or its affiliates]
+   Portions Copyright 2020-2025 Payara Foundation and/or its affiliates
 -->
 
 <sun:masthead id="Masthead" productImageURL="#{request.contextPath}/resource/payara-enterprise-theme/images/masthead-product_name_open-new.png"
@@ -46,7 +46,7 @@
               productImageDescription="$resource{theme.productName}"
               productImageWidth="191"
               productImageHeight="91"
-              userInfo="#{userName}"  userInfoLabel="$resource{i18n.masthead.userInfoLabel}"
+              userInfo="#{sanitisedUserName}"  userInfoLabel="$resource{i18n.masthead.userInfoLabel}"
               roleInfo="#{domainName}" roleInfoLabel="$resource{i18n.masthead.domainInfoLabel}"
               serverInfo="#{hostName}" serverInfoLabel="$resource{i18n.masthead.serverInfoLabel}"
               dateTime="$boolean{false}" notificationMsg="$attribute{null}">

--- a/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
+++ b/appserver/admingui/payara-theme/src/main/resources/branding/masthead.inc
@@ -38,13 +38,13 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-   Portions Copyright [2016-2022] [Payara Foundation and/or its affiliates] 
+   Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 -->
 
 <sun:masthead id="Masthead" productImageURL="#{request.contextPath}/resource/community-theme/images/masthead-product_name_open-new.png" 
               style="border-width: 0px"
               productImageDescription="$resource{theme.productName}"
-              userInfo="#{userName}"  userInfoLabel="$resource{i18n.masthead.userInfoLabel}"
+              userInfo="#{sanitisedUserName}"  userInfoLabel="$resource{i18n.masthead.userInfoLabel}"
               roleInfo="#{domainName}" roleInfoLabel="$resource{i18n.masthead.domainInfoLabel}"
               serverInfo="#{hostName}" serverInfoLabel="$resource{i18n.masthead.serverInfoLabel}"
               dateTime="$boolean{false}" notificationMsg="$attribute{null}">

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/provider/ActionReportResultHtmlProvider.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/provider/ActionReportResultHtmlProvider.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 
 package org.glassfish.admin.rest.provider;
 
@@ -330,7 +330,7 @@ public class ActionReportResultHtmlProvider extends BaseProvider<ActionReportRes
             result.append("<li><table border=\"1\" style=\"border-collapse: collapse\">")
                     .append("<tr><td>Message</td>")
                     .append("<td>")
-                    .append(part.getMessage())
+                    .append(ResourceUtil.encodeString(part.getMessage()))
                     .append("</td></tr><td>Properties</td><td>")
                     .append(getHtml(part.getProps()))
                     .append("</td></tr>");
@@ -369,7 +369,7 @@ public class ActionReportResultHtmlProvider extends BaseProvider<ActionReportRes
                 result = getHtml((Map) object);
             }
         } else {
-            result = object.toString();
+            result = ResourceUtil.encodeString(object.toString());
         }
 
         return result;


### PR DESCRIPTION
## Description
Escapes HTTP characters in the REST interface, to help lock down any XSS attempts someone may try if they have access to the application server's filesystem.

Most config which would be displayed here is protected by validation of the domain.xml, as that prevents you from having the "<" or ">" characters as values. The key files however don't have this validation, and so we must escape them.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
On a clean domain:
* Add the following to the `admin-keyfile` file under domain config: `user3<img src=x onerror=alert('XSS')>;{SSHA256}qXV9vLHbkJRoMaJkGsNUrz5jSHDzMTR0CyFmZjUt8HJQVlIi2X8XaA==;asadmin`
* Add the following to the `keyfile` file under domain config: `wibbles<img src=x onerror=alert('XSS')>;{SSHA256}6v8s3F0zGwF9bi9s1tygCvTz+az/Im55nS6Z3Z1sCIS9ng9aLAykCQ==;`
* Ping the REST interface http://localhost:4848/management/domain/configs/config/server-config/security-service/auth-realm/file/list-users - no message box should appear
* Ping the REST interface http://localhost:4848/management/domain/configs/config/server-config/security-service/auth-realm/admin-realm/list-users
* Create a standalone instance called _Elated-Whalefish_
* From the admin console, edit the value of its `ASADMIN_LISTENER_PORT` property to `24848<img src=x onerror=alert(1)>` - Instances > Elated-Whalefish > Properties
  * This was previously fixed in https://github.com/payara/Payara/pull/6943
* Load this page in the REST interface, no message box should appear - http://localhost:4848/management/domain/servers/server/Elated-Whalefish/system-property/ASADMIN_LISTENER_PORT


### Testing Environment
Windows 11, Maven 3.9.9, Zulu JDK 11.0.26

## Documentation
https://github.com/payara/Payara-Documentation/pull/552

## Notes for Reviewers
None
