### PR TITLE
FISH-9749 Add option to skip jdbc client info validation

### DIFF
--- a/appserver/admingui/jdbc/src/main/resources/advancePool.inc
+++ b/appserver/admingui/jdbc/src/main/resources/advancePool.inc
@@ -148,6 +148,10 @@ Portions Copyright [2016] [Payara Foundation]
         <sun:textField id="p5" styleClass="integer" columns="$int{30}" maxLength="#{sessionScope.fieldLengths['maxLength.jdbcPool.maxConnectionUsageCount']}" text="#{pageSession.valueMap['maxConnectionUsageCount']}"/> 
    </sun:property>
 
+   <sun:property id="p11"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18njdbc.jdbcPool.skipClientInfoValidation}" helpText="$resource{i18njdbc.jdbcPool.skipClientInfoValidationHelp}">
+        <sun:checkbox selected="#{pageSession.valueMap['skipClientInfoValidation']}" label=" " selectedValue="true" />
+    </sun:property>
+
 </sun:propertySheetSection>
 <!-- -------------------- Connection Validation ------------ -->
 

--- a/appserver/admingui/jdbc/src/main/resources/advancePool.inc
+++ b/appserver/admingui/jdbc/src/main/resources/advancePool.inc
@@ -37,7 +37,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-Portions Copyright [2016] [Payara Foundation]
+Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 -->
 
 <!-- jdbc/advancePool.inc -->

--- a/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvance.jsf
+++ b/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvance.jsf
@@ -37,7 +37,7 @@
     and therefore, elected the GPL Version 2 license, then the option applies
     only if the new code is made subject to such option by the copyright
     holder.
-Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 -->
 
 <!-- jdbc/jdbcConnectionPoolAdvance.jsf -->

