### PR TITLE
FISH-9527 Implement Movable Master Password

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/DomainConfig.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/DomainConfig.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2019] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2025] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.servermgmt;
 
@@ -64,6 +64,7 @@ public class DomainConfig extends RepositoryConfig {
     public static final String K_PASSWORD = "domain.password";
     public static final String K_NEW_MASTER_PASSWORD = "domain.newMasterPassword";
     public static final String K_MASTER_PASSWORD = "domain.masterPassword";
+    public static final String K_MASTER_PASSWORD_LOCATION = "domain.masterPasswordLocation";
     public static final String K_SAVE_MASTER_PASSWORD = "domain.saveMasterPassword";
     public static final String K_ADMIN_PORT = "domain.adminPort";
     public static final String K_INSTANCE_PORT = "domain.instancePort";

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/MasterPasswordFileManager.java
@@ -37,19 +37,24 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.sun.enterprise.admin.servermgmt.pe.PEFileLayout;
 import com.sun.enterprise.security.store.PasswordAdapter;
 import com.sun.enterprise.util.i18n.StringManager;
 import com.sun.enterprise.util.io.FileUtils;
 
+import jakarta.annotation.Nullable;
 import org.glassfish.security.common.FileProtectionUtility;
 
 
@@ -91,20 +96,44 @@ public class MasterPasswordFileManager extends KeystoreManager {
         final File pwdFile = layout.getMasterPasswordFile();    
         FileUtils.deleteFile(pwdFile);
     }
-    
+
+    /**
+     * Create the master password keystore at the default path. This routine can also modify the master password
+     * if the keystore already exists.
+     * @param config
+     * @param masterPassword
+     * @throws RepositoryException
+     */
+    @Deprecated
+    protected void createMasterPasswordFile(RepositoryConfig config, String masterPassword)
+        throws RepositoryException
+    {
+        this.createMasterPasswordFile(config, masterPassword, null);
+    }
+
     /**
      * Create the master password keystore. This routine can also modify the master password
      * if the keystore already exists
-     * @param config
-     * @param masterPassword 
+     * @param config The config information.
+     * @param masterPassword The password to set.
+     * @param path The path to save the master password to.
      * @throws RepositoryException
-     */    
-    protected void createMasterPasswordFile(
-        RepositoryConfig config, String masterPassword) 
+     */
+    protected void createMasterPasswordFile(RepositoryConfig config, String masterPassword, @Nullable String path)
         throws RepositoryException
     {
         final PEFileLayout layout = getFileLayout(config);
-        final File pwdFile = layout.getMasterPasswordFile();                     
+        if (path != null) {
+            File mpLocation = layout.getMasterPasswordLocationFile();
+            try (FileWriter writer = new FileWriter(mpLocation)) {
+                writer.write(path);
+            } catch (IOException e) {
+                Logger.getAnonymousLogger().log(Level.SEVERE,
+                    "Failed to write master-password-location file: ", e);
+            }
+        }
+
+        final File pwdFile = layout.getMasterPasswordFile();
         try {                    
             PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), getMasterPasswordPassword());
             p.setPasswordForAlias(MASTERPASSWORD_FILE, masterPassword.getBytes());
@@ -139,7 +168,22 @@ public class MasterPasswordFileManager extends KeystoreManager {
             //Return null if the password file does not exist.
             return null;
         }
-    }   
+    }
+
+    /**
+     * Changes the master password in the master password file
+     * @param saveMasterPassword
+     * @param config
+     * @param newPassword
+     * @throws RepositoryException
+     */
+    @Deprecated
+    protected void changeMasterPasswordInMasterPasswordFile(RepositoryConfig config, String newPassword,
+        boolean saveMasterPassword) throws RepositoryException
+    {
+        this.changeMasterPasswordInMasterPasswordFile(config, newPassword, saveMasterPassword, null);
+    }
+
     /**
      * Changes the master password in the master password file
      * @param saveMasterPassword
@@ -148,11 +192,11 @@ public class MasterPasswordFileManager extends KeystoreManager {
      * @throws RepositoryException
      */
     protected void changeMasterPasswordInMasterPasswordFile(RepositoryConfig config, String newPassword,
-        boolean saveMasterPassword) throws RepositoryException 
+        boolean saveMasterPassword, @Nullable String newMPLocation) throws RepositoryException
     {
         deleteMasterPasswordFile(config);
         if (saveMasterPassword) {
-            createMasterPasswordFile(config, newPassword);
+            createMasterPasswordFile(config, newPassword, newMPLocation);
         }         
     }
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2025] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -55,6 +55,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * The change-master-password command.
@@ -88,6 +89,9 @@ public class ChangeMasterPasswordCommand extends CLICommand {
 
     @Param(name = "savemasterpassword", optional = true, defaultValue = "false")
     private boolean savemp;
+
+    @Param(name = "masterpasswordlocation", optional = true)
+    private String mpLocation;
 
     @Param(name = "domain_name_or_node_name", primary = true, optional = true)
     private String domainNameOrNodeName;
@@ -127,12 +131,12 @@ public class ChangeMasterPasswordCommand extends CLICommand {
                 // nodeDir is not specified and domainNameOrNodeName is not a domain.
                 // It could be a node
                 // We add defaultNodeDir parameter to args
-                ArrayList arguments = new ArrayList<String>(Arrays.asList(argv));
+                List<String> arguments = new ArrayList<>(Arrays.asList(argv));
                 arguments.remove(argv.length -1);
                 arguments.add("--nodedir");
                 arguments.add(getDefaultNodesDirs().getAbsolutePath());
                 arguments.add(domainNameOrNodeName);
-                String[] newargs = (String[]) arguments.toArray(new String[arguments.size()]);
+                String[] newargs = arguments.toArray(new String[0]);
                 
                 command = CLICommand.getCommand(habitat,
                 CHANGE_MASTER_PASSWORD_NODE);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeMasterPasswordCommandDAS.java
@@ -37,14 +37,11 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2023] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.logging.Level;
-import java.util.Arrays;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -73,6 +70,9 @@ public class ChangeMasterPasswordCommandDAS extends LocalDomainCommand {
 
     @Param(name = "savemasterpassword", optional = true, defaultValue = "false")
     protected boolean savemp;
+
+    @Param(name = "masterpasswordlocation", optional = true)
+    private String mpLocation;
 
     private static final LocalStringsImpl STRINGS = new LocalStringsImpl(ChangeMasterPasswordCommandDAS.class);
 
@@ -123,6 +123,9 @@ public class ChangeMasterPasswordCommandDAS extends LocalDomainCommand {
             domainConfig.put(DomainConfig.K_MASTER_PASSWORD, mp);
             domainConfig.put(DomainConfig.K_NEW_MASTER_PASSWORD, nmp);
             domainConfig.put(DomainConfig.K_SAVE_MASTER_PASSWORD, savemp);
+            if (savemp && mpLocation != null) {
+                domainConfig.put(DomainConfig.K_MASTER_PASSWORD_LOCATION, mpLocation);
+            }
             manager.changeMasterPassword(domainConfig);
 
             try {

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/CreateDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/CreateDomainCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2018-2025] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -82,6 +82,7 @@ import static com.sun.enterprise.admin.servermgmt.DomainConfig.K_ADMIN_CERT_DN;
 import static com.sun.enterprise.admin.servermgmt.DomainConfig.K_ADMIN_PORT;
 import static com.sun.enterprise.admin.servermgmt.DomainConfig.K_INITIAL_ADMIN_USER_GROUPS;
 import static com.sun.enterprise.admin.servermgmt.DomainConfig.K_INSTANCE_CERT_DN;
+import static com.sun.enterprise.admin.servermgmt.DomainConfig.K_MASTER_PASSWORD_LOCATION;
 import static com.sun.enterprise.admin.servermgmt.DomainConfig.K_PORTBASE;
 import static com.sun.enterprise.admin.servermgmt.DomainConfig.K_SECURE_ADMIN_IDENTIFIER;
 import static com.sun.enterprise.admin.servermgmt.DomainConfig.K_TEMPLATE_NAME;
@@ -151,6 +152,9 @@ public final class CreateDomainCommand extends CLICommand {
 
     @Param(name = SAVE_MASTER_PASSWORD, optional = true, defaultValue = "false")
     private boolean saveMasterPassword = false;
+
+    @Param(name = "masterpasswordlocation", optional = true)
+    private String masterPasswordLocation;
 
     @Param(name = "usemasterpassword", optional = true, defaultValue = "false")
     private boolean useMasterPassword = false;
@@ -527,6 +531,9 @@ public final class CreateDomainCommand extends CLICommand {
             domainConfig.put(K_TEMPLATE_NAME, template);
             domainConfig.put(K_PORTBASE, portBase);
             domainConfig.put(K_INITIAL_ADMIN_USER_GROUPS, Version.getInitialAdminGroups());
+            if (masterPasswordLocation != null) {
+                domainConfig.put(K_MASTER_PASSWORD_LOCATION, masterPasswordLocation);
+            }
             initSecureAdminSettings(domainConfig);
 
             try {

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2024] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
@@ -61,6 +61,7 @@ import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.util.io.ServerDirs;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.admin.CommandException;
+import org.glassfish.grizzly.utils.Charsets;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -80,14 +81,17 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.nio.file.Files;
 import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_LOCATION_FILE;
 
 /**
  * A class that's supposed to capture all the behavior common to operation on a
@@ -562,11 +566,26 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     protected File getMasterPasswordFile() {
-
-        if (serverDirs == null)
+        if (serverDirs == null) {
             return null;
+        }
 
-        File mp = new File(serverDirs.getConfigDir(), MASTERPASSWORD_FILE);
+        File mp;
+        File mpLocation = new File(serverDirs.getConfigDir(), MASTERPASSWORD_LOCATION_FILE);
+        if (mpLocation.canRead()) {
+            try {
+                String path = Files.readString(mpLocation.toPath(), Charsets.UTF8_CHARSET);
+                mp = new File(path);
+            }
+            catch (IOException e) {
+                Logger.getAnonymousLogger().log(Level.WARNING,
+                    "Failed to read master-password-location file due error: " + e);
+                mp = new File(serverDirs.getConfigDir(), MASTERPASSWORD_FILE);
+            }
+        } else {
+            mp = new File(serverDirs.getConfigDir(), MASTERPASSWORD_FILE);
+        }
+
         if (!mp.canRead())
             return null;
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2025] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.servermgmt.domain;
 
@@ -61,6 +61,7 @@ import com.sun.enterprise.util.io.FileUtils;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Enumeration;
@@ -365,6 +366,7 @@ public class DomainBuilder {
         String[] adminUserGroups = ((String) domainConfig.get(DomainConfig.K_INITIAL_ADMIN_USER_GROUPS)).split(",");
         String masterPassword = (String) domainConfig.get(DomainConfig.K_MASTER_PASSWORD);
         Boolean saveMasterPassword = (Boolean) domainConfig.get(DomainConfig.K_SAVE_MASTER_PASSWORD);
+        String mpLocation = (String)domainConfig.get(DomainConfig.K_MASTER_PASSWORD_LOCATION);
 
         // Process domain security.
         DomainSecurity domainSecurity = new DomainSecurity();
@@ -386,8 +388,21 @@ public class DomainBuilder {
                 }
             }
         }
-        domainSecurity.changeMasterPasswordInMasterPasswordFile(new File(configDir, DomainConstants.MASTERPASSWORD_FILE), masterPassword,
-                saveMasterPassword);
+
+        File mpFile = new File(configDir, DomainConstants.MASTERPASSWORD_FILE);
+        if (mpLocation != null) {
+            File mpLocationFile = new File(configDir, DomainConstants.MASTERPASSWORD_LOCATION_FILE);
+            try (FileWriter writer = new FileWriter(mpLocationFile)) {
+                writer.write(mpLocation);
+                mpFile = new File(mpLocation);
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE,
+                    "Failed to write master-password-location file, using default location due to error: ",
+                    e.getMessage());
+            }
+        }
+
+        domainSecurity.changeMasterPasswordInMasterPasswordFile(mpFile, masterPassword, saveMasterPassword);
         domainSecurity.createPasswordAliasKeystore(new File(configDir, DomainConstants.DOMAIN_PASSWORD_FILE), masterPassword);
 
         return domainSecurity;

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainConstants.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainConstants.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2023 Payara Foundation and/or its affiliates 
+// Portions Copyright 2023-2025 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.admin.servermgmt.domain;
 
@@ -70,6 +70,11 @@ public class DomainConstants {
      * Master password file name stores the password for secure key store.
      */
     public static final String MASTERPASSWORD_FILE = "master-password";
+
+    /**
+     * File name for the file that contains the path to the master password.
+     */
+    public static final String MASTERPASSWORD_LOCATION_FILE = "master-password-location";
 
     /**
      * Filename contains the trusted certificates, including public keys.

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEDomainsManager.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEDomainsManager.java
@@ -37,13 +37,14 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2025] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.admin.servermgmt.pe;
 
 import com.sun.enterprise.admin.servermgmt.*;
 import com.sun.enterprise.admin.util.TokenValueSet;
 import com.sun.enterprise.util.i18n.StringManager;
+
 import java.io.File;
 import java.util.BitSet;
 
@@ -219,6 +220,10 @@ public class PEDomainsManager extends RepositoryManager implements DomainsManage
         Boolean b = (Boolean)domainConfig.get(DomainConfig.K_SAVE_MASTER_PASSWORD);
         return b;
     }
+
+    protected static String getNewMasterPasswordLocation(DomainConfig domainConfig) {
+        return (String)domainConfig.get(DomainConfig.K_MASTER_PASSWORD_LOCATION);
+    }
     
     /**
      * Changes the master password for the domain
@@ -228,7 +233,9 @@ public class PEDomainsManager extends RepositoryManager implements DomainsManage
     {                                      
         try {
             String oldPass = getMasterPasswordClear(config);
-            String newPass = getNewMasterPasswordClear(config);                        
+            String newPass = getNewMasterPasswordClear(config);
+            String mpLocation = getNewMasterPasswordLocation(config);
+            boolean saveMp = saveMasterPassword(config);
             
             //Change the password of the keystore alias file
             changePasswordAliasKeystorePassword(config, oldPass, newPass);
@@ -238,7 +245,7 @@ public class PEDomainsManager extends RepositoryManager implements DomainsManage
 
             //Change the password in the masterpassword file or delete the file if it is 
             //not to be saved.
-            changeMasterPasswordInMasterPasswordFile(config, newPass, saveMasterPassword(config));
+            changeMasterPasswordInMasterPasswordFile(config, newPass, saveMp, mpLocation);
         } catch (Exception ex) {
             throw new DomainException(
                 STRINGS_MANAGER.getString("masterPasswordNotChanged"), ex);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEFileLayout.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2023] [Payara Foundation and/or affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or affiliates]
 
 package com.sun.enterprise.admin.servermgmt.pe;
 
@@ -49,12 +49,19 @@ import com.sun.enterprise.util.OS;
 import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.i18n.StringManager;
 import com.sun.enterprise.util.io.FileUtils;
+import org.glassfish.grizzly.utils.Charsets;
+
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_LOCATION_FILE;
 
 public class PEFileLayout
 {
@@ -780,7 +787,21 @@ public class PEFileLayout
 
     public File getMasterPasswordFile()
     {
+        File mpLocation = getMasterPasswordLocationFile();
+        if (mpLocation.canRead()) {
+            try {
+                String mpPath = Files.readString(mpLocation.toPath(), Charsets.UTF8_CHARSET);
+                return new File(mpPath);
+            } catch (IOException e) {
+                Logger.getAnonymousLogger().log(Level.WARNING,
+                    "Failed to read master-password-location file due error: " + e);
+            }
+        }
         return new File(getConfigRoot(), MASTERPASSWORD_FILE);
+    }
+
+    public File getMasterPasswordLocationFile () {
+        return new File(getConfigRoot(), MASTERPASSWORD_LOCATION_FILE);
     }
 
     public static final String PASSWORD_ALIAS_KEYSTORE = PasswordAdapter.PASSWORD_ALIAS_KEYSTORE;

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
@@ -56,21 +56,28 @@ import com.sun.enterprise.util.io.FileUtils;
 import fish.payara.admin.cli.cluster.NamingHelper;
 import fish.payara.util.cluster.PayaraServerNameGenerator;
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandValidationException;
+import org.glassfish.grizzly.utils.Charsets;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.security.common.FileProtectionUtility;
 import org.jvnet.hk2.annotations.Service;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_LOCATION_FILE;
 
 
 /**
@@ -110,6 +117,9 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
 
     @Param(name = "savemasterpassword", optional = true, defaultValue = "false")
     private boolean saveMasterPassword = false;
+
+    @Param(name = "masterpasswordlocation", optional = true)
+    private String mpLocation;
 
     @Param(name = "usemasterpassword", optional = true, defaultValue = "false")
     private boolean useMasterPassword = false;
@@ -334,7 +344,6 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
             File mp = new File(new File(getServerDirs().getServerDir(), "config"), "keystore.p12");
             if (mp.canRead()) {
                 if (verifyMasterPassword(masterPassword)) {
-
                     createMasterPasswordFile(masterPassword);
                 } else {
                     logger.info(Strings.get("masterPasswordIncorrect"));
@@ -346,6 +355,22 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
 
     }
 
+    @Override
+    protected File getMasterPasswordFile () {
+        File mp = new File(new File(getServerDirs().getServerDir(), "config"), "keystore.p12");
+        File mpLocationFile = new File(new File(getServerDirs().getServerDir(), "config"), MASTERPASSWORD_LOCATION_FILE);
+        if (mpLocationFile.canRead()) {
+            try {
+                String currentMpLocation = Files.readString(mpLocationFile.toPath(), Charsets.UTF8_CHARSET);
+                mp = new File(currentMpLocation);
+            } catch (IOException e) {
+                Logger.getAnonymousLogger().log(Level.SEVERE,
+                    "Failed to read master-password-location file: ", e.getMessage());
+            }
+        }
+        return mp;
+    }
+
 
     /**
      * Create the master password keystore. This routine can also modify the master password
@@ -354,7 +379,18 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
      * @throws CommandException
      */
     protected void createMasterPasswordFile(String masterPassword) throws CommandException {
-        final File pwdFile = new File(this.getServerDirs().getAgentDir(), MASTERPASSWORD_FILE);
+        File pwdFile = new File(this.getServerDirs().getAgentDir(), MASTERPASSWORD_FILE);
+        if (mpLocation != null) {
+            File mpLocationFile = new File(this.getServerDirs().getAgentDir(), MASTERPASSWORD_LOCATION_FILE);
+            try (FileWriter writer = new FileWriter(mpLocationFile)) {
+                writer.write(mpLocation);
+                pwdFile = new File(mpLocation);
+            } catch (IOException e) {
+                Logger.getAnonymousLogger().log(Level.SEVERE,
+                    "Failed to write master-password-location, using default location due to error: ", e);
+            }
+        }
+
         try {
             PasswordAdapter p = new PasswordAdapter(pwdFile.getAbsolutePath(), MASTERPASSWORD_FILE.toCharArray());
             p.setPasswordForAlias(MASTERPASSWORD_FILE, masterPassword.getBytes(StandardCharsets.UTF_8));

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalInstanceCommand.java
@@ -42,6 +42,7 @@
 package com.sun.enterprise.admin.cli.cluster;
 
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_FILE;
+import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.MASTERPASSWORD_LOCATION_FILE;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -51,8 +52,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
 import java.util.Properties;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.sun.enterprise.admin.cli.remote.RemoteCLICommand;
 import com.sun.enterprise.admin.servermgmt.cli.LocalServerCommand;
@@ -67,6 +70,7 @@ import com.sun.enterprise.util.net.NetUtils;
 import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandValidationException;
+import org.glassfish.grizzly.utils.Charsets;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.UserInterruptException;
 
@@ -661,11 +665,27 @@ public abstract class LocalInstanceCommand extends LocalServerCommand {
 
     @Override
     protected File getMasterPasswordFile() {
-
-        if (nodeDirChild == null)
+        if (nodeDirChild == null) {
             return null;
+        }
 
-        File mp = new File(new File(nodeDirChild,"agent"), MASTERPASSWORD_FILE);
+        File mpLocation = new File(new File(nodeDirChild, "agent"), MASTERPASSWORD_LOCATION_FILE);
+        File mp;
+
+        if (mpLocation.canRead()) {
+            try {
+                String path = Files.readString(mpLocation.toPath(), Charsets.UTF8_CHARSET);
+                mp = new File(path);
+            }
+            catch (IOException e) {
+                Logger.getAnonymousLogger().log(Level.WARNING,
+                    "Failed to read master-password-location file due error: ", e);
+                mp = new File(new File(nodeDirChild, "agent"), MASTERPASSWORD_FILE);
+            }
+        } else {
+            mp = new File(new File(nodeDirChild, "agent"), MASTERPASSWORD_FILE);
+        }
+
         if (!mp.canRead()) {
             return null;
         }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Implements FISH-9527
  - Instead of saving the master password to the default location, the user has the option to save the master password to a different location.
  - A `masterpasswordlocation` parameter has been added to `create-domain`, `change-master-password`, `create-local-instance`.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
- Created a new domain without a master password.
- Created a new domain with a master password (default location).
- Created a new domain with a master password (custom location).
- Changed master password to a new location.
- Created a new local instance with a master password (default location).
- Created a new local instance with a master password (custom location).

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
