### PR TITLE
FISH-11003 Correct `deploy.skip` Property Value

### DIFF
--- a/appserver/admin/backup-l10n/pom.xml
+++ b/appserver/admin/backup-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admin/cli-optional-l10n/pom.xml
+++ b/appserver/admin/cli-optional-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/admingui/cdieventbus-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/cdieventbus-notifier-console-plugin-l10n/pom.xml
@@ -39,6 +39,7 @@
   only if the new code is made subject to such option by the copyright
   holder.
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
 
 

--- a/appserver/admingui/cluster-l10n/pom.xml
+++ b/appserver/admingui/cluster-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
 
     <build>

--- a/appserver/admingui/common-l10n/pom.xml
+++ b/appserver/admingui/common-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -56,7 +56,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
 
     <build>

--- a/appserver/admingui/concurrent-l10n/pom.xml
+++ b/appserver/admingui/concurrent-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
 
     <build>

--- a/appserver/admingui/corba-l10n/pom.xml
+++ b/appserver/admingui/corba-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
 
     <build>

--- a/appserver/admingui/core-l10n/pom.xml
+++ b/appserver/admingui/core-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/ejb-l10n/pom.xml
+++ b/appserver/admingui/ejb-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/ejb-lite-l10n/pom.xml
+++ b/appserver/admingui/ejb-lite-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/eventbus-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/eventbus-notifier-console-plugin-l10n/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. 
+  Copyright (c) 2018-2025 Payara Foundation and/or its affiliates.
   All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
@@ -53,7 +53,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     

--- a/appserver/admingui/full-l10n/pom.xml
+++ b/appserver/admingui/full-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
 
     <build>

--- a/appserver/admingui/healthcheck-service-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/healthcheck-service-console-plugin-l10n/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. 
+  Copyright (c) 2018-2025 Payara Foundation and/or its affiliates.
   All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
@@ -53,7 +53,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     

--- a/appserver/admingui/jca-l10n/pom.xml
+++ b/appserver/admingui/jca-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/jdbc-l10n/pom.xml
+++ b/appserver/admingui/jdbc-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/jms-notifier-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/jms-notifier-console-plugin-l10n/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. 
+  Copyright (c) 2018-2025 Payara Foundation and/or its affiliates.
   All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
@@ -53,7 +53,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     

--- a/appserver/admingui/jms-plugin-l10n/pom.xml
+++ b/appserver/admingui/jms-plugin-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/jmx-monitoring-plugin-l10n/pom.xml
+++ b/appserver/admingui/jmx-monitoring-plugin-l10n/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. 
+  Copyright (c) 2018-2025 Payara Foundation and/or its affiliates.
   All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
@@ -53,7 +53,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     

--- a/appserver/admingui/jts-l10n/pom.xml
+++ b/appserver/admingui/jts-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/microprofile-console-plugin-l10n/pom.xml
+++ b/appserver/admingui/microprofile-console-plugin-l10n/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. 
+  Copyright (c) 2018-2025 Payara Foundation and/or its affiliates.
   All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
@@ -53,7 +53,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     

--- a/appserver/admingui/payara-console-extras-l10n/pom.xml
+++ b/appserver/admingui/payara-console-extras-l10n/pom.xml
@@ -3,7 +3,7 @@
 
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
- Copyright (c) 2016-2019 Payara Foundation. All rights reserved.
+ Copyright (c) 2016-2025 Payara Foundation. All rights reserved.
 
  The contents of this file are subject to the terms of the Common Development
  and Distribution License("CDDL") (collectively, the "License").  You
@@ -30,7 +30,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/payara-theme-l10n/pom.xml
+++ b/appserver/admingui/payara-theme-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/web-l10n/pom.xml
+++ b/appserver/admingui/web-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/webui-jsf-plugin-l10n/pom.xml
+++ b/appserver/admingui/webui-jsf-plugin-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -54,7 +54,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/admingui/webui-jsf-suntheme-plugin-l10n/pom.xml
+++ b/appserver/admingui/webui-jsf-suntheme-plugin-l10n/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!--"Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -54,7 +54,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/appclient/client/acc-l10n/pom.xml
+++ b/appserver/appclient/client/acc-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/appclient/client/acc-standalone-l10n/pom.xml
+++ b/appserver/appclient/client/acc-standalone-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -52,7 +53,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/appclient/server/core-l10n/pom.xml
+++ b/appserver/appclient/server/core-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/common/annotation-framework-l10n/pom.xml
+++ b/appserver/common/annotation-framework-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/common/container-common-l10n/pom.xml
+++ b/appserver/common/container-common-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/common/glassfish-naming-l10n/pom.xml
+++ b/appserver/common/glassfish-naming-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -54,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
      <developers>

