### PR TITLE
FISH-10876 Fix error page property parsing

### DIFF
--- a/appserver/tests/payara-samples/micro-programmatic/pom.xml
+++ b/appserver/tests/payara-samples/micro-programmatic/pom.xml
@@ -38,6 +38,25 @@
             <artifactId>shrinkwrap-impl-base</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
+            <version>1.1.7</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/appserver/tests/payara-samples/micro-programmatic/src/test/java/fish/payara/samples/programatic/CustomErrorPageTest.java
+++ b/appserver/tests/payara-samples/micro-programmatic/src/test/java/fish/payara/samples/programatic/CustomErrorPageTest.java
@@ -1,0 +1,102 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2021 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.programatic;
+
+import fish.payara.micro.ClusterCommandResult;
+import fish.payara.micro.PayaraMicro;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+
+public class CustomErrorPageTest {
+
+    private static final String HOST_NAME = System.getProperty("payara.adminHost", "localhost");
+    private static final String CUSTOM_ERROR_PAGE_REPSONSE = "<!DOCTYPE html>\n"
+            + "<html lang=\"en\">\n"
+            + "<head>\n"
+            + "    <meta charset=\"UTF-8\">\n"
+            + "    <title>Page Not Found</title>\n"
+            + "</head>\n"
+            + "<body>\n"
+            + "    <h1>Oops! This page does not exist.</h1>\n"
+            + "</body>\n"
+            + "</html>\n";
+
+    private static final String ERROR_PAGE_REPSONSE = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>Payara Micro 6.2025.5- Error report</title><style type=\"text/css\"><!--H1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} H2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} H3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} BODY {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;}  B {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} P{font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;}A {color : black;}HR {color : #525D76;}--></style> </head><body><h1>HTTP Status 404 - </h1><hr/><p><b>type</b> Status report </p><p><b>message </b></p><p><b>description </b>The requested resource is not available.</p><hr/><h3>Payara Micro 6.2025.5</h3></body></html>";
+
+
+    @Test
+    public void customErrorPageIsSet() throws Exception {
+        PayaraMicro micro = PayaraMicro.getInstance();
+        micro.setPreBootHandler(t -> {
+            ClusterCommandResult result = t.run("set", "configs.config.server-config.http-service.virtual-server.server.property.send-error_1=\"code=404 path=src/test/resources/custom-404.html reason=not_found\"");
+            Assert.assertEquals(ClusterCommandResult.ExitStatus.SUCCESS, result.getExitStatus());
+            Assert.assertNull(result.getFailureCause());
+        });
+        micro.setHttpAutoBind(true);
+        micro.bootStrap();
+        Assert.assertEquals(CUSTOM_ERROR_PAGE_REPSONSE, download());
+        micro.shutdown();
+    }
+
+    @Test
+    public void defaultErrorPage() throws Exception {
+        PayaraMicro micro = PayaraMicro.getInstance();
+        micro.setHttpAutoBind(true);
+        micro.bootStrap();
+        Assert.assertEquals(ERROR_PAGE_REPSONSE, download());
+        micro.shutdown();
+    }
+
+    private String download() throws Exception {
+        HttpClient httpClient = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://" + CustomErrorPageTest.HOST_NAME + ":8080" + "/"))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.body();
+    }
+
+}

--- a/appserver/tests/payara-samples/micro-programmatic/src/test/java/fish/payara/samples/programatic/DataGridTest.java
+++ b/appserver/tests/payara-samples/micro-programmatic/src/test/java/fish/payara/samples/programatic/DataGridTest.java
@@ -1,12 +1,14 @@
 package fish.payara.samples.programatic;
 
