### PR TITLE
Fish 8858 docker images do not log to file

### DIFF
--- a/appserver/extras/docker-images/server-full/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-full/src/main/docker/bin/entrypoint.sh
@@ -41,10 +41,8 @@
 
 if [ "${ENABLE_FILE_LOGS:-false}" == "true" ]; then
       echo "[Entrypoint] Enabling Logs into server.log"
-      ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME}
-      ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
-            set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=true
-      ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME}
+      sed -i 's/^com.sun.enterprise.server.logging.GFFileHandler.logtoFile=.*/com.sun.enterprise.server.logging.GFFileHandler.logtoFile=true/' \
+          ${PAYARA_DIR}/glassfish/domains/domain1/config/logging.properties
 fi
 
 for f in ${SCRIPT_DIR}/init_* ${SCRIPT_DIR}/init.d/*; do

--- a/appserver/extras/docker-images/server-full/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-full/src/main/docker/bin/entrypoint.sh
@@ -39,6 +39,14 @@
 #    holder.
 ################################################################################
 
+if [ "${ENABLE_FILE_LOGS:-false}" == "true" ]; then
+      echo "[Entrypoint] Enabling Logs into server.log"
+      ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} start-domain ${DOMAIN_NAME}
+      ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} \
+            set-log-attributes com.sun.enterprise.server.logging.GFFileHandler.logtoFile=true
+      ${PAYARA_DIR}/bin/asadmin --user=${ADMIN_USER} --passwordfile=${PASSWORD_FILE} stop-domain ${DOMAIN_NAME}
+fi
+
 for f in ${SCRIPT_DIR}/init_* ${SCRIPT_DIR}/init.d/*; do
       case "$f" in
         *.sh)  echo "[Entrypoint] running $f"; . "$f" ;;

--- a/appserver/extras/docker-images/server-web/src/main/docker/bin/entrypoint.sh
+++ b/appserver/extras/docker-images/server-web/src/main/docker/bin/entrypoint.sh
@@ -2,7 +2,7 @@
 ################################################################################
 #    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-#    Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+#    Copyright (c) 2023-2025 Payara Foundation and/or its affiliates. All rights reserved.
 #
 #    The contents of this file are subject to the terms of either the GNU
 #    General Public License Version 2 only ("GPL") or the Common Development
@@ -38,6 +38,12 @@
 #    only if the new code is made subject to such option by the copyright
 #    holder.
 ################################################################################
+
+if [ "${ENABLE_FILE_LOGS:-false}" == "true" ]; then
+      echo "[Entrypoint] Enabling Logs into server.log"
+      sed -i 's/^com.sun.enterprise.server.logging.GFFileHandler.logtoFile=.*/com.sun.enterprise.server.logging.GFFileHandler.logtoFile=true/' \
+          ${PAYARA_DIR}/glassfish/domains/domain1/config/logging.properties
+fi
 
 for f in ${SCRIPT_DIR}/init_* ${SCRIPT_DIR}/init.d/*; do
       case "$f" in


### PR DESCRIPTION
## Description
Payara Docker Images do not log to file server.log

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. Use in WSL
2. mvn clean install -DskipTests at root directory
3. cd appserver/extras/docker-images/server-full
4. mvn clean package
5. cd target/docker
6. docker build -t payara/server-full:local -f ./payara/server-full/build/Dockerfile.jdk11 ./payara/server-full/tmp/docker-build/
7. docker run -it -e ENABLE_FILE_LOGS=true -p 8080:8080 -p 4848:4848 --name payara_docker payara/server-full:local
8. Verify that server.log file now is filled with logs and the system property com.sun.enterprise.server.logging.GFFileHandler.logtoFile is enabled


### Testing Environment
Zulu JDK 11 on Ubuntu 22.04 with Maven 3.9.0

## Documentation
PR will be created

## Notes for Reviewers
None
