### PR TITLE
FISH-10958 Invalid Password Location Handling

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
@@ -368,6 +368,17 @@ public class DomainBuilder {
         Boolean saveMasterPassword = (Boolean) domainConfig.get(DomainConfig.K_SAVE_MASTER_PASSWORD);
         String mpLocation = (String)domainConfig.get(DomainConfig.K_MASTER_PASSWORD_LOCATION);
 
+        File mpFile = new File(configDir, DomainConstants.MASTERPASSWORD_FILE);
+        if (mpLocation != null) {
+            File mpLocationFile = new File(configDir, DomainConstants.MASTERPASSWORD_LOCATION_FILE);
+            try (FileWriter writer = new FileWriter(mpLocationFile)) {
+                writer.write(mpLocation);
+                mpFile = new File(mpLocation);
+            } catch (IOException e) {
+                throw new IOException(STRINGS.get("masterPasswordNotSaved"), e);
+            }
+        }
+
         // Process domain security.
         DomainSecurity domainSecurity = new DomainSecurity();
         domainSecurity.processAdminKeyFile(new File(configDir, DomainConstants.ADMIN_KEY_FILE), user, password, adminUserGroups);
@@ -386,19 +397,6 @@ public class DomainBuilder {
                 if (fos != null) {
                     fos.close();
                 }
-            }
-        }
-
-        File mpFile = new File(configDir, DomainConstants.MASTERPASSWORD_FILE);
-        if (mpLocation != null) {
-            File mpLocationFile = new File(configDir, DomainConstants.MASTERPASSWORD_LOCATION_FILE);
-            try (FileWriter writer = new FileWriter(mpLocationFile)) {
-                writer.write(mpLocation);
-                mpFile = new File(mpLocation);
-            } catch (IOException e) {
-                LOGGER.log(Level.SEVERE,
-                    "Failed to write master-password-location file, using default location due to error: ",
-                    e.getMessage());
             }
         }
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/LocalStrings.properties
@@ -75,6 +75,7 @@ listDomainElement={0} {1}
 
 
 masterPasswordNotChanged=Error changing master password
+masterPasswordNotSaved=Error writing master password file
 
 cannotChangePassword_invalidState=Could not change password for domain {0}. Domain is {1}.
 

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEDomainsManager.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/pe/PEDomainsManager.java
@@ -236,6 +236,28 @@ public class PEDomainsManager extends RepositoryManager implements DomainsManage
             String newPass = getNewMasterPasswordClear(config);
             String mpLocation = getNewMasterPasswordLocation(config);
             boolean saveMp = saveMasterPassword(config);
+
+            // valid: exists and is a directory (creates new file)
+            // valid: exists and you can write here
+            // valid: does not exist, but the parent is a directory (creates new file)
+
+            // invalid: exists and you cannot write here
+            // invalid: does not exist, parent directory also does not exist
+
+            // Validate master password location (a valid password requires a writable file, or an existing directory)
+            if (mpLocation != null) {
+                File passwordFile = new File(mpLocation);
+                if (passwordFile.exists()) {
+                    if (!passwordFile.isDirectory() && !passwordFile.canWrite()) {
+                        throw new RepositoryException(STRINGS_MANAGER.getString("masterPasswordNotSaved") +
+                            ": No write access at this location.");
+                    }
+                }
+                else if (passwordFile.getParentFile() == null || !passwordFile.getParentFile().isDirectory()) {
+                    throw new RepositoryException(STRINGS_MANAGER.getString("masterPasswordNotSaved") +
+                        ": Directory not found.");
+                }
+            }
             
             //Change the password of the keystore alias file
             changePasswordAliasKeystorePassword(config, oldPass, newPass);

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/CreateLocalInstanceCommand.java
@@ -390,8 +390,7 @@ public final class CreateLocalInstanceCommand extends CreateLocalInstanceFilesys
                 writer.write(mpLocation);
                 pwdFile = new File(mpLocation);
             } catch (IOException e) {
-                Logger.getAnonymousLogger().log(Level.SEVERE,
-                    "Failed to write master-password-location, using default location due to error: ", e);
+                throw new CommandException(Strings.get("masterPasswordFileNotCreated", pwdFile), e);
             }
         }
 

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalStrings.properties
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/LocalStrings.properties
@@ -104,6 +104,8 @@ Instance.DasConfig=Node {0} is configured to connect to DAS on {1}:{2} with secu
 create.local.instance.usagetext=create-local-instance\n\t[--config <config> | --cluster <cluster>]\n\t[--lbenabled[=<lbenabled>]]\n\t[--systemproperties <systemproperties>] [--portbase <portbase>]\n\t[--checkports[=<checkports(default:true)>]]\n\t[--savemasterpassword[=<savemasterpassword(default:false)>]]\n\t[--nodedir <nodedir>] [--node <node>]\n\t[-?|--help[=<help(default:false)>]] instance_name
 Instance.alreadyExists=A Server instance with a "{0}" name already exists in the configuration
 masterPasswordFileNotCreated=Error creating master password file {0}
+masterPasswordFileLocationNotSaved=Error creating master password location file
+masterPasswordFileLocationNotDeleted=Error removing old master password location file
 fileNotFound=File {0} not found.
 MasterPassword=Enter the master password
 MasterPasswordAgain=Enter the master password again


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-10958
  - If the user supplies an invalid master password location, the command will fail before changing the master password.
  - Additionally applied a similar change to `create-domain` and `create-local-instance`.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
-Followed the reproducer: attempt to change password with a non-existent master password path, check the command output, check if the password has still been changed.
- Attempt to create a domain with an invalid master password location, command fails and no domain is created.
- Attempt to create a local instance with an invalid master password location, command fails and no instance is created.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 11.0.23, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
