### PR TITLE
FISH-10805 Remove Semantic Versioning Check from Payara Core

### DIFF
--- a/core/core-parent/pom.xml
+++ b/core/core-parent/pom.xml
@@ -568,70 +568,8 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${maven.build.helper.plugin.version}</version>
                 </plugin>
-                <plugin>
-                    <groupId>com.github.siom79.japicmp</groupId>
-                    <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>${japicmp.maven.plugin.version}</version>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>
-    
-    <profiles>
-        <profile>
-            <id>force-semver</id>
-            <!-- Force semantic versioning. The differences are in target/japicmp in text, html and xml -->
-            <activation>
-                <property>
-                    <!-- Active unless explicitly set to false -->
-                    <name>core.force.semver</name>
-                    <value>!false</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.siom79.japicmp</groupId>
-                        <artifactId>japicmp-maven-plugin</artifactId>
-                        <configuration>
-                            <!-- Use the latest published version. It's necessary to use specific version because subprojects using glassfish-jar cannot be found. -->
-                            <oldVersion> 
-                                <dependency>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>${project.artifactId}</artifactId>
-                                    <version>${payara.core.compare-version}</version>
-                                    <type>jar</type>
-                                </dependency>
-                            </oldVersion>
-                            <!-- Use the current version. It's necessary to use <file> because subprojects using glassfish-jar cannot be found.-->
-                            <newVersion>
-                                <file>
-                                    <path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
-                                </file>
-                            </newVersion>
-                            <parameter>
-                                <!-- see documentation https://siom79.github.io/japicmp/MavenPlugin.html -->
-                                <ignoreMissingClasses>true</ignoreMissingClasses>
-                                <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
-                                <excludes>
-                                    <exclude>io.opentelemetry.extension</exclude>
-                                    <exclude>io.opentelemetry.instrumentation</exclude>
-                                    <exclude>fish.payara.shaded</exclude>
-                                </excludes>
-                            </parameter>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>cmp</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -186,7 +186,6 @@
         <hk2.plugin.version>3.0.2</hk2.plugin.version>
         <maven.build.helper.plugin.version>3.6.0</maven.build.helper.plugin.version>
         <maven.flatten.plugin.version>1.7.0</maven.flatten.plugin.version>
-        <japicmp.maven.plugin.version>0.23.1</japicmp.maven.plugin.version>
 
         <!-- build settings -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Description
The experiment is over, we have decided that getting the codebase into a less monolithic state with individually versioning APIs and modules is too much effort, and even when complete adds a lot of mental overhead for all of the different versions of Enterprise we support and adds complexity to any attempt to stagger changes between Community and Enterprise.

This is the first PR of a few which will look to remove the concept of Core vs. Server.
Step 1 (FISH-10805) - removing the semantic versioning enforcement we have.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* Built the server - no errors.
* Made a breaking API change and compiled the module - no errors

### Testing Environment
Windows 11, Maven 3.9.9, Zulu Java 11.0.26

## Documentation
_Pending..._

## Notes for Reviewers
None