-import com.hazelcast.core.*;
-import com.hazelcast.map.*;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import javax.servlet.annotation.*;
-import javax.servlet.http.*;
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
 
 @WebServlet(urlPatterns = "/cache-provider")
 public class DataGridTest extends HttpServlet {

--- a/appserver/tests/payara-samples/micro-programmatic/src/test/java/fish/payara/samples/programatic/StartPayaraMicroWithNoClusterTest.java
+++ b/appserver/tests/payara-samples/micro-programmatic/src/test/java/fish/payara/samples/programatic/StartPayaraMicroWithNoClusterTest.java
@@ -1,12 +1,18 @@
 package fish.payara.samples.programatic;
 
-import com.hazelcast.core.*;
-import fish.payara.micro.*;
-import org.junit.*;
+import fish.payara.micro.BootstrapException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 public class StartPayaraMicroWithNoClusterTest
 {
@@ -39,10 +45,20 @@ public class StartPayaraMicroWithNoClusterTest
   }
 
   private static File createWar() {
-    return ShrinkWrap.create(WebArchive.class, "test.war")
-      .addClass(DataGridTest.class)
-      .addAsLibraries(
-        Maven.resolver().resolve("org.apache.commons:commons-lang3:3.12.0")
-          .withTransitivity().asFile());
+    WebArchive war = ShrinkWrap.create(WebArchive.class, "test.war")
+            .addClass(DataGridTest.class)
+            .addAsLibraries(
+                    Maven.resolver().resolve("org.apache.commons:commons-lang3:3.12.0")
+                            .withTransitivity().asFile()
+            );
+      File warFile = null;
+      try {
+          warFile = File.createTempFile(DataGridTest.class.getSimpleName(), "test.war");
+      } catch (IOException e) {
+          throw new RuntimeException(e);
+      }
+      warFile.deleteOnExit();
+    war.as(ZipExporter.class).exportTo(warFile, true);
+    return warFile;
   }
 }

--- a/appserver/tests/payara-samples/micro-programmatic/src/test/resources/custom-404.html
+++ b/appserver/tests/payara-samples/micro-programmatic/src/test/resources/custom-404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Page Not Found</title>
+</head>
+<body>
+    <h1>Oops! This page does not exist.</h1>
+</body>
+</html>

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
@@ -38,7 +38,7 @@
  * holder.
  */
 
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package com.sun.enterprise.web;
 
@@ -1166,6 +1166,7 @@ public class VirtualServer extends StandardHost implements org.glassfish.embedda
                 _logger.log(Level.WARNING, LogFacade.NULL_VIRTUAL_SERVER_PROPERTY, getID());
                 continue;
             }
+            propValue = propValue.replace("\"", "");
 
             if (!propName.startsWith("send-error_")) {
                 continue;

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
@@ -1166,7 +1166,10 @@ public class VirtualServer extends StandardHost implements org.glassfish.embedda
                 _logger.log(Level.WARNING, LogFacade.NULL_VIRTUAL_SERVER_PROPERTY, getID());
                 continue;
             }
-            propValue = propValue.replace("\"", "");
+
+            if (propValue.startsWith("\"") && propValue.endsWith("\"")) {
+                propValue = propValue.substring(1, propValue.length() - 1);
+            }
 
             if (!propName.startsWith("send-error_")) {
                 continue;


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
When specifying a custom error page within a preboot file, this wouldn't work due to the property being parsed incorrectly.

This PR will strip the property value of any additional quotation marks.

i.e.
property = "code=500 reason=example path=/wibbles/wobbles.html"
will result in = code=500 reason=example path=/wibbles/wobbles.html

Note the stripped quotation marks.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
Created payara micro programmatic test 

go to payara-samples directory and run `mvn clean verify -Ppayara-micro-managed -Dpayara.version=6.2025.5-SNAPSHOT -Dtest=CustomErrorPageTest` (might have to comment out other modules)
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
1. Created a 404 html page somewhere on my local device.
2. Created preboot command to specify the property:
`set configs.config.server-config.http-service.virtual-server.server.property.send-error_1="code=404 path=/Users/kalinchan/Downloads/custom-404.html reason=not_found"`
3. Ran payara-micro
`java -jar payara-micro.jar --prebootcommandfile preboot.txt --deploy clusterjsp.war`
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
Payara-micro-progamattic tests wouldn't compile so made some changes to fix that 

There are also some issues with payara-micro-programmatic, but that is another issue