--- a/appserver/common/stats77-l10n/pom.xml
+++ b/appserver/common/stats77-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/concurrent/concurrent-connector-l10n/pom.xml
+++ b/appserver/concurrent/concurrent-connector-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/concurrent/concurrent-impl-l10n/pom.xml
+++ b/appserver/concurrent/concurrent-impl-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/connectors/admin-l10n/pom.xml
+++ b/appserver/connectors/admin-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/connectors/connectors-inbound-runtime-l10n/pom.xml
+++ b/appserver/connectors/connectors-inbound-runtime-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -56,7 +57,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/connectors/connectors-internal-api-l10n/pom.xml
+++ b/appserver/connectors/connectors-internal-api-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -55,7 +56,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/connectors/connectors-runtime-l10n/pom.xml
+++ b/appserver/connectors/connectors-runtime-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/connectors/work-management-l10n/pom.xml
+++ b/appserver/connectors/work-management-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -54,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
      <developers>

--- a/appserver/deployment/client-l10n/pom.xml
+++ b/appserver/deployment/client-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
 
     <developers>

--- a/appserver/deployment/dol-l10n/pom.xml
+++ b/appserver/deployment/dol-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/deployment/javaee-core-l10n/pom.xml
+++ b/appserver/deployment/javaee-core-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <developers>

--- a/appserver/deployment/javaee-full-l10n/pom.xml
+++ b/appserver/deployment/javaee-full-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -55,7 +56,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/ejb/ejb-connector-l10n/pom.xml
+++ b/appserver/ejb/ejb-connector-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/ejb/ejb-container-l10n/pom.xml
+++ b/appserver/ejb/ejb-container-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/jdbc/admin-l10n/pom.xml
+++ b/appserver/jdbc/admin-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/jdbc/jdbc-config-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-config-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/jdbc/jdbc-ra/jdbc-core-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-core-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/jdbc/jdbc-runtime-l10n/pom.xml
+++ b/appserver/jdbc/jdbc-runtime-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/jms/admin-l10n/pom.xml
+++ b/appserver/jms/admin-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/jms/gf-jms-connector-l10n/pom.xml
+++ b/appserver/jms/gf-jms-connector-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/jms/gf-jms-injection-l10n/pom.xml
+++ b/appserver/jms/gf-jms-injection-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/jms/jms-core-l10n/pom.xml
+++ b/appserver/jms/jms-core-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/load-balancer/admin-l10n/pom.xml
+++ b/appserver/load-balancer/admin-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -56,7 +56,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/load-balancer/gf-load-balancer-connector-l10n/pom.xml
+++ b/appserver/load-balancer/gf-load-balancer-connector-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -55,7 +56,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/orb/orb-connector-l10n/pom.xml
+++ b/appserver/orb/orb-connector-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/osgi-platforms/glassfish-osgi-console-plugin-l10n/pom.xml
+++ b/appserver/osgi-platforms/glassfish-osgi-console-plugin-l10n/pom.xml
@@ -41,7 +41,7 @@
 
 -->
 
-<!-- "Portions Copyright [2016-2019] [Payara Foundation]" -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -58,7 +58,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
@@ -2,7 +2,7 @@
 <!--
   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-  Copyright (c) [2016-2022] Payara Foundation and/or its affiliates. All rights reserved.
+  Copyright (c) 2016-2025 Payara Foundation and/or its affiliates. All rights reserved.
 
   The contents of this file are subject to the terms of either the GNU
   General Public License Version 2 only ("GPL") or the Common Development
@@ -53,8 +53,6 @@
     
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <dependencies>

