### PR TITLE
FISH-10073 Reduce EE11 Shim

### DIFF
--- a/appserver/packager/external/jakarta-ee11-shim/pom.xml
+++ b/appserver/packager/external/jakarta-ee11-shim/pom.xml
@@ -78,20 +78,6 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <!-- Downgrade shim for Jakarta Security API 3.0, required by security-connector-oidc-client. Remove once Security Connectors upgraded -->
-        <dependency>
-            <groupId>jakarta.security.enterprise</groupId>
-            <artifactId>jakarta.security.enterprise-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- Downgrade shim for Soteria 3.0, required by security-connector-oauth2-client. Remove once Security Connectors upgraded -->
-        <dependency>
-            <groupId>org.glassfish.soteria</groupId>
-            <artifactId>soteria</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -117,11 +103,7 @@
                                     <!-- Downgrade shim for Jakarta EL, required by Jersey-HK2/Hibernate Validator(?). Remove once Jersey-HK2/Hibernate Validator(?) upgraded -->
                                     jakarta.el-api,
                                     <!-- Downgrade shim for JAX-RS, required by MicroProfile Rest Client. Remove once MicroProfile Rest Client upgraded -->
-                                    jakarta.ws.rs-api,
-                                    <!-- Downgrade shim for Jakarta Security API 3.0, required by security-connector-oidc-client. Remove once Security Connectors upgraded -->
-                                    jakarta.security.enterprise-api,
-                                    <!-- Downgrade shim for Soteria 3.0, required by security-connector-oauth2-client. Remove once Security Connectors upgraded -->
-                                    org.glassfish.soteria
+                                    jakarta.ws.rs-api
                                 </Require-Bundle>
                                 <!-- Manually specify the shim versions of packages to be exported via this bundle -->
                                 <!-- Note the "shortened" syntax here: For every API the packages are delimited with
@@ -141,31 +123,7 @@
                                     jakarta.ws.rs.container;
                                     jakarta.ws.rs.core;
                                     jakarta.ws.rs.ext;
-                                    jakarta.ws.rs.sse;version="3.1.99";shim=true,
-                                    <!-- Downgrade shim for Jakarta Security API 3.0, required by security-connector-oidc-client. Remove once Security Connectors upgraded -->
-                                    jakarta.security.enterprise;
-                                    jakarta.security.enterprise.authentication.mechanism.http;
-                                    jakarta.security.enterprise.authentication.mechanism.http.openid;
-                                    jakarta.security.enterprise.credential;
-                                    jakarta.security.enterprise.identitystore;
-                                    jakarta.security.enterprise.identitystore.openid;version="3.0.99";shim=true,
-                                    <!-- Downgrade shim for Soteria 3.0, required by security-connector-oauth2-client. Remove once Security Connectors upgraded -->
-                                    org.glassfish.soteria;
-                                    org.glassfish.soteria.authorization;
-                                    org.glassfish.soteria.authorization.spi;
-                                    org.glassfish.soteria.authorization.spi.impl;
-                                    org.glassfish.soteria.cdi;
-                                    org.glassfish.soteria.cdi.spi;
-                                    org.glassfish.soteria.cdi.spi.impl;
-                                    org.glassfish.soteria.identitystores;
-                                    org.glassfish.soteria.identitystores.annotation;
-                                    org.glassfish.soteria.identitystores.hash;
-                                    org.glassfish.soteria.mechanisms;
-                                    org.glassfish.soteria.mechanisms.jaspic;
-                                    org.glassfish.soteria.mechanisms.openid;
-                                    org.glassfish.soteria.mechanisms.openid.controller;
-                                    org.glassfish.soteria.mechanisms.openid.domain;
-                                    org.glassfish.soteria.servlet;version="3.0.99";shim=true
+                                    jakarta.ws.rs.sse;version="3.1.99";shim=true
                                 </Export-Package>
                             </instructions>
                         </configuration>


### PR DESCRIPTION
## Description
Now that security connectors have been updated, we can remove the downgrade shim for Soteria and the Security API.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started the DAS and loaded the admin console - no explosions.
Ran through the Jakarta TCKs - no OSGi issues to do with resolving the security connectors spotted.

### Testing Environment
Windows 11, Maven 3.9.9, Zulu 21.0.6

## Documentation
N/A

## Notes for Reviewers
None
