### PR TITLE
FISH-10499: Adding simple crud operation using jakarta data interface methods

### DIFF
--- a/appserver/data/data-core/pom.xml
+++ b/appserver/data/data-core/pom.xml
@@ -74,5 +74,28 @@
             <artifactId>classgraph</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Export-Package />
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/DynamicInterfaceDataProducer.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/DynamicInterfaceDataProducer.java
@@ -39,6 +39,12 @@
  */
 package fish.payara.jakarta.data.core.cdi.extension;
 
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Default;
@@ -47,28 +53,41 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.PassivationCapable;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
- * This is a generic class that works as a producer for a Bean that is going to be used during 
+ * This is a generic class that works as a producer for a Bean that is going to be used during
  * injection point resolution
+ *
  * @param <T>
  */
-public class DynamicInterfaceDataProducer <T> implements Bean<T>, PassivationCapable {
+public class DynamicInterfaceDataProducer<T> implements Bean<T>, PassivationCapable {
 
-    Class<T> repository;
-    BeanManager beanManager;
-    JakartaDataExtension jakartaDataExtension;
+    private static final Logger logger = Logger.getLogger(DynamicInterfaceDataProducer.class.getName());
+
+    private Class<T> repository;
+    private BeanManager beanManager;
+    private JakartaDataExtension jakartaDataExtension;
     private Set<Type> beanTypes = null;
+    private Map<Class<?>, List<QueryData>> queriesForEntity = new HashMap<>();
 
     DynamicInterfaceDataProducer(Class<?> instance, BeanManager beanManager, JakartaDataExtension jakartaDataExtension) {
         this.repository = (Class<T>) instance;
         this.beanManager = beanManager;
         this.jakartaDataExtension = jakartaDataExtension;
         this.beanTypes = Set.of(instance);
+        processQueriesForEntity();
     }
 
     @Override
@@ -83,15 +102,13 @@ public class DynamicInterfaceDataProducer <T> implements Bean<T>, PassivationCap
 
     @Override
     public T create(CreationalContext<T> context) {
-        Class<T> repositoryInterface = repository;
-        RepositoryImpl<?> handler = new RepositoryImpl<>(repositoryInterface);
-        return (T) Proxy.newProxyInstance(repositoryInterface.getClassLoader(), new Class[]{repositoryInterface},
+        RepositoryImpl<?> handler = new RepositoryImpl<>(repository, queriesForEntity, jakartaDataExtension.getApplicationName());
+        return (T) Proxy.newProxyInstance(repository.getClassLoader(), new Class[]{repository},
                 handler);
     }
 
     @Override
     public void destroy(T t, CreationalContext<T> creationalContext) {
-
     }
 
     @Override
@@ -127,5 +144,92 @@ public class DynamicInterfaceDataProducer <T> implements Bean<T>, PassivationCap
     @Override
     public String getId() {
         return this.repository.getName();
+    }
+
+    private void processQueriesForEntity() {
+        logger.info("Processing query for entity class: " + repository);
+        //get entity type
+        Class<?> declaredEntityClass = getEntityType(this.repository);
+        logger.info("Processing entity class " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null"));
+        Set<Class<?>> lifecycleMethodEntityClasses = new HashSet<>();
+        for (Method method : this.repository.getMethods()) {
+            logger.info("Processing query for " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null") + "." + method.getName());
+            //skip if method is default 
+            if (method.isDefault()) {
+                continue;
+            }
+            Class<?> entityParamType = null;
+            entityParamType = getEntityParamClass(method);
+            addQueries(repository, entityParamType, method);
+        }
+    }
+
+    /**
+     * This method review all the interfaces implemented by this class and get the entity type mapped
+     *
+     * @param repositoryInterface This is the interface class from the application
+     * @return the entity class used of the operation
+     */
+    private Class<?> getEntityType(Class<?> repositoryInterface) {
+        Class<?>[] interfaceClasses = repositoryInterface.getInterfaces();
+        for (Type type : repositoryInterface.getGenericInterfaces()) {
+            if (type instanceof ParameterizedType parameterizedType) {
+                for (Class<?> interfaceClass : interfaceClasses) {
+                    if (interfaceClass.equals(parameterizedType.getRawType())) {
+                        if (DataRepository.class.isAssignableFrom(interfaceClass)) {
+                            Type[] typeParams = parameterizedType.getActualTypeArguments();
+                            Type firstParamType = typeParams.length > 0 ? typeParams[0] : null;
+                            if (firstParamType instanceof Class) {
+                                return (Class<?>) firstParamType;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    public Class<?> getEntityParamClass(Method method) {
+        Class<?> entityParamType = null;
+        // Determine entity class from parameters
+        if (method.getParameterCount() == 1 && !method.isDefault() &&
+                (method.isAnnotationPresent(Insert.class) || method.isAnnotationPresent(Update.class)
+                        || method.isAnnotationPresent(Save.class) || method.isAnnotationPresent(Delete.class))) {
+            Class<?> c = method.getParameterTypes()[0];
+            if (Object.class.equals(c)) {
+                entityParamType = c;
+            }
+        }
+        return entityParamType;
+    }
+
+    /**
+     * Here is added the queries to be resolved for specific entity type
+     *
+     * @param entityClass
+     * @param entityParamType
+     * @param method
+     */
+    public void addQueries(Class<?> entityClass, Class<?> entityParamType, Method method) {
+        List<QueryData> queries;
+        queries = queriesForEntity.get(entityClass);
+        if (queries == null) {
+            queriesForEntity.put(entityClass, queries = new ArrayList<>());
+        }
+        QueryData.QueryType queryType = null;
+        if (method.isAnnotationPresent(Save.class)) {
+            queryType = QueryData.QueryType.SAVE;
+        } else if (method.isAnnotationPresent(Delete.class)) {
+            queryType = QueryData.QueryType.DELETE;
+        } else if (method.isAnnotationPresent(Update.class)) {
+            queryType = QueryData.QueryType.UPDATE;
+        } else if (method.isAnnotationPresent(Insert.class)) {
+            queryType = QueryData.QueryType.INSERT;
+        } else if (method.isAnnotationPresent(Find.class)) {
+            queryType = QueryData.QueryType.FIND;
+        }
+        queries.add(new QueryData(repository, method, entityParamType, queryType));
     }
 }

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/DynamicInterfaceDataProducer.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/DynamicInterfaceDataProducer.java
@@ -214,17 +214,17 @@ public class DynamicInterfaceDataProducer<T> implements Bean<T>, PassivationCapa
     public void addQueries(Class<?> entityClass, Class<?> declaredEntityClass, Class<?> entityParamType, Method method) {
         List<QueryData> queries;
         queries = queriesForEntity.computeIfAbsent(entityClass, k -> new ArrayList<>());
-        QueryData.QueryType queryType = null;
+        QueryType queryType = null;
         if (method.isAnnotationPresent(Save.class)) {
-            queryType = QueryData.QueryType.SAVE;
+            queryType = QueryType.SAVE;
         } else if (method.isAnnotationPresent(Delete.class)) {
-            queryType = QueryData.QueryType.DELETE;
+            queryType = QueryType.DELETE;
         } else if (method.isAnnotationPresent(Update.class)) {
-            queryType = QueryData.QueryType.UPDATE;
+            queryType = QueryType.UPDATE;
         } else if (method.isAnnotationPresent(Insert.class)) {
-            queryType = QueryData.QueryType.INSERT;
+            queryType = QueryType.INSERT;
         } else if (method.isAnnotationPresent(Find.class)) {
-            queryType = QueryData.QueryType.FIND;
+            queryType = QueryType.FIND;
         }
         queries.add(new QueryData(repository, method, declaredEntityClass, entityParamType, queryType));
     }

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/JakartaDataExtension.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/JakartaDataExtension.java
@@ -66,6 +66,15 @@ import java.util.stream.Collectors;
 public class JakartaDataExtension implements Extension {
 
     private static final Logger logger = Logger.getLogger(JakartaDataExtension.class.getName());
+    
+    private String applicationName;
+
+    public JakartaDataExtension() {
+    }
+    
+    public JakartaDataExtension(String appName) {
+        this.applicationName = appName;
+    }
 
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager manager) {
         logger.info("Finishing scanning process");
@@ -79,7 +88,7 @@ public class JakartaDataExtension implements Extension {
         Set<Class<?>> repositories = new HashSet<>();
         //here is the place to start to use the classgraph api to get information from the classes that are 
         //annotated by the jakarta data annotation 
-        try (ScanResult result = new ClassGraph().enableAllInfo().scan()) {
+        try (ScanResult result = new ClassGraph().enableClassInfo().enableAnnotationInfo().scan()) {
             repositories.addAll(locateAndGetRepositories(result));
         }
         return repositories.stream().filter(cl -> {
@@ -128,5 +137,9 @@ public class JakartaDataExtension implements Extension {
             return entity;
         }
         return null;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
     }
 }

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/JakartaDataExtension.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/JakartaDataExtension.java
@@ -88,7 +88,7 @@ public class JakartaDataExtension implements Extension {
         Set<Class<?>> repositories = new HashSet<>();
         //here is the place to start to use the classgraph api to get information from the classes that are 
         //annotated by the jakarta data annotation 
-        try (ScanResult result = new ClassGraph().enableClassInfo().enableAnnotationInfo().scan()) {
+        try (ScanResult result = new ClassGraph().enableAnnotationInfo().scan()) {
             repositories.addAll(locateAndGetRepositories(result));
         }
         return repositories.stream().filter(cl -> {

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/QueryData.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/QueryData.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2025] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -37,63 +37,64 @@
  *     only if the new code is made subject to such option by the copyright
  *     holder.
  */
-package fish.payara.jakarta.data.core.connector;
+package fish.payara.jakarta.data.core.cdi.extension;
 
-import jakarta.enterprise.inject.spi.Extension;
-import java.util.Collection;
-import java.util.function.Supplier;
-import org.glassfish.api.deployment.Deployer;
-import org.glassfish.api.deployment.DeploymentContext;
-import org.glassfish.api.deployment.MetaData;
-import org.glassfish.hk2.api.PerLookup;
-import org.glassfish.weld.WeldDeployer;
-import org.jvnet.hk2.annotations.Service;
-import fish.payara.jakarta.data.core.cdi.extension.JakartaDataExtension;
-
+import java.lang.reflect.Method;
 
 /**
- * Deployer create to process Jakarta Data annotations, here we can declare information related to process the annotations
- * and also here we can register an extension if needed
- *
- * @author Alfonso Valdez
+ * This class represent the structure of a query to be resolved during runtime
  */
-@Service
-@PerLookup
-public class JakartaDataRepositoryDeployer implements Deployer<JakartaDataContainer, JakartaDataApplicationContainer> {
+public class QueryData {
 
-    @Override
-    public MetaData getMetaData() {
-        return null;
+    private Class<?> repositoryInterface;
+    private Method method;
+    private Class<?> entityParamType;
+    private QueryType queryType;
+
+    public enum QueryType {
+        SAVE,
+        UPDATE,
+        DELETE,
+        INSERT,
+        FIND
     }
 
-    @Override
-    public <V> V loadMetaData(Class<V> type, DeploymentContext context) {
-        return null;
+    public QueryData(Class<?> repositoryInterface, Method method, Class<?> entityParamType, QueryType queryType) {
+        this.repositoryInterface = repositoryInterface;
+        this.method = method;
+        this.entityParamType = entityParamType;
+        this.queryType = queryType;
     }
 
-    @Override
-    public boolean prepare(DeploymentContext context) {
-        return true;
+    public Class<?> getRepositoryInterface() {
+        return repositoryInterface;
     }
 
-    @Override
-    public JakartaDataApplicationContainer load(JakartaDataContainer container, DeploymentContext context) {
-        //Here we can declare extension to process beans
-        Collection<Supplier<Extension>> snifferExtensions =
-                context.getTransientAppMetaData(WeldDeployer.SNIFFER_EXTENSIONS, Collection.class);
-        if (snifferExtensions != null) {
-            snifferExtensions.add(() -> new JakartaDataExtension(context.getArchiveHandler().getDefaultApplicationName(context.getSource(), context)));
-        }
-        return new JakartaDataApplicationContainer(context);
+    public void setRepositoryInterface(Class<?> repositoryInterface) {
+        this.repositoryInterface = repositoryInterface;
     }
 
-    @Override
-    public void unload(JakartaDataApplicationContainer appContainer, DeploymentContext context) {
-
+    public Method getMethod() {
+        return method;
     }
 
-    @Override
-    public void clean(DeploymentContext context) {
+    public void setMethod(Method method) {
+        this.method = method;
+    }
 
+    public Class<?> getEntityParamType() {
+        return entityParamType;
+    }
+
+    public void setEntityParamType(Class<?> entityParamType) {
+        this.entityParamType = entityParamType;
+    }
+
+    public QueryType getQueryType() {
+        return queryType;
+    }
+
+    public void setQueryType(QueryType queryType) {
+        this.queryType = queryType;
     }
 }

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/QueryData.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/QueryData.java
@@ -49,6 +49,7 @@ public class QueryData {
     private Class<?> repositoryInterface;
     private Method method;
     private Class<?> entityParamType;
+    private Class<?> declaredEntityClass;
     private QueryType queryType;
 
     public enum QueryType {
@@ -59,10 +60,11 @@ public class QueryData {
         FIND
     }
 
-    public QueryData(Class<?> repositoryInterface, Method method, Class<?> entityParamType, QueryType queryType) {
+    public QueryData(Class<?> repositoryInterface, Method method, Class<?> declaredEntityClass, Class<?> entityParamType, QueryType queryType) {
         this.repositoryInterface = repositoryInterface;
         this.method = method;
         this.entityParamType = entityParamType;
+        this.declaredEntityClass = declaredEntityClass;
         this.queryType = queryType;
     }
 
@@ -96,5 +98,13 @@ public class QueryData {
 
     public void setQueryType(QueryType queryType) {
         this.queryType = queryType;
+    }
+
+    public Class<?> getDeclaredEntityClass() {
+        return declaredEntityClass;
+    }
+
+    public void setDeclaredEntityClass(Class<?> declaredEntityClass) {
+        this.declaredEntityClass = declaredEntityClass;
     }
 }

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/QueryType.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/QueryType.java
@@ -39,64 +39,13 @@
  */
 package fish.payara.jakarta.data.core.cdi.extension;
 
-import java.lang.reflect.Method;
-
 /**
- * This class represent the structure of a query to be resolved during runtime
+ * Enum type used to identify each kind of query from Jakarta Data interface methods
  */
-public class QueryData {
-
-    private Class<?> repositoryInterface;
-    private Method method;
-    private Class<?> entityParamType;
-    private Class<?> declaredEntityClass;
-    private QueryType queryType;
-
-    public QueryData(Class<?> repositoryInterface, Method method, Class<?> declaredEntityClass, Class<?> entityParamType, QueryType queryType) {
-        this.repositoryInterface = repositoryInterface;
-        this.method = method;
-        this.entityParamType = entityParamType;
-        this.declaredEntityClass = declaredEntityClass;
-        this.queryType = queryType;
-    }
-
-    public Class<?> getRepositoryInterface() {
-        return repositoryInterface;
-    }
-
-    public void setRepositoryInterface(Class<?> repositoryInterface) {
-        this.repositoryInterface = repositoryInterface;
-    }
-
-    public Method getMethod() {
-        return method;
-    }
-
-    public void setMethod(Method method) {
-        this.method = method;
-    }
-
-    public Class<?> getEntityParamType() {
-        return entityParamType;
-    }
-
-    public void setEntityParamType(Class<?> entityParamType) {
-        this.entityParamType = entityParamType;
-    }
-
-    public QueryType getQueryType() {
-        return queryType;
-    }
-
-    public void setQueryType(QueryType queryType) {
-        this.queryType = queryType;
-    }
-
-    public Class<?> getDeclaredEntityClass() {
-        return declaredEntityClass;
-    }
-
-    public void setDeclaredEntityClass(Class<?> declaredEntityClass) {
-        this.declaredEntityClass = declaredEntityClass;
-    }
+public enum QueryType {
+    SAVE,
+    UPDATE,
+    DELETE,
+    INSERT,
+    FIND
 }

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/RepositoryImpl.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/RepositoryImpl.java
@@ -39,29 +39,150 @@
  */
 package fish.payara.jakarta.data.core.cdi.extension;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
+import org.glassfish.hk2.api.ServiceHandle;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.data.ApplicationInfo;
+import org.glassfish.internal.data.ApplicationRegistry;
+
 
 /**
- * This is a generic class that represent the proxy to be used during runtime 
+ * This is a generic class that represent the proxy to be used during runtime
+ *
  * @param <T>
  */
-public class RepositoryImpl <T> implements InvocationHandler {
+public class RepositoryImpl<T> implements InvocationHandler {
 
     public static final Logger logger = Logger.getLogger(RepositoryImpl.class.getName());
 
-    final Class<T> repositoryInterface;
+    private final Class<T> repositoryInterface;
+    private Map<Class<?>, List<QueryData>> queriesPerEntityClass;
+    private final Map<Method, QueryData> queries = new HashMap<>();
+    private final String applicationName;
 
-    public RepositoryImpl(Class<T> repositoryInterface) {
+    public RepositoryImpl(Class<T> repositoryInterface, Map<Class<?>, List<QueryData>> queriesPerEntityClass, String applicationName) {
         this.repositoryInterface = repositoryInterface;
+        this.queriesPerEntityClass = queriesPerEntityClass;
+        this.applicationName = applicationName;
     }
-    
+
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         //In this method we can add implementation to execute dynamic queries
-        logger.info("executing method:"+method.getName());
-        return "executing method:"+method.getName();
+        logger.info("executing method:" + method.getName());
+        preProcessQuery();
+        QueryData dataForQuery = queries.get(method);
+        switch (dataForQuery.getQueryType()) {
+            case SAVE -> processSaveOperation(args);
+            case INSERT -> processInsertOperation(args);
+            case DELETE -> processDeleteOperation(args);
+            case UPDATE -> processUpdateOperation(args, dataForQuery.getEntityParamType());
+        }
+
+        return "executing method:" + method.getName();
+    }
+
+    public void preProcessQuery() {
+        for (Map.Entry<Class<?>, List<QueryData>> entry : queriesPerEntityClass.entrySet()) {
+            for (QueryData queryData : entry.getValue()) {
+                queries.put(queryData.getMethod(), queryData);
+            }
+        }
+    }
+
+
+    public void processSaveOperation(Object[] args) throws SystemException, NotSupportedException,
+            HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        TransactionManager transactionManager = getTransactionManager();
+        EntityManager em = getEntityManager();
+        if (args[0] != null) {
+            transactionManager.begin();
+            em.joinTransaction();
+            Object entity = em.merge(args[0]);
+            em.flush();
+            transactionManager.commit();
+        }
+    }
+
+    public void processInsertOperation(Object[] args) throws SystemException, NotSupportedException,
+            HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        TransactionManager transactionManager = getTransactionManager();
+        EntityManager em = getEntityManager();
+        if (args[0] != null) {
+            transactionManager.begin();
+            em.joinTransaction();
+            em.persist(args[0]);
+            em.flush();
+            transactionManager.commit();
+        }
+    }
+
+    public void processDeleteOperation(Object[] args) throws SystemException, NotSupportedException,
+            HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        TransactionManager transactionManager = getTransactionManager();
+        EntityManager em = getEntityManager();
+        if (args[0] != null) {
+            transactionManager.begin();
+            em.joinTransaction();
+            em.remove(em.merge(args[0]));
+            em.flush();
+            transactionManager.commit();
+        }
+    }
+
+    public void processUpdateOperation(Object[] args, Class<?> entityParam) throws SystemException,
+            NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        logger.info("Need to process update operation with query based on jpql");
+        TransactionManager transactionManager = getTransactionManager();
+        EntityManager em = getEntityManager();
+        if (args[0] != null) {
+            transactionManager.begin();
+            em.joinTransaction();
+            Object entity = em.merge(args[0]);
+            em.flush();
+            transactionManager.commit();
+        }
+    }
+
+    public ApplicationRegistry getRegistry() {
+        ApplicationRegistry registry = Globals.get(ApplicationRegistry.class);
+        return registry;
+    }
+
+    public TransactionManager getTransactionManager() {
+        ServiceLocator locator = Globals.get(ServiceLocator.class);
+        ServiceHandle<TransactionManager> inhabitant =
+                locator.getServiceHandle(TransactionManager.class);
+        if (inhabitant != null && inhabitant.isActive()) {
+            TransactionManager txmgr = inhabitant.getService();
+            return txmgr;
+        }
+        return null;
+    }
+
+    public EntityManager getEntityManager() {
+        ApplicationRegistry applicationRegistry = getRegistry();
+        ApplicationInfo applicationInfo = applicationRegistry.get(this.applicationName);
+        List<EntityManagerFactory> factoryList = applicationInfo.getTransientAppMetaData(EntityManagerFactory.class.toString(), List.class);
+        if (factoryList.size() == 1) {
+            EntityManagerFactory factory = factoryList.get(0);
+            return factory.createEntityManager();
+        }
+        return null;
     }
 
 }

--- a/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/JPADeployer.java
+++ b/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/JPADeployer.java
@@ -482,6 +482,7 @@ public class JPADeployer extends SimpleDeployer<JPAContainer, JPApplicationConta
      * @param context
      */
     private void iterateInitializedPUsAtApplicationPrepare(final DeploymentContext context) {
+        
         final DeployCommandParameters deployCommandParameters = context.getCommandParameters(DeployCommandParameters.class);
         String appName = deployCommandParameters.name;
         final ApplicationInfo appInfo = applicationRegistry.get(appName);

--- a/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/JPADeployer.java
+++ b/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/JPADeployer.java
@@ -482,7 +482,6 @@ public class JPADeployer extends SimpleDeployer<JPAContainer, JPApplicationConta
      * @param context
      */
     private void iterateInitializedPUsAtApplicationPrepare(final DeploymentContext context) {
-        
         final DeployCommandParameters deployCommandParameters = context.getCommandParameters(DeployCommandParameters.class);
         String appName = deployCommandParameters.name;
         final ApplicationInfo appInfo = applicationRegistry.get(appName);

--- a/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/JPADeployer.java
+++ b/appserver/persistence/jpa-container/src/main/java/org/glassfish/persistence/jpa/JPADeployer.java
@@ -482,7 +482,6 @@ public class JPADeployer extends SimpleDeployer<JPAContainer, JPApplicationConta
      * @param context
      */
     private void iterateInitializedPUsAtApplicationPrepare(final DeploymentContext context) {
-
         final DeployCommandParameters deployCommandParameters = context.getCommandParameters(DeployCommandParameters.class);
         String appName = deployCommandParameters.name;
         final ApplicationInfo appInfo = applicationRegistry.get(appName);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

Adding implementation of simple CRUD operations using jakarta data interfaces

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

This is a feature to include the execution of CRUD operations using the Jakarta Data interfaces

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

Manual testing using the following r
[JakartaDataReproducer.zip](https://github.com/user-attachments/files/19769500/JakartaDataReproducer.zip)
eproducer:



The current implementation on the server can resolve the following operation for a simple entity on the default database on Payara Server:

We need a class  on an application that implements the CrudRepository interface and also this interface should need to be annotated by the annotation @Repository, here the example:

![image](https://github.com/user-attachments/assets/decd22fa-38a1-47aa-96a3-5b1d03720b04)

where the Author is a valid entity defined on the application that follows Jakarta Persistence rules for its definition

then on the application we can define endpoints to use our interface as follows:

![image](https://github.com/user-attachments/assets/284e137c-be01-44ea-8ed5-43d36c9ae18a)

we need to inject the interface to use the methods provided by the Jakarta Data interfaces. From the reproducer we have the following endpoints to interact with the database using Jakarta Data CRUD operation:

This will insert a new entity on the database
- http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/hello-world/insert
This will save a new entity on the database
- http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/hello-world/save
This will update the indicated id for an entity
- http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/hello-world/update/1
this will delete the indicated id from the database
- http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/hello-world/delete/1
this will get all available entities from the database
- http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/hello-world/find

For now the implementation is using default embedded H2 database from the server. You can create a connection to the database to verify the previous behavior described here:

create a connection to the default  location of the embedded database

`
C:/java/projects/Payara/appserver/distributions/payara/target/stage/payara7/glassfish/domains/domain1/lib/databases/embedded_default.mv.db
`

![image](https://github.com/user-attachments/assets/3748c561-15c2-4c4f-b94a-6fd1bf956452)

then execute querys to verify results from each operation

![image](https://github.com/user-attachments/assets/f1fee35a-0d4d-4449-9da8-48cdca6f6aa0)


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11,  zulu 21 jdk, maven 3.9.5
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