--- a/appserver/persistence/cmp-l10n/ejb-mapping-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/ejb-mapping-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/persistence/cmp-l10n/enhancer-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/enhancer-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/persistence/cmp-l10n/generator-database-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/generator-database-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/persistence/cmp-l10n/model-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/model-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/persistence/cmp-l10n/support-ejb-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/support-ejb-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/persistence/cmp-l10n/support-sqlstore-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/support-sqlstore-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/persistence/cmp-l10n/utility-l10n/pom.xml
+++ b/appserver/persistence/cmp-l10n/utility-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/persistence/jpa-container-l10n/pom.xml
+++ b/appserver/persistence/jpa-container-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/registration/registration-impl-l10n/pom.xml
+++ b/appserver/registration/registration-impl-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/resources/javamail/javamail-connector-l10n/pom.xml
+++ b/appserver/resources/javamail/javamail-connector-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -56,7 +57,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/resources/resources-connector-l10n/pom.xml
+++ b/appserver/resources/resources-connector-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -55,7 +56,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/security/core-ee-l10n/pom.xml
+++ b/appserver/security/core-ee-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -55,7 +56,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/security/webservices.security-l10n/pom.xml
+++ b/appserver/security/webservices.security-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/transaction/internal-api-l10n/pom.xml
+++ b/appserver/transaction/internal-api-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/transaction/jta-l10n/pom.xml
+++ b/appserver/transaction/jta-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/transaction/jts-l10n/pom.xml
+++ b/appserver/transaction/jts-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
 
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/web/admin-l10n/pom.xml
+++ b/appserver/web/admin-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/web/gui-plugin-common-l10n/pom.xml
+++ b/appserver/web/gui-plugin-common-l10n/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -55,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/web/war-util-l10n/pom.xml
+++ b/appserver/web/war-util-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/web/web-core-l10n/pom.xml
+++ b/appserver/web/web-core-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/web/web-glue-l10n/pom.xml
+++ b/appserver/web/web-glue-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -55,7 +56,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/web/web-naming-l10n/pom.xml
+++ b/appserver/web/web-naming-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/webservices/connector-l10n/pom.xml
+++ b/appserver/webservices/connector-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/appserver/webservices/jsr109-impl-l10n/pom.xml
+++ b/appserver/webservices/jsr109-impl-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
     </properties>
     
     <build>

--- a/nucleus/admin/cli-l10n/pom.xml
+++ b/nucleus/admin/cli-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/admin/config-api-l10n/pom.xml
+++ b/nucleus/admin/config-api-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/admin/launcher-l10n/pom.xml
+++ b/nucleus/admin/launcher-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/admin/monitor-l10n/pom.xml
+++ b/nucleus/admin/monitor-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/admin/rest/rest-service-l10n/pom.xml
+++ b/nucleus/admin/rest/rest-service-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/admin/server-mgmt-l10n/pom.xml
+++ b/nucleus/admin/server-mgmt-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/admin/util-l10n/pom.xml
+++ b/nucleus/admin/util-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/cluster/admin-l10n/pom.xml
+++ b/nucleus/cluster/admin-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/cluster/cli-l10n/pom.xml
+++ b/nucleus/cluster/cli-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/cluster/common-l10n/pom.xml
+++ b/nucleus/cluster/common-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/cluster/ssh-l10n/pom.xml
+++ b/nucleus/cluster/ssh-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/cluster/uc-l10n/pom.xml
+++ b/nucleus/cluster/uc-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/common/common-util-l10n/pom.xml
+++ b/nucleus/common/common-util-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/common/glassfish-api-l10n/pom.xml
+++ b/nucleus/common/glassfish-api-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/common/internal-api-l10n/pom.xml
+++ b/nucleus/common/internal-api-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/common/mbeanserver-l10n/pom.xml
+++ b/nucleus/common/mbeanserver-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -54,7 +55,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/core/kernel-l10n/pom.xml
+++ b/nucleus/core/kernel-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/core/logging-l10n/pom.xml
+++ b/nucleus/core/logging-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,8 +54,7 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
-        <build.info.exclude>true</build.info.exclude>        
+        <build.info.exclude>true</build.info.exclude>
     </properties>
     
     <build>

