### PR TITLE
FISH-10899 Update Jersey to 3.1.10.payara-p1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -75,7 +75,7 @@
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
         <jaxb-api.version>4.0.2</jaxb-api.version>
         <jackson.version>2.18.3</jackson.version>
-        <jersey.version>3.1.7.payara-p1</jersey.version>
+        <jersey.version>3.1.10.payara-p1</jersey.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <hibernate.validator.version>8.0.1.Final.payara-p1</hibernate.validator.version>
         <hibernate.validator.osgi.version>8.0.1.Final</hibernate.validator.osgi.version>


### PR DESCRIPTION
## Description
Updates Jersey to 3.1.10 with our outstanding patches reapplied

## Important Info
### Blockers
https://github.com/payara/patched-src-jersey/pull/234

## Testing
### New tests
None

### Testing Performed
I started the admin console - no explosions

### Testing Environment
Windows 11, Maven 3.9.9, Zulu JDK 11.0.26

## Documentation
N/A

## Notes for Reviewers
None
