### PR TITLE
FISH-10914 Add Missing Help Text

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/create-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/create-domain.1
@@ -12,6 +12,7 @@ SYNOPSIS
            [--template template-name]
            [--domaindir domaindir]
            [--savemasterpassword={false|true}]
+           [--masterpasswordlocation filepath]
            [--usemasterpassword={false|true}]
            [--hazelcastdasport hazelcastdasport]
            [--hazelcaststartport hazelcaststartport]
@@ -175,6 +176,11 @@ OPTIONS
            password is saved, then start-domain does not prompt for it. The
            master password gives an extra level of security to the
            environment.
+
+       --masterpasswordlocation
+           Only applies if the --savemasterpassword parameter is set to true.
+           This parameter receives an absolute filepath that the master password
+           will be saved to.
 
        --usemasterpassword
            Specifies whether the key store is encrypted with a master password

--- a/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/create-local-instance.1
+++ b/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/create-local-instance.1
@@ -11,6 +11,7 @@ SYNOPSIS
            [--lbenabled={true|false}]
            [--portbase port-number] [--checkports={true|false}]
            [--savemasterpassword={false|true}]
+           [--masterpasswordlocation filepath]
            [--usemasterpassword={false|true}]
            [--systemproperties (name=value)[:name=value]* ]
            instance-name
@@ -224,6 +225,11 @@ OPTIONS
            directory, not the domain directory. Therefore, this option is
            required only for the first instance that is created for each node
            in a domain.
+
+       --masterpasswordlocation
+           Only applies if the --savemasterpassword parameter is set to true.
+           This parameter receives an absolute filepath that the master password
+           will be saved to.
 
        --usemasterpassword
            Specifies whether the key store is encrypted with a master password


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-10914
  - Adds the `--masterpasswordlocation` parameter to the help pages for `create-domain` and `create-local-instance`.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Used the `asadmin help` command to view the changed manpages.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