--- a/nucleus/deployment/admin-l10n/pom.xml
+++ b/nucleus/deployment/admin-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/deployment/autodeploy-l10n/pom.xml
+++ b/nucleus/deployment/autodeploy-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/deployment/common-l10n/pom.xml
+++ b/nucleus/deployment/common-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright [2016-2019] [Payara Foundation] -->
+<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
 <!--
   modules used to build glassfish packages
 -->
@@ -77,7 +77,6 @@
     </developers>
 
     <properties>
-        <deploy.skip>true</deploy.skip>
         <stage.dir.name>stage</stage.dir.name>
         <stage.dir>${project.build.directory}/${stage.dir.name}</stage.dir>
         <temp.dir>${project.build.directory}/dependency</temp.dir>

--- a/nucleus/flashlight/framework-l10n/pom.xml
+++ b/nucleus/flashlight/framework-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/osgi-platforms/osgi-cli-interactive-l10n/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-interactive-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -55,7 +56,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/osgi-platforms/osgi-cli-remote-l10n/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-remote-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -56,7 +56,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>        
     </properties>
     

--- a/nucleus/packager/nucleus-cluster-l10n/pom.xml
+++ b/nucleus/packager/nucleus-cluster-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -53,7 +54,6 @@
     <packaging>distribution-fragment</packaging>
 
     <properties>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude> 
     </properties>
 

--- a/nucleus/packager/nucleus-common-l10n/pom.xml
+++ b/nucleus/packager/nucleus-common-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -53,7 +54,6 @@
     <packaging>distribution-fragment</packaging>
 
     <properties>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude> 
     </properties>
     

--- a/nucleus/packager/nucleus-l10n/pom.xml
+++ b/nucleus/packager/nucleus-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -53,7 +54,6 @@
     <packaging>distribution-fragment</packaging>
 
     <properties>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude> 
     </properties>
     

--- a/nucleus/packager/nucleus-management-l10n/pom.xml
+++ b/nucleus/packager/nucleus-management-l10n/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -53,7 +54,6 @@
     <packaging>distribution-fragment</packaging>
     
     <properties>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
 

--- a/nucleus/resources-l10n/pom.xml
+++ b/nucleus/resources-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -55,7 +56,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/security/core-l10n/pom.xml
+++ b/nucleus/security/core-l10n/pom.xml
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2019] [Payara Foundation and/or its affiliates]
+    Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -54,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/nucleus/security/services-l10n/pom.xml
+++ b/nucleus/security/services-l10n/pom.xml
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
@@ -53,7 +54,6 @@
     
     <properties>
         <javadoc.skip>true</javadoc.skip>
-        <deploy.skip>true</deploy.skip>
         <build.info.exclude>true</build.info.exclude>
     </properties>
     

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jdk.version>11</jdk.version>
         <javase.version>${jdk.version}</javase.version>
-        <deploy.skip>false</deploy.skip>
+        <deploy.skip>true</deploy.skip>
         <javadoc.skip>true</javadoc.skip>
         <source.skip>true</source.skip>
 


### PR DESCRIPTION
## Description
Fixes the `deploy.skip` property value, removing duplicates.
The end result is that deployment is now skipped for all artefacts other than the distributions:
* payara
* payara-ml
* payara-web
* payara-web-ml
* payara-micro
* payara-embedded-all
* payara-embedded-web
* payara-api
* payara-bom
* ejb-http-client

## Important Info
### Blockers
Based on top of https://github.com/payara/Payara/pull/7308

## Testing
### New tests
None

### Testing Performed
Made a test local repo: `mkdir D:\Downloads\Maven2`
Made a test deployment directory: `mkdir D:\Downloads\Maven3`
Built the server, using the created repo and deployment directories: `mvn clean deploy -PBuildEmbedded "-Dmaven.repo.local=D:\Downloads\Maven2" -DskipTests "-DaltDeploymentRepository=local::file:///D:\Downloads\Maven3" -T 1C`
Checked inside of `D:\Downloads\Maven3` - only the expected artefacts are deployed.

### Testing Environment
Windows 11, Maven 3.9.9, Zulu 11.0.26

## Documentation
N/A

## Notes for Reviewers
Review https://github.com/payara/Payara/pull/7308 first, then I will rebase