--- a/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvance.jsf
+++ b/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvance.jsf
@@ -102,7 +102,8 @@ Portions Copyright [2016] [Payara Foundation and/or its affiliates]
         setPageSessionAttribute(key="convertToFalseList" value={"wrapJdbcObjects" "pooling" "connectionLeakReclaim"
                                                                 "lazyConnectionAssociation" "lazyConnectionEnlistment"
                                                                 "associateWithThread" "matchConnections" "allowNonComponentCallers"
-                                                                "isConnectionValidationRequired" "failAllConnections" "logJdbcCalls"});
+                                                                "isConnectionValidationRequired" "failAllConnections" "logJdbcCalls"
+                                                                "skipClientInfoValidation"});
         setPageSessionAttribute(key="skipAttrsList", value={"jndiName"});
         gf.createAttributeMap(keys={"poolName"} values={"$pageSession{encodedName}"} map="#{pageSession.attrMap}");
         if(#{pageSession.isAppScopedRes}){

--- a/appserver/admingui/jdbc/src/main/resources/org/glassfish/jdbc/admingui/Strings.properties
+++ b/appserver/admingui/jdbc/src/main/resources/org/glassfish/jdbc/admingui/Strings.properties
@@ -36,7 +36,7 @@
 # and therefore, elected the GPL Version 2 license, then the option applies
 # only if the new code is made subject to such option by the copyright
 # holder.
-# Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+# Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 button.Flush=Flush
 tree.jdbcResources=JDBC Resources

--- a/appserver/admingui/jdbc/src/main/resources/org/glassfish/jdbc/admingui/Strings.properties
+++ b/appserver/admingui/jdbc/src/main/resources/org/glassfish/jdbc/admingui/Strings.properties
@@ -181,6 +181,8 @@ jdbcPool.matchConnections=Match Connections:
 jdbcPool.matchConnectionsHelp=Turns connection matching for the pool on or off
 jdbcPool.maxConnectionUsageCount=Max Connection Usage :
 jdbcPool.maxConnectionUsageCountHelp=Connections will be reused by the pool for the specified number of times, after which they will be closed. 0 implies the feature is not enabled.
+jdbcPool.skipClientInfoValidation=Skip Client Info Validation:
+jdbcPool.skipClientInfoValidationHelp=Skip the validation of the client info properties.
 jdbcConnectionPool.propertyPageTitle=Edit JDBC Connection Pool Properties
 jdbcConnectionPool.propertyPageTitleHelp=Modify properties of an existing JDBC connection pool.
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/CreateJdbcConnectionPool.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/CreateJdbcConnectionPool.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright (c) 2020-2021 Payara Foundation and/or affiliates
+// Portions Copyright (c) 2020-2025 Payara Foundation and/or affiliates
 
 package org.glassfish.jdbc.admin.cli;
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/CreateJdbcConnectionPool.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/CreateJdbcConnectionPool.java
@@ -193,6 +193,9 @@ public class CreateJdbcConnectionPool implements AdminCommand {
     @Param(name="jdbc_connection_pool_id", alias = "name" /*Mapped to ResourceConstants.CONNECTION_POOL_NAME below */,  primary=true)
     String jdbc_connection_pool_id;
 
+    @Param(name = "skipClientInfoValidation", optional = true, defaultValue = "false")
+    Boolean skipClientInfoValidation;
+
     @Inject
     Domain domain;
 
@@ -249,6 +252,7 @@ public class CreateJdbcConnectionPool implements AdminCommand {
         attrList.put(ResourceConstants.VALIDATION_CLASSNAME, validationclassname);
         attrList.put(ResourceConstants.WRAP_JDBC_OBJECTS, wrapjdbcobjects.toString());
         attrList.put(ResourceConstants.LOG_JDBC_CALLS, logJdbcCalls.toString());
+        attrList.put(ResourceConstants.SKIP_CLIENT_INFO_VALIDATION, skipClientInfoValidation.toString());
         
         ResourceStatus rs;
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2020-2021] Payara Foundation and/or affiliates
+// Portions Copyright [2020-2025] Payara Foundation and/or affiliates
 
 package org.glassfish.jdbc.admin.cli;
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCConnectionPoolManager.java
@@ -115,6 +115,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
 
     private String description = null;
     private String jdbcconnectionpoolid = null;
+    private String skipClientInfoValidation = Boolean.FALSE.toString();
 
     public JDBCConnectionPoolManager() {
     }
@@ -250,6 +251,9 @@ public class JDBCConnectionPoolManager implements ResourceManager {
         if(statementcachesize != null){
             newResource.setStatementCacheSize(statementcachesize);
         }
+        if (skipClientInfoValidation != null) {
+            newResource.setSkipClientInfoValidation(skipClientInfoValidation);
+        }
         if (validationclassname != null) {
             newResource.setValidationClassname(validationclassname);
         }
@@ -325,7 +329,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
         validationclassname = (String) attrList.get(VALIDATION_CLASSNAME);
         initsql = (String) attrList.get(INIT_SQL);
         logJDBCCalls = (String) attrList.get(LOG_JDBC_CALLS);
-        
+
         // Can't be set to null as the default value is now the SilentSqlTraceListener class
         sqltracelisteners = (String) attrList.get(SQL_TRACE_LISTENERS);
         if (sqltracelisteners == null) {
@@ -335,6 +339,7 @@ public class JDBCConnectionPoolManager implements ResourceManager {
         pooling = (String) attrList.get(POOLING);
         ping = (String) attrList.get(PING);
         driverclassname = (String) attrList.get(DRIVER_CLASSNAME);
+        skipClientInfoValidation = (String) attrList.get(SKIP_CLIENT_INFO_VALIDATION);
     }
 
     public ResourceStatus delete(Iterable<Server> servers, Iterable<Cluster> clusters, final Resources resources, final String cascade,

--- a/appserver/jdbc/admin/src/main/manpages/org/glassfish/jdbc/admin/cli/create-jdbc-connection-pool.1
+++ b/appserver/jdbc/admin/src/main/manpages/org/glassfish/jdbc/admin/cli/create-jdbc-connection-pool.1
@@ -44,6 +44,7 @@ SYNOPSIS
            [--wrapjdbcobjects={false|true}]
            [--description description]
            [--property name=value)[:name=value]*]
+           [--skipclientinfovalidation={false|true}]
            [--target=target]
            connectionpoolid
 
@@ -515,6 +516,17 @@ OPTIONS
                |characters in command options, see the  |
                |asadmin(1M) man page.                   |
                +----------------------------------------+
+
+       --skipclientinfovalidation
+           Determines whether to skip the validation of client info properties.
+
+           Possible values of --skipclientinfovalidation are as follows:
+
+           false
+               The client info properties will be validated. (default).
+
+           true
+               The validation of client info properties will be skipped.
 
        --target
            Do not specify this option. This option is retained for

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.jdbc.config;
 

--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -745,6 +745,10 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      */
     void setStatementCacheSize(String value) throws PropertyVetoException;
 
+    @Attribute (defaultValue = "false", dataType = Boolean.class)
+    String getSkipClientInfoValidation();
+    void setSkipClientInfoValidation(String value) throws PropertyVetoException;
+
     /**
      * Gets the value of the statementCacheType property.
      *

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/common/DataSourceSpec.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/common/DataSourceSpec.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2016-2022 Payara Foundation and/or its affiliates
+// Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 
 package com.sun.gjc.common;
 

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/common/DataSourceSpec.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/common/DataSourceSpec.java
@@ -112,10 +112,11 @@ public class DataSourceSpec implements java.io.Serializable {
     public static final int SLOWSQLLOGTHRESHOLD = 48;
     public static final int LOGJDBCCALLS = 49;
     public static final int MAXCACHESIZE = 50;
+    public static final int SKIPCLIENTINFOVALIDATION = 51;
 
     private static final long serialVersionUID = 1L;
 
-    private final ConcurrentHashMap<Integer, String> details = new ConcurrentIgnoredHashMap(URL,LOGJDBCCALLS,SLOWSQLLOGTHRESHOLD, STATEMENTCACHESIZE, NUMBEROFTOPQUERIESTOREPORT,TIMETOKEEPQUERIESINMINUTES, STATEMENTTIMEOUT, PASSWORD, MAXCACHESIZE);
+    private final ConcurrentHashMap<Integer, String> details = new ConcurrentIgnoredHashMap(URL,LOGJDBCCALLS,SLOWSQLLOGTHRESHOLD, STATEMENTCACHESIZE, NUMBEROFTOPQUERIESTOREPORT,TIMETOKEEPQUERIESINMINUTES, STATEMENTTIMEOUT, PASSWORD, MAXCACHESIZE, SKIPCLIENTINFOVALIDATION);
 
     /**
      * Set the property.

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
@@ -1216,6 +1216,14 @@ public abstract class ManagedConnectionFactoryImpl implements jakarta.resource.s
     public String getLogJdbcCalls() {
          return spec.getDetail(DataSourceSpec.LOGJDBCCALLS);       
     }
+
+    public void setSkipClientInfoValidation(String enabled) {
+        spec.setDetail(DataSourceSpec.SKIPCLIENTINFOVALIDATION, enabled);
+    }
+
+    public String getSkipClientInfoValidation() {
+        return spec.getDetail(DataSourceSpec.SKIPCLIENTINFOVALIDATION);
+    }
     
     /**
      * Sets the description.

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionFactoryImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2017-2022 Payara Foundation and/or its affiliates
+// Portions Copyright 2017-2025 Payara Foundation and/or its affiliates
 
 package com.sun.gjc.spi;
 

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2016-2022 Payara Foundation and/or its affiliates.
+// Portions Copyright 2016-2025 Payara Foundation and/or its affiliates.
 
 package com.sun.gjc.spi;
 

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -135,6 +135,7 @@ public class ManagedConnectionImpl implements jakarta.resource.spi.ManagedConnec
     private boolean lastAutoCommitValue = defaultAutoCommitValue;
 
     private boolean markedForRemoval = false;
+    private boolean skipClientInfoValidation;
 
     //private boolean statemntWrapping;
     private int statementTimeout;
@@ -226,6 +227,7 @@ public class ManagedConnectionImpl implements jakarta.resource.spi.ManagedConnec
         tuneStatementLeakTracing(poolInfo, statementLeakTimeout, statementLeakReclaim);
         
         connectionPool = getJdbcConnectionPool(mcf);
+        skipClientInfoValidation = connectionPool != null && Boolean.parseBoolean(connectionPool.getSkipClientInfoValidation());
         try {
             RunLevelController runLevelController = Globals.getDefaultHabitat().getService(RunLevelController.class);
             if (runLevelController != null && runLevelController.getCurrentRunLevel() == StartupRunLevel.VAL) {
@@ -1379,5 +1381,10 @@ public class ManagedConnectionImpl implements jakarta.resource.spi.ManagedConnec
             return -1;
         }
         return Math.round(parseDouble(thresholdInSeconds) * 1000);
+    }
+
+
+    public boolean isSkipClientInfoValidation() {
+        return skipClientInfoValidation;
     }
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/base/ConnectionHolder.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/base/ConnectionHolder.java
@@ -84,6 +84,7 @@ public abstract class ConnectionHolder implements Connection {
 
     protected int statementTimeout;
     protected boolean statementTimeoutEnabled;
+    protected boolean skipClientInfoValidation;
 
 
     private MethodExecutor executor = null;
@@ -121,6 +122,7 @@ public abstract class ConnectionHolder implements Connection {
         mcf_ = mc.getMcf();
         cxReqInfo_ = cxRequestInfo;
         statementTimeout = mc.getStatementTimeout();
+        skipClientInfoValidation = mc.isSkipClientInfoValidation();
         executor = new MethodExecutor();
         if (statementTimeout > 0) {
             statementTimeoutEnabled = true;

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/base/ConnectionHolder.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/base/ConnectionHolder.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2025] Payara Foundation and/or affiliates
 
 package com.sun.gjc.spi.base;
 

--- a/appserver/jdbc/jdbc-ra/jdbc40/src/main/java/com/sun/gjc/spi/jdbc40/ConnectionHolder40.java
+++ b/appserver/jdbc/jdbc-ra/jdbc40/src/main/java/com/sun/gjc/spi/jdbc40/ConnectionHolder40.java
@@ -102,7 +102,7 @@ public class ConnectionHolder40 extends ConnectionHolder {
      */
     protected void init() {
         try {
-            if (!skipClientInfoValidation && isSupportClientInfo()) {
+            if (isSupportClientInfo()) {
                 defaultClientInfo = getClientInfo();
             }
         } catch (Exception e) {
@@ -400,6 +400,9 @@ public class ConnectionHolder40 extends ConnectionHolder {
      * @since 1.6
      */
     private boolean isSupportClientInfo() {
+        if (skipClientInfoValidation) {
+            return false;
+        }
         Boolean isSupportClientInfo = getManagedConnection().isClientInfoSupported();
         if (isSupportClientInfo != null) {
             return isSupportClientInfo;

--- a/appserver/jdbc/jdbc-ra/jdbc40/src/main/java/com/sun/gjc/spi/jdbc40/ConnectionHolder40.java
+++ b/appserver/jdbc/jdbc-ra/jdbc40/src/main/java/com/sun/gjc/spi/jdbc40/ConnectionHolder40.java
@@ -102,7 +102,7 @@ public class ConnectionHolder40 extends ConnectionHolder {
      */
     protected void init() {
         try {
-            if (isSupportClientInfo()) {
+            if (!skipClientInfoValidation && isSupportClientInfo()) {
                 defaultClientInfo = getClientInfo();
             }
         } catch (Exception e) {

--- a/appserver/jdbc/jdbc-ra/jdbc40/src/main/java/com/sun/gjc/spi/jdbc40/ConnectionHolder40.java
+++ b/appserver/jdbc/jdbc-ra/jdbc40/src/main/java/com/sun/gjc/spi/jdbc40/ConnectionHolder40.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright 2016-2022 Payara Foundation and/or affiliates
+ * Portions Copyright 2016-2025 Payara Foundation and/or affiliates
  */
 
 package com.sun.gjc.spi.jdbc40;

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.jdbc.deployer;
 

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbc/deployer/DataSourceDefinitionDeployer.java
@@ -911,6 +911,16 @@ public class DataSourceDefinitionDeployer implements ResourceDeployer {
         }
 
         @Override
+        public String getSkipClientInfoValidation() {
+            return getPropertyValue("fish.payara.skip-client-info-validation", "false");
+        }
+
+        @Override
+        public void setSkipClientInfoValidation(String value) throws PropertyVetoException {
+
+        }
+
+        @Override
         public String getMatchConnections() {
             return getPropertyValue("fish.payara.match-connections", "true");
         }

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/service/JdbcServiceConfigListener.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/service/JdbcServiceConfigListener.java
@@ -59,9 +59,6 @@ import java.util.List;
 public class JdbcServiceConfigListener implements ConfigListener {
 
     @Inject
-    private JdbcConnectionPool jdbcConnectionPool;
-
-    @Inject
     private Transactions transactions;
 
     @PostConstruct

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/service/JdbcServiceConfigListener.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/service/JdbcServiceConfigListener.java
@@ -1,0 +1,48 @@
+package org.glassfish.jdbcruntime.service;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import org.glassfish.api.StartupRunLevel;
+import org.glassfish.hk2.runlevel.RunLevel;
+import org.glassfish.jdbc.config.JdbcConnectionPool;
+import org.jvnet.hk2.annotations.Service;
+import org.jvnet.hk2.config.ConfigListener;
+import org.jvnet.hk2.config.Transactions;
+import org.jvnet.hk2.config.UnprocessedChangeEvent;
+import org.jvnet.hk2.config.UnprocessedChangeEvents;
+
+import java.beans.PropertyChangeEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RunLevel(StartupRunLevel.VAL)
+public class JdbcServiceConfigListener implements ConfigListener {
+
+    @Inject
+    private JdbcConnectionPool jdbcConnectionPool;
+
+    @Inject
+    private Transactions transactions;
+
+    @PostConstruct
+    public void postConstruct() {
+        transactions.addListenerForType(JdbcConnectionPool.class, this);
+    }
+
+    @Override
+    public UnprocessedChangeEvents changed(PropertyChangeEvent[] events) {
+        List<UnprocessedChangeEvent> unprocessedChanges = new ArrayList<>();
+        for (PropertyChangeEvent pce : events) {
+            if (pce.getPropertyName().equalsIgnoreCase("skip-client-info-validation")
+                    && Boolean.parseBoolean(pce.getOldValue().toString()) != Boolean.parseBoolean(pce.getNewValue().toString())) {
+                unprocessedChanges.add(new UnprocessedChangeEvent(pce, "JDBC Skip Client Info Validation Changed"));
+            }
+        }
+
+        if (unprocessedChanges.isEmpty()) {
+            return null;
+        }
+        return new UnprocessedChangeEvents(unprocessedChanges);
+    }
+}

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/service/JdbcServiceConfigListener.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/service/JdbcServiceConfigListener.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package org.glassfish.jdbcruntime.service;
 
 import jakarta.annotation.PostConstruct;

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
@@ -259,6 +259,7 @@ public final class ResourceConstants {
     public static final String THREAD_LIFETIME_SECONDS = "thread-lifetime-seconds";
     public static final String TASK_QUEUE_CAPACITY = "task-queue-capacity";
     public static final String MAX_ASYNC = "max-async";
+    public static final String SKIP_CLIENT_INFO_VALIDATION = "skip-client-info-validation";
 
     public static final String SYSTEM_ALL_REQ = "system-all-req";
     

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2025] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.resources.admin.cli;
 

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
@@ -142,6 +142,8 @@ public final class ResourceConstants {
 
     public static final String STATEMENT_LEAK_RECLAIM = "statement-leak-reclaim";
 
+    public static final String SKIP_CLIENT_INFO_VALIDATION = "skip-client-info-validation";
+
     //Mail resource
     public static final String MAIL_HOST = "host";
 
@@ -259,7 +261,6 @@ public final class ResourceConstants {
     public static final String THREAD_LIFETIME_SECONDS = "thread-lifetime-seconds";
     public static final String TASK_QUEUE_CAPACITY = "task-queue-capacity";
     public static final String MAX_ASYNC = "max-async";
-    public static final String SKIP_CLIENT_INFO_VALIDATION = "skip-client-info-validation";
 
     public static final String SYSTEM_ALL_REQ = "system-all-req";
     

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2017-2024 [Payara Foundation and/or its affiliates]
+// Portions Copyright 2017-2025 [Payara Foundation and/or its affiliates]
 
 package org.glassfish.resources.admin.cli;
 

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
@@ -1046,6 +1046,7 @@ public class ResourcesXMLParser implements EntityResolver
                 attributes.getNamedItem(STATEMENT_LEAK_TIMEOUT_IN_SECONDS);
         Node statementLeakReclaimNode =
                 attributes.getNamedItem(STATEMENT_LEAK_RECLAIM);
+        Node skipClientInfoValidationNode = attributes.getNamedItem(SKIP_CLIENT_INFO_VALIDATION);
 
 
         org.glassfish.resources.api.Resource jdbcConnPool = new Resource(org.glassfish.resources.api.Resource.JDBC_CONNECTION_POOL);
@@ -1205,6 +1206,10 @@ public class ResourcesXMLParser implements EntityResolver
         if (statementLeakReclaimNode != null) {
            jdbcConnPool.setAttribute(STATEMENT_LEAK_RECLAIM,
                                         statementLeakReclaimNode.getNodeValue());
+        }
+
+        if (skipClientInfoValidationNode != null) {
+            jdbcConnPool.setAttribute(SKIP_CLIENT_INFO_VALIDATION, skipClientInfoValidationNode.getNodeValue());
         }
 
         NodeList children = nextKid.getChildNodes();


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Add option to admin console to skip client info validation.
Also throw a restart required when changed.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
none
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Deployed an simple jpa example from Payara-Examples to verify if client info was skipped when set.
Also verified behaviour isn't changed dynamically
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.5, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.5-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "15.1.1", arch: "aarch64", family: "mac"

## Documentation
<!-- Link documentation if a PR exists -->
https://github.com/payara/Payara-Documentation/pull/578
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
