### PR TITLE
Move `payara-nexus-staging` Repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,16 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
+            <releases>
+                <enabled>${payara-nexus-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${payara-nexus-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -145,6 +155,16 @@
             </releases>
             <snapshots>
                 <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
+            <releases>
+                <enabled>${payara-nexus-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${payara-nexus-staging.repo.snapshots.enabled}</enabled>
             </snapshots>
         </pluginRepository>
     </pluginRepositories>
@@ -215,6 +235,8 @@
         <deploy.skip>false</deploy.skip>
         <javadoc.skip>true</javadoc.skip>
         <source.skip>true</source.skip>
+        <payara-nexus-staging.repo.releases.enabled>false</payara-nexus-staging.repo.releases.enabled>
+        <payara-nexus-staging.repo.snapshots.enabled>false</payara-nexus-staging.repo.snapshots.enabled>
 
         <!-- BOM-referenced versions -->
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
@@ -448,30 +470,10 @@
 
         <profile>
             <id>payara-nexus-staging</id>
-            <repositories>
-                <repository>
-                    <id>payara-nexus-staging</id>
-                    <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>payara-nexus-staging</id>
-                    <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
+            <properties>
+                <payara-nexus-staging.repo.releases.enabled>true</payara-nexus-staging.repo.releases.enabled>
+                <payara-nexus-staging.repo.snapshots.enabled>true</payara-nexus-staging.repo.snapshots.enabled>
+            </properties>
         </profile>
 
         <profile>


### PR DESCRIPTION
## Description
Moves the definition of this repository to the "default" repository block and has it enabled/disabled via properties. This keeps the repository order intact by having them polled after all of the standard set of repositories - when they are added by profile they get queried first.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Wiped local maven repo, built server with profile enabled, inspect logs - payara-nexus-staging is not queried first.

### Testing Environment
Windows 11, Maven 3.9.9, Zulu 11.0.26

## Documentation
N/A

## Notes for Reviewers
None
