### PR TITLE
FISH-10808 Remove "core" Group ID (Payara7)

### DIFF
--- a/appserver/admin/admin-core/pom.xml
+++ b/appserver/admin/admin-core/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.admin</groupId>
     <artifactId>admin-core</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -58,12 +57,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -79,7 +78,7 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/appserver/admin/backup/pom.xml
+++ b/appserver/admin/backup/pom.xml
@@ -87,12 +87,12 @@
                 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admin/cli-optional/pom.xml
+++ b/appserver/admin/cli-optional/pom.xml
@@ -131,37 +131,37 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>server-mgmt</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>launcher</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admin/cli/pom.xml
+++ b/appserver/admin/cli/pom.xml
@@ -89,7 +89,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/cdieventbus-notifier-console-plugin/pom.xml
+++ b/appserver/admingui/cdieventbus-notifier-console-plugin/pom.xml
@@ -76,7 +76,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/cluster/pom.xml
+++ b/appserver/admingui/cluster/pom.xml
@@ -77,25 +77,25 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/common-l10n/osgi.bundle
+++ b/appserver/admingui/common-l10n/osgi.bundle
@@ -38,6 +38,6 @@
 # holder.
 #
 
-# "Portions Copyright [2016-2019] [Payara Foundation]"
+# Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.admingui.console-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.admingui.console-common; bundle-version=${project.osgi.version}

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>admingui</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.admingui</groupId>
     <artifactId>console-common</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -75,13 +74,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-client</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -98,20 +97,20 @@
             <scope>provided</scope>
        </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>rest-client</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/concurrent/pom.xml
+++ b/appserver/admingui/concurrent/pom.xml
@@ -76,7 +76,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/corba/pom.xml
+++ b/appserver/admingui/corba/pom.xml
@@ -77,13 +77,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/core-l10n/osgi.bundle
+++ b/appserver/admingui/core-l10n/osgi.bundle
@@ -38,6 +38,6 @@
 # holder.
 #
 
-# "Portions Copyright [2016-2019] [Payara Foundation]"
+# Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.admingui.console-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.admingui.console-common; bundle-version=${project.osgi.version}

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -79,25 +79,25 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>dataprovider</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -108,7 +108,7 @@
             <version>${woodstock-jsf.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/dataprovider/pom.xml
+++ b/appserver/admingui/dataprovider/pom.xml
@@ -47,7 +47,6 @@
         <artifactId>admingui</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.admingui</groupId>
     <artifactId>dataprovider</artifactId>
     <name>DataProvider</name>
     <modelVersion>4.0.0</modelVersion>

--- a/appserver/admingui/devtests/pom.xml
+++ b/appserver/admingui/devtests/pom.xml
@@ -68,7 +68,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/appserver/admingui/ejb-lite/pom.xml
+++ b/appserver/admingui/ejb-lite/pom.xml
@@ -77,7 +77,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/ejb/pom.xml
+++ b/appserver/admingui/ejb/pom.xml
@@ -77,7 +77,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/eventbus-notifier-console-plugin/pom.xml
+++ b/appserver/admingui/eventbus-notifier-console-plugin/pom.xml
@@ -78,7 +78,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/faces-compat/pom.xml
+++ b/appserver/admingui/faces-compat/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.admingui</groupId>
     <artifactId>faces-compat</artifactId>
 
     <properties>
@@ -115,7 +114,7 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>dataprovider</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -126,27 +125,27 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/full/pom.xml
+++ b/appserver/admingui/full/pom.xml
@@ -73,19 +73,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/gf-admingui-connector/pom.xml
+++ b/appserver/admingui/gf-admingui-connector/pom.xml
@@ -48,7 +48,6 @@
         <artifactId>admingui</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.admingui</groupId>
     <artifactId>gf-admingui-connector</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -65,7 +64,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/healthcheck-service-console-plugin/pom.xml
+++ b/appserver/admingui/healthcheck-service-console-plugin/pom.xml
@@ -77,7 +77,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/jca/pom.xml
+++ b/appserver/admingui/jca/pom.xml
@@ -73,19 +73,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/jdbc/pom.xml
+++ b/appserver/admingui/jdbc/pom.xml
@@ -77,13 +77,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/jms-notifier-console-plugin/pom.xml
+++ b/appserver/admingui/jms-notifier-console-plugin/pom.xml
@@ -78,7 +78,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/jms-plugin/pom.xml
+++ b/appserver/admingui/jms-plugin/pom.xml
@@ -106,7 +106,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -124,13 +124,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/jmx-monitoring-plugin/pom.xml
+++ b/appserver/admingui/jmx-monitoring-plugin/pom.xml
@@ -84,7 +84,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/jts/pom.xml
+++ b/appserver/admingui/jts/pom.xml
@@ -77,7 +77,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/microprofile-console-plugin/pom.xml
+++ b/appserver/admingui/microprofile-console-plugin/pom.xml
@@ -78,7 +78,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/payara-console-extras/pom.xml
+++ b/appserver/admingui/payara-console-extras/pom.xml
@@ -79,26 +79,26 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/payara-enterprise-theme/pom.xml
+++ b/appserver/admingui/payara-enterprise-theme/pom.xml
@@ -130,12 +130,12 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/payara-theme/pom.xml
+++ b/appserver/admingui/payara-theme/pom.xml
@@ -129,12 +129,12 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/plugin-service/pom.xml
+++ b/appserver/admingui/plugin-service/pom.xml
@@ -48,7 +48,6 @@
         <artifactId>admingui</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.admingui</groupId>
     <artifactId>console-plugin-service</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -65,12 +64,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>gf-admingui-connector</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/reference-manual/pom.xml
+++ b/appserver/admingui/reference-manual/pom.xml
@@ -55,7 +55,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/rest-monitoring-plugin/pom.xml
+++ b/appserver/admingui/rest-monitoring-plugin/pom.xml
@@ -83,7 +83,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -102,8 +102,8 @@
                     <archive>
                         <manifestEntries>
                             <Glassfish-require-services>org.glassfish.api.admingui.ConsoleProvider</Glassfish-require-services>
-                            <HK2-Import-Bundles>fish.payara.server.core.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.core.admingui.console-plugin-service, fish.payara.server.core.deployment.deployment-client,
-                                jakarta.servlet-api,jakarta.servlet.jsp-api,org.glassfish.expressly,fish.payara.server.core.admingui.faces-compat,fish.payara.server.core.admingui.dataprovider,com.sun.pkg.client</HK2-Import-Bundles>
+                            <HK2-Import-Bundles>fish.payara.server.internal.admingui.console-common,org.glassfish.hk2.hk2,fish.payara.server.internal.admingui.console-plugin-service, fish.payara.server.internal.deployment.deployment-client,
+                                jakarta.servlet-api,jakarta.servlet.jsp-api,org.glassfish.expressly,fish.payara.server.internal.admingui.faces-compat,fish.payara.server.internal.admingui.dataprovider,com.sun.pkg.client</HK2-Import-Bundles>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -149,7 +149,7 @@
             <artifactId>woodstock-webui-jsf</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/admingui/web/pom.xml
+++ b/appserver/admingui/web/pom.xml
@@ -73,7 +73,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -84,36 +84,36 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>monitoring-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-client</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-gui-plugin-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/admingui/webui-jsf-plugin-l10n/osgi.bundle
+++ b/appserver/admingui/webui-jsf-plugin-l10n/osgi.bundle
@@ -38,6 +38,6 @@
 # holder.
 #
 
-# "Portions Copyright [2016-2019] [Payara Foundation]"
+# Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.admingui.console-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.admingui.console-common; bundle-version=${project.osgi.version}

--- a/appserver/admingui/webui-jsf-suntheme-plugin-l10n/osgi.bundle
+++ b/appserver/admingui/webui-jsf-suntheme-plugin-l10n/osgi.bundle
@@ -38,6 +38,6 @@
 # holder.
 #
 
-# "Portions Copyright [2016-2019] [Payara Foundation]"
+# Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.admingui.console-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.admingui.console-common; bundle-version=${project.osgi.version}

--- a/appserver/ant-tasks/pom.xml
+++ b/appserver/ant-tasks/pom.xml
@@ -73,25 +73,25 @@
        </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-embed-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/appclient/client/acc/pom.xml
+++ b/appserver/appclient/client/acc/pom.xml
@@ -179,7 +179,7 @@
             required for annotation processing support
         -->
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -215,7 +215,7 @@
 
         <!-- required for InjectionManager -->
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -223,7 +223,7 @@
             Required for AnnotationDetector, AnnotationScanner, PersistenceUnitDescriptor
         -->
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -240,7 +240,7 @@
             Required for ClientNamingConfigurator
         -->
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -268,7 +268,7 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-naming</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -287,7 +287,7 @@
         
         
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -317,7 +317,7 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/appclient/client/jws/pom.xml
+++ b/appserver/appclient/client/jws/pom.xml
@@ -84,22 +84,22 @@
                 <artifactId>core</artifactId>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
        <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/appclient/server/connector/pom.xml
+++ b/appserver/appclient/server/connector/pom.xml
@@ -58,12 +58,12 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -72,7 +72,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/appclient/server/core/pom.xml
+++ b/appserver/appclient/server/core/pom.xml
@@ -58,32 +58,32 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -102,22 +102,22 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-enabler</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/batch/glassfish-batch-commands/pom.xml
+++ b/appserver/batch/glassfish-batch-commands/pom.xml
@@ -68,7 +68,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/batch/glassfish-batch-connector/pom.xml
+++ b/appserver/batch/glassfish-batch-connector/pom.xml
@@ -54,7 +54,7 @@
     <name>Batch Connector for Glassfish</name>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -87,7 +87,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/batch/hazelcast-jbatch-store/pom.xml
+++ b/appserver/batch/hazelcast-jbatch-store/pom.xml
@@ -52,7 +52,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
     <name>Hazelcast Batch Persistence Service</name>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/common/amx-javaee/pom.xml
+++ b/appserver/common/amx-javaee/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>amx-javaee</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -71,12 +70,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>amx-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -91,7 +90,7 @@
             <artifactId>glassfish-corba-omgapi</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>stats77</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/common/annotation-framework-l10n/osgi.bundle
+++ b/appserver/common/annotation-framework-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.nucleus.annotation-framework; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.common.annotation-framework; bundle-version=${project.osgi.version}

--- a/appserver/common/annotation-framework/pom.xml
+++ b/appserver/common/annotation-framework/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>common</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>annotation-framework</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -93,7 +92,7 @@
             <artifactId>class-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -103,12 +102,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/common/container-common-l10n/osgi.bundle
+++ b/appserver/common/container-common-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.container-common; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.common.container-common; bundle-version=${project.osgi.version}

--- a/appserver/common/container-common/pom.xml
+++ b/appserver/common/container-common/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>container-common</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>Container Common</name>
@@ -98,37 +97,37 @@
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-naming</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -137,12 +136,12 @@
             <artifactId>jakarta.mail-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -151,7 +150,7 @@
             <artifactId>ha-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/appserver/common/glassfish-ee-api/pom.xml
+++ b/appserver/common/glassfish-ee-api/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>glassfish-ee-api</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -79,17 +78,17 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/common/glassfish-naming-l10n/osgi.bundle
+++ b/appserver/common/glassfish-naming-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.common.glassfish-naming; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.common.glassfish-naming; bundle-version=${project.osgi.version}

--- a/appserver/common/glassfish-naming/pom.xml
+++ b/appserver/common/glassfish-naming/pom.xml
@@ -50,7 +50,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>glassfish-naming</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -82,12 +81,12 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -97,7 +96,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/common/stats77-l10n/osgi.bundle
+++ b/appserver/common/stats77-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.stats77; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.common.stats77; bundle-version=${project.osgi.version}

--- a/appserver/common/stats77/pom.xml
+++ b/appserver/common/stats77/pom.xml
@@ -50,7 +50,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>stats77</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -71,7 +70,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/concurrent/concurrent-connector/pom.xml
+++ b/appserver/concurrent/concurrent-connector/pom.xml
@@ -56,7 +56,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -65,17 +65,17 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
              <version>${project.version}</version>
          </dependency>
        <dependency>
-           <groupId>fish.payara.server.core.resourcebase.resources</groupId>
+           <groupId>fish.payara.server.internal.resourcebase.resources</groupId>
            <artifactId>nucleus-resources</artifactId>
            <version>${project.version}</version>
         </dependency>

--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -62,7 +62,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -76,32 +76,32 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.resourcebase.resources</groupId>
+            <groupId>fish.payara.server.internal.resourcebase.resources</groupId>
             <artifactId>nucleus-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.resources</groupId>
+            <groupId>fish.payara.server.internal.resources</groupId>
             <artifactId>resources-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -125,22 +125,22 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>monitoring-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-stuck</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/connectors/admin/pom.xml
+++ b/appserver/connectors/admin/pom.xml
@@ -89,12 +89,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -104,33 +104,33 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-admin</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-cli</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/connectors/connectors-connector/pom.xml
+++ b/appserver/connectors/connectors-connector/pom.xml
@@ -87,31 +87,31 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
        <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
            <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/connectors/connectors-inbound-runtime/pom.xml
+++ b/appserver/connectors/connectors-inbound-runtime/pom.xml
@@ -85,7 +85,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -95,12 +95,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -109,12 +109,12 @@
             <artifactId>jakarta.resource-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/connectors/connectors-internal-api-l10n/osgi.bundle
+++ b/appserver/connectors/connectors-internal-api-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.connectors.internal-api; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.connectors.internal-api; bundle-version=${project.osgi.version}

--- a/appserver/connectors/connectors-internal-api/pom.xml
+++ b/appserver/connectors/connectors-internal-api/pom.xml
@@ -50,7 +50,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.server.core.connectors</groupId>
     <artifactId>connectors-internal-api</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -87,38 +86,38 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
              <version>${project.version}</version>
         </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
              <version>${project.version}</version>
          </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
              <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.resources</groupId>
+            <groupId>fish.payara.server.internal.resources</groupId>
             <artifactId>resources-connector</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/connectors/connectors-runtime/pom.xml
+++ b/appserver/connectors/connectors-runtime/pom.xml
@@ -94,12 +94,12 @@
     </build>
     <dependencies>
 	    <dependency>
-            <groupId>fish.payara.server.core.flashlight</groupId>
+            <groupId>fish.payara.server.internal.flashlight</groupId>
             <artifactId>flashlight-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>monitoring-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -108,17 +108,17 @@
             <artifactId>jakarta.resource-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -127,52 +127,52 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-ee-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -182,7 +182,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/connectors/work-management/pom.xml
+++ b/appserver/connectors/work-management/pom.xml
@@ -109,13 +109,13 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -131,19 +131,19 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/core/jakartaee-kernel/pom.xml
+++ b/appserver/core/jakartaee-kernel/pom.xml
@@ -69,17 +69,17 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -88,7 +88,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/data/data-core/pom.xml
+++ b/appserver/data/data-core/pom.xml
@@ -53,7 +53,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/deployment/client/pom.xml
+++ b/appserver/deployment/client/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>deployment</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.deployment</groupId>
     <artifactId>deployment-client</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -88,12 +87,12 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -102,7 +101,7 @@
             <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/deployment/dol-l10n/osgi.bundle
+++ b/appserver/deployment/dol-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.deployment.dol; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.deployment.dol; bundle-version=${project.osgi.version}

--- a/appserver/deployment/dol/pom.xml
+++ b/appserver/deployment/dol/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.deployment</groupId>
     <artifactId>dol</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>Deployment Object Library</name>
@@ -144,22 +143,22 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>annotation-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -173,12 +172,12 @@
             <artifactId>payara-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.resourcebase.resources</groupId>
+            <groupId>fish.payara.server.internal.resourcebase.resources</groupId>
             <artifactId>nucleus-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
             <type>jar</type>

--- a/appserver/deployment/javaee-core/pom.xml
+++ b/appserver/deployment/javaee-core/pom.xml
@@ -50,7 +50,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.server.core.deployment</groupId>
     <artifactId>deployment-javaee-core</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -104,7 +103,7 @@
             <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -113,32 +112,32 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
        <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/appserver/deployment/javaee-full/pom.xml
+++ b/appserver/deployment/javaee-full/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>jakarta.enterprise.deploy-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -100,37 +100,37 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
        <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
            <version>${project.version}</version>
         </dependency>
        <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>gf-web-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -155,7 +155,7 @@
           <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/docker/pom.xml
+++ b/appserver/docker/pom.xml
@@ -57,14 +57,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -83,7 +83,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-admin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/ejb/ejb-all/pom.xml
+++ b/appserver/ejb/ejb-all/pom.xml
@@ -72,7 +72,7 @@
             <type>distribution-fragment</type>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/ejb/ejb-connector/pom.xml
+++ b/appserver/ejb/ejb-connector/pom.xml
@@ -71,17 +71,17 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -94,7 +94,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -126,57 +126,57 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>monitoring-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>stats77</artifactId>
             <version>${project.version}</version>
        </dependency>
        <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
            <version>${project.version}</version>
         </dependency>
        <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
            <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-naming</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -186,27 +186,27 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -221,7 +221,7 @@
 	    <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -244,7 +244,7 @@
             <artifactId>payara-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/ejb/ejb-http-remoting/admin/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/admin/pom.xml
@@ -64,12 +64,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -82,12 +82,12 @@
             <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/ejb/ejb-http-remoting/endpoint/pom.xml
+++ b/appserver/ejb/ejb-http-remoting/endpoint/pom.xml
@@ -81,7 +81,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/ejb/ejb-internal-api/pom.xml
+++ b/appserver/ejb/ejb-internal-api/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.ejb</groupId>
     <artifactId>ejb-internal-api</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -81,17 +80,17 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -104,7 +103,7 @@
 	    <artifactId>jakarta.interceptor-api</artifactId>
 	</dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/ejb/ejb-opentracing/pom.xml
+++ b/appserver/ejb/ejb-opentracing/pom.xml
@@ -53,12 +53,12 @@ holder.
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/extras/embedded/common/bootstrap/pom.xml
+++ b/appserver/extras/embedded/common/bootstrap/pom.xml
@@ -70,7 +70,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>fish.payara.server.core.common</groupId>
+                                    <groupId>fish.payara.server.internal.common</groupId>
                                     <artifactId>simple-glassfish-api</artifactId>
                                     <version>${project.version}</version>
                                     <overWrite>false</overWrite>
@@ -78,7 +78,7 @@
                                     <excludes>META-INF/**</excludes>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>fish.payara.server.core.nucleus</groupId>
+                                    <groupId>fish.payara.server.internal.core</groupId>
                                     <artifactId>glassfish</artifactId>
                                     <version>${project.version}</version>
                                     <overWrite>false</overWrite>
@@ -106,13 +106,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/extras/embedded/common/osgi-modules-uninstaller/pom.xml
+++ b/appserver/extras/embedded/common/osgi-modules-uninstaller/pom.xml
@@ -62,7 +62,7 @@ holder.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/extras/embedded/shell/glassfish-embedded-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-shell/pom.xml
@@ -146,12 +146,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/extras/payara-micro/payara-micro-core/pom.xml
+++ b/appserver/extras/payara-micro/payara-micro-core/pom.xml
@@ -100,7 +100,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/flashlight/client/pom.xml
+++ b/appserver/flashlight/client/pom.xml
@@ -62,12 +62,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.flashlight</groupId>
+            <groupId>fish.payara.server.internal.flashlight</groupId>
             <artifactId>flashlight-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/grizzly/grizzly-container/pom.xml
+++ b/appserver/grizzly/grizzly-container/pom.xml
@@ -72,12 +72,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/ha/ha-hazelcast-store/pom.xml
+++ b/appserver/ha/ha-hazelcast-store/pom.xml
@@ -73,7 +73,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -87,7 +87,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/jdbc/admin/pom.xml
+++ b/appserver/jdbc/admin/pom.xml
@@ -89,22 +89,22 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-admin</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
              <version>${project.version}</version>
         </dependency>
@@ -114,13 +114,13 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/jdbc/jdbc-config/pom.xml
+++ b/appserver/jdbc/jdbc-config/pom.xml
@@ -54,7 +54,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -63,12 +63,12 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
@@ -73,17 +73,17 @@
 
   <dependencies>
       <dependency>
-          <groupId>fish.payara.server.core.common</groupId>
+          <groupId>fish.payara.server.internal.common</groupId>
           <artifactId>glassfish-api</artifactId>
           <version>${project.version}</version>
       </dependency>
       <dependency>
-          <groupId>fish.payara.server.core.connectors</groupId>
+          <groupId>fish.payara.server.internal.connectors</groupId>
           <artifactId>connectors-internal-api</artifactId>
           <version>${project.version}</version>
       </dependency>
       <dependency>
-          <groupId>fish.payara.server.core.common</groupId>
+          <groupId>fish.payara.server.internal.common</groupId>
           <artifactId>common-util</artifactId>
           <version>${project.version}</version>
       </dependency>
@@ -96,7 +96,7 @@
           <artifactId>gmbal</artifactId>
       </dependency>
       <dependency>
-          <groupId>fish.payara.server.core.payara-modules</groupId>
+          <groupId>fish.payara.server.internal.payara-modules</groupId>
           <artifactId>requesttracing-core</artifactId>
           <version>${project.version}</version>
       </dependency>

--- a/appserver/jdbc/jdbc-runtime/pom.xml
+++ b/appserver/jdbc/jdbc-runtime/pom.xml
@@ -97,7 +97,7 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/appserver/jms/admin/pom.xml
+++ b/appserver/jms/admin/pom.xml
@@ -88,28 +88,28 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-    	    <groupId>fish.payara.server.core.connectors</groupId>
+    	    <groupId>fish.payara.server.internal.connectors</groupId>
     	    <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -129,7 +129,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/jms/gf-jms-connector/pom.xml
+++ b/appserver/jms/gf-jms-connector/pom.xml
@@ -67,7 +67,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/jms/gf-jms-injection/pom.xml
+++ b/appserver/jms/gf-jms-injection/pom.xml
@@ -68,13 +68,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -92,7 +92,7 @@
         </dependency>
 
          <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
              <version>${project.version}</version>
         </dependency>

--- a/appserver/jms/jms-core/pom.xml
+++ b/appserver/jms/jms-core/pom.xml
@@ -87,17 +87,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-mbeanserver</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -112,12 +112,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -127,7 +127,7 @@
             <version>${project.version}</version>
         </dependency>
     	<dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/load-balancer/admin/pom.xml
+++ b/appserver/load-balancer/admin/pom.xml
@@ -97,28 +97,28 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -128,12 +128,12 @@
             <artifactId>schema2beans</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/load-balancer/gf-load-balancer-connector/pom.xml
+++ b/appserver/load-balancer/gf-load-balancer-connector/pom.xml
@@ -95,7 +95,7 @@
             <artifactId>jakarta.resource-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/monitoring-console/core/pom.xml
+++ b/appserver/monitoring-console/core/pom.xml
@@ -62,13 +62,13 @@
             <artifactId>monitoring-console-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -79,12 +79,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/orb/orb-connector/pom.xml
+++ b/appserver/orb/orb-connector/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>orb</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.orb</groupId>
     <artifactId>orb-connector</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -69,12 +68,12 @@
     </developers>
     <dependencies>
     	<dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-enabler</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -99,7 +98,7 @@
             <artifactId>jakarta.el-api</artifactId>
         </dependency>
        <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
            <version>${project.version}</version>
         </dependency>
@@ -108,23 +107,23 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
         <dependency>
-           <groupId>fish.payara.server.core.cluster</groupId>
+           <groupId>fish.payara.server.internal.cluster</groupId>
            <artifactId>cluster-admin</artifactId>
             <version>${project.version}</version>
 	   <scope>test</scope>
        </dependency>
         <dependency>
-           <groupId>fish.payara.server.core.common</groupId>
+           <groupId>fish.payara.server.internal.common</groupId>
            <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
        </dependency>
         <dependency>
-           <groupId>fish.payara.server.core.admin</groupId>
+           <groupId>fish.payara.server.internal.admin</groupId>
            <artifactId>config-api</artifactId>
             <version>${project.version}</version>
        </dependency>
        <dependency>
-           <groupId>fish.payara.server.core.admin</groupId>
+           <groupId>fish.payara.server.internal.admin</groupId>
            <artifactId>monitoring-core</artifactId>
            <version>${project.version}</version>
        </dependency>
@@ -137,7 +136,7 @@
 	    <artifactId>gmbal</artifactId>
         </dependency>
        <dependency>
-           <groupId>fish.payara.server.core.test-utils</groupId>
+           <groupId>fish.payara.server.internal.test-utils</groupId>
            <artifactId>utils</artifactId>
            <version>${project.version}</version>
            <scope>test</scope>

--- a/appserver/orb/orb-enabler/pom.xml
+++ b/appserver/orb/orb-enabler/pom.xml
@@ -48,7 +48,6 @@
         <artifactId>orb</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.orb</groupId>
     <artifactId>orb-enabler</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -72,12 +71,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>    
     	<dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
     	<dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/orb/orb-iiop/pom.xml
+++ b/appserver/orb/orb-iiop/pom.xml
@@ -71,7 +71,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -96,32 +96,32 @@
             <artifactId>pfl-dynamic</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-enabler</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/osgi-platforms/felix-webconsole-extension/pom.xml
+++ b/appserver/osgi-platforms/felix-webconsole-extension/pom.xml
@@ -91,12 +91,12 @@
         </dependency>
         <!-- TangYong's contribution towards Glassfish-12975 begins -->
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-services</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/osgi-platforms/glassfish-osgi-console-plugin/pom.xml
+++ b/appserver/osgi-platforms/glassfish-osgi-console-plugin/pom.xml
@@ -68,25 +68,25 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/packager/appserver-core/pom.xml
+++ b/appserver/packager/appserver-core/pom.xml
@@ -86,58 +86,58 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>amx-javaee</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>annotation-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-enabler</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -176,17 +176,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>libpam4j-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.resourcebase.resources</groupId>
+            <groupId>fish.payara.server.internal.resourcebase.resources</groupId>
             <artifactId>nucleus-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.resources</groupId>
+            <groupId>fish.payara.server.internal.resources</groupId>
             <artifactId>resources-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -207,7 +207,7 @@
             <artifactId>exousia</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/packager/external/libpam4j/pom.xml
+++ b/appserver/packager/external/libpam4j/pom.xml
@@ -50,7 +50,7 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.packager</groupId>
+    <groupId>fish.payara.server.internal.packager</groupId>
     <artifactId>libpam4j-repackaged</artifactId>
     <name>libpam4j repackaged as a module</name>
     <description>libpam4j (Java binding for libpam.so) repackaged as a module</description>

--- a/appserver/packager/glassfish-common-web/pom.xml
+++ b/appserver/packager/glassfish-common-web/pom.xml
@@ -90,7 +90,7 @@
             <artifactId>pkg-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-client</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/packager/glassfish-common/pom.xml
+++ b/appserver/packager/glassfish-common/pom.xml
@@ -92,7 +92,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-naming</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -109,7 +109,7 @@
             <type>zip</type>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>monitoring-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/packager/glassfish-ejb/pom.xml
+++ b/appserver/packager/glassfish-ejb/pom.xml
@@ -74,7 +74,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-enabler</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/packager/glassfish-gui/pom.xml
+++ b/appserver/packager/glassfish-gui/pom.xml
@@ -96,17 +96,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-plugin-service</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>dataprovider</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -144,7 +144,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>gf-admingui-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -174,7 +174,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admingui</groupId>
+            <groupId>fish.payara.server.internal.admingui</groupId>
             <artifactId>faces-compat</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>

--- a/appserver/packager/glassfish-jca/pom.xml
+++ b/appserver/packager/glassfish-jca/pom.xml
@@ -123,7 +123,7 @@
             <version>${project.version}</version>
         </dependency>
     	<dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-ee-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/packager/glassfish-web/pom.xml
+++ b/appserver/packager/glassfish-web/pom.xml
@@ -85,7 +85,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>gf-web-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -110,32 +110,32 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>stats77</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-embed-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-gui-plugin-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -145,17 +145,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-naming</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-sse</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>war-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -235,7 +235,7 @@
             <artifactId>tyrus-container-glassfish-ejb</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>websecurity</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/cdi-auth-roles/pom.xml
+++ b/appserver/payara-appserver-modules/cdi-auth-roles/pom.xml
@@ -81,7 +81,7 @@
         
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/environment-warning/pom.xml
+++ b/appserver/payara-appserver-modules/environment-warning/pom.xml
@@ -57,12 +57,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/hazelcast-eclipselink-coordination/pom.xml
+++ b/appserver/payara-appserver-modules/hazelcast-eclipselink-coordination/pom.xml
@@ -60,12 +60,12 @@
     </developers>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/hazelcast-ejb-timer/pom.xml
+++ b/appserver/payara-appserver-modules/hazelcast-ejb-timer/pom.xml
@@ -65,7 +65,7 @@
     </developers>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/healthcheck-metrics/pom.xml
+++ b/appserver/payara-appserver-modules/healthcheck-metrics/pom.xml
@@ -55,7 +55,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/jaxrs-client-tracing/pom.xml
+++ b/appserver/payara-appserver-modules/jaxrs-client-tracing/pom.xml
@@ -53,7 +53,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -62,7 +62,7 @@
             <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/jmx-monitoring-service/pom.xml
+++ b/appserver/payara-appserver-modules/jmx-monitoring-service/pom.xml
@@ -108,12 +108,12 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <version>2.4.0-b14</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-mbeanserver</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -122,7 +122,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <artifactId>hk2-runlevel</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>amx-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/config-extensions/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/config-extensions/pom.xml
@@ -63,7 +63,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/config/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/config/pom.xml
@@ -69,12 +69,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
@@ -93,12 +93,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/healthcheck/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/healthcheck/pom.xml
@@ -78,12 +78,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -93,7 +93,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/pom.xml
@@ -106,13 +106,13 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -124,7 +124,7 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/metrics/pom.xml
@@ -100,7 +100,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -110,12 +110,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/microprofile-common/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/microprofile-common/pom.xml
@@ -63,12 +63,12 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/microprofile-connector/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/microprofile-connector/pom.xml
@@ -54,19 +54,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- For ArchiveType dependencies -->
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>gf-web-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -76,7 +76,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/openapi/pom.xml
@@ -78,12 +78,12 @@
             <artifactId>jersey-container-servlet</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/opentracing-jaxws/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/opentracing-jaxws/pom.xml
@@ -54,7 +54,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/appserver/payara-appserver-modules/microprofile/opentracing/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/opentracing/pom.xml
@@ -65,7 +65,7 @@ holder.
             <artifactId>jersey-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -91,7 +91,7 @@ holder.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/rest-client-ssl/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/rest-client-ssl/pom.xml
@@ -79,12 +79,12 @@ holder.
             <artifactId>hk2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/rest-client/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/rest-client/pom.xml
@@ -59,7 +59,7 @@ holder.
             <artifactId>microprofile-rest-client-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>war-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/microprofile/telemetry/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/telemetry/pom.xml
@@ -64,7 +64,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/appserver/payara-appserver-modules/notification-jms-core/pom.xml
+++ b/appserver/payara-appserver-modules/notification-jms-core/pom.xml
@@ -54,7 +54,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/payara-jsr107/pom.xml
+++ b/appserver/payara-appserver-modules/payara-jsr107/pom.xml
@@ -93,7 +93,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/payara-micro-service/pom.xml
+++ b/appserver/payara-appserver-modules/payara-micro-service/pom.xml
@@ -88,27 +88,27 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -128,13 +128,13 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/payara-rest-endpoints/pom.xml
+++ b/appserver/payara-appserver-modules/payara-rest-endpoints/pom.xml
@@ -53,7 +53,7 @@ holder.
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-service/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-service/pom.xml
@@ -51,17 +51,17 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
+++ b/appserver/payara-appserver-modules/yubikey-authentication/pom.xml
@@ -84,7 +84,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -105,7 +105,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -115,7 +115,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/persistence/cmp/ejb-mapping/pom.xml
+++ b/appserver/persistence/cmp/ejb-mapping/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>schema2beans</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/cmp/generator-database/pom.xml
+++ b/appserver/persistence/cmp/generator-database/pom.xml
@@ -87,7 +87,7 @@
             <artifactId>dbschema</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/cmp/model/pom.xml
+++ b/appserver/persistence/cmp/model/pom.xml
@@ -91,7 +91,7 @@
             <artifactId>dbschema</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/cmp/support-ejb/pom.xml
+++ b/appserver/persistence/cmp/support-ejb/pom.xml
@@ -119,12 +119,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/cmp/support-sqlstore/pom.xml
+++ b/appserver/persistence/cmp/support-sqlstore/pom.xml
@@ -132,7 +132,7 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -142,7 +142,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -152,12 +152,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/cmp/utility/pom.xml
+++ b/appserver/persistence/cmp/utility/pom.xml
@@ -82,7 +82,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/common/pom.xml
+++ b/appserver/persistence/common/pom.xml
@@ -75,17 +75,17 @@
     </developers>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/entitybean-container/pom.xml
+++ b/appserver/persistence/entitybean-container/pom.xml
@@ -68,17 +68,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -87,7 +87,7 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/gf-jpa-connector/pom.xml
+++ b/appserver/persistence/gf-jpa-connector/pom.xml
@@ -78,37 +78,37 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/persistence/jpa-container/pom.xml
+++ b/appserver/persistence/jpa-container/pom.xml
@@ -86,47 +86,47 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/registration/glassfish-registration/pom.xml
+++ b/appserver/registration/glassfish-registration/pom.xml
@@ -71,12 +71,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/registration/glassfish-registration/src/main/java/com/sun/enterprise/registration/glassfish/ModuleMap.java
+++ b/appserver/registration/glassfish-registration/src/main/java/com/sun/enterprise/registration/glassfish/ModuleMap.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2024] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.registration.glassfish;
 
@@ -167,11 +167,11 @@ public class ModuleMap {
                 put("fish.payara.server.internal.admin.backup", 108);
                 put("fish.payara.server.internal.admin.cli", 109);
                 put("fish.payara.server.internal.admin.cli-optional", 110);
-                put("fish.payara.server.core.admin.config-api", 111);
+                put("fish.payara.server.internal.admin.config-api", 111);
                 put("fish.payara.server.internal.admin.core", 112);
                 put("fish.payara.server.internal.admin.javax.management.j2ee", 113);
-                put("fish.payara.server.core.admin.launcher", 114);
-                put("fish.payara.server.core.admin.monitoring-core", 115);
+                put("fish.payara.server.internal.admin.launcher", 114);
+                put("fish.payara.server.internal.admin.monitoring-core", 115);
                 put("fish.payara.server.internal.admin.rest-service", 116);
                 put("fish.payara.server.internal.admin.server-mgmt", 117);
                 put("fish.payara.server.internal.admin.util", 118);
@@ -201,16 +201,16 @@ public class ModuleMap {
                 put("fish.payara.server.internal.cluster.gms-bootstrap", 142);
                 put("fish.payara.server.internal.cluster.ssh", 143);
                 put("fish.payara.server.internal.common.amx-all", 144);
-                put("fish.payara.server.core.common.annotation-framework", 145);
-                put("fish.payara.server.core.common.container-common", 146);
-                put("fish.payara.server.core.common.glassfish-api", 147);
-                put("fish.payara.server.core.common.glassfish-ee-api", 148);
-                put("fish.payara.server.core.common.glassfish-mbeanserver", 149);
-                put("fish.payara.server.core.common.glassfish-naming", 150);
-                put("fish.payara.server.core.common.internal-api", 151);
-                put("fish.payara.server.core.common.scattered-archive-api", 152);
-                put("fish.payara.server.core.common.simple-glassfish-api", 153);
-                put("fish.payara.server.core.common.stats77", 154);
+                put("fish.payara.server.internal.common.annotation-framework", 145);
+                put("fish.payara.server.internal.common.container-common", 146);
+                put("fish.payara.server.internal.common.glassfish-api", 147);
+                put("fish.payara.server.internal.common.glassfish-ee-api", 148);
+                put("fish.payara.server.internal.common.glassfish-mbeanserver", 149);
+                put("fish.payara.server.internal.common.glassfish-naming", 150);
+                put("fish.payara.server.internal.common.internal-api", 151);
+                put("fish.payara.server.internal.common.scattered-archive-api", 152);
+                put("fish.payara.server.internal.common.simple-glassfish-api", 153);
+                put("fish.payara.server.internal.common.stats77", 154);
                 put("fish.payara.server.internal.common.util", 155);
                 put("fish.payara.server.internal.connectors.admin", 156);
                 put("fish.payara.server.internal.connectors.gf-connectors-connector", 157);
@@ -220,16 +220,16 @@ public class ModuleMap {
                 put("fish.payara.server.internal.connectors.runtime", 161);
                 put("fish.payara.server.internal.connectors.work-management", 162);
                 put("fish.payara.server.internal.core.branding", 163);
-                put("fish.payara.server.core.nucleus.glassfish", 164);
+                put("fish.payara.server.internal.core.glassfish", 164);
                 put("fish.payara.server.internal.core.glassfish-extra-jre-packages", 165);
                 put("fish.payara.server.internal.core.jakartaee-kernel", 166);
-                put("fish.payara.server.core.nucleus.kernel", 167);
-                put("fish.payara.server.core.nucleus.logging", 168);
+                put("fish.payara.server.internal.core.kernel", 167);
+                put("fish.payara.server.internal.core.logging", 168);
                 put("fish.payara.server.internal.deployment.admin", 169);
                 put("fish.payara.server.internal.deployment.autodeploy", 170);
                 put("fish.payara.server.internal.deployment.common", 171);
                 put("fish.payara.server.internal.deployment.deployment-client", 172);
-                put("fish.payara.server.core.deployment.dol", 173);
+                put("fish.payara.server.internal.deployment.dol", 173);
                 put("fish.payara.server.internal.deployment.javaee-core", 174);
                 put("fish.payara.server.internal.deployment.javaee-full", 175);
                 put("fish.payara.server.internal.deployment.javax.enterprise.deploy", 176);
@@ -284,8 +284,8 @@ public class ModuleMap {
                 put("fish.payara.server.internal.security.inmemory.jacc.provider", 225);
                 put("fish.payara.server.internal.security.jakarta.security.auth.message", 226);
                 put("fish.payara.server.internal.security.jakarta.security.jacc", 227);
-                put("fish.payara.server.core.security.ssl-impl", 228);
-                put("fish.payara.server.core.security.websecurity", 229);
+                put("fish.payara.server.internal.security.ssl-impl", 228);
+                put("fish.payara.server.internal.security.websecurity", 229);
                 put("fish.payara.server.internal.security.webservices.security", 230);
                 put("fish.payara.server.internal.transaction.internal-api", 231);
                 put("fish.payara.server.internal.transaction.jakarta.transaction", 232);
@@ -293,16 +293,16 @@ public class ModuleMap {
                 put("fish.payara.server.internal.transaction.jts", 234);
                 put("fish.payara.server.internal.web.cli", 235);
                 put("fish.payara.server.internal.web.core", 236);
-                put("fish.payara.server.core.web.gf-web-connector", 237);
-                put("fish.payara.server.core.web.glue", 238);
+                put("fish.payara.server.internal.web.gf-web-connector", 237);
+                put("fish.payara.server.internal.web.glue", 238);
                 put("fish.payara.server.internal.web.gui-plugin-common", 239);
                 put("fish.payara.server.internal.web.ha", 240);
                 put("fish.payara.server.internal.web.jsf-connector", 241);
                 put("fish.payara.server.internal.web.jspcaching-connector", 242);
                 put("fish.payara.server.internal.web.jstl-connector", 243);
                 put("fish.payara.server.internal.web.naming", 244);
-                put("fish.payara.server.core.web.war-util", 245);
-                put("fish.payara.server.core.web.web-embed.api", 246);
+                put("fish.payara.server.internal.web.war-util", 245);
+                put("fish.payara.server.internal.web.web-embed.api", 246);
                 put("fish.payara.server.internal.web.web-embed.impl", 247);
                 put("fish.payara.server.internal.web.weld-integration", 248);
                 put("fish.payara.server.internal.web.weld-integration-fragment", 249);

--- a/appserver/registration/registration-impl/pom.xml
+++ b/appserver/registration/registration-impl/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/resources/javamail/javamail-connector/pom.xml
+++ b/appserver/resources/javamail/javamail-connector/pom.xml
@@ -90,39 +90,39 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.resources</groupId>
+            <groupId>fish.payara.server.internal.resources</groupId>
             <artifactId>resources-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-services</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/appserver/resources/javamail/javamail-runtime/pom.xml
+++ b/appserver/resources/javamail/javamail-runtime/pom.xml
@@ -89,17 +89,17 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.resources</groupId>
+            <groupId>fish.payara.server.internal.resources</groupId>
             <artifactId>resources-connector</artifactId>
              <version>${project.version}</version>
         </dependency>

--- a/appserver/resources/javamail/pom.xml
+++ b/appserver/resources/javamail/pom.xml
@@ -83,7 +83,7 @@
             <artifactId>angus-mail</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-services</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/appserver/resources/resources-connector/pom.xml
+++ b/appserver/resources/resources-connector/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.resources</groupId>
     <artifactId>resources-connector</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -91,39 +90,39 @@
             <artifactId>jakarta.el-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.resourcebase.resources</groupId>
+            <groupId>fish.payara.server.internal.resourcebase.resources</groupId>
             <artifactId>nucleus-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- Even though nothing from Kernel is used, we need it to get an instance of CommandRunner -->
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/appserver/resources/resources-runtime/pom.xml
+++ b/appserver/resources/resources-runtime/pom.xml
@@ -86,31 +86,31 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.resources</groupId>
+            <groupId>fish.payara.server.internal.resources</groupId>
             <artifactId>resources-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/security/appclient.security/pom.xml
+++ b/appserver/security/appclient.security/pom.xml
@@ -96,12 +96,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -116,7 +116,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/security/core-ee/pom.xml
+++ b/appserver/security/core-ee/pom.xml
@@ -50,7 +50,7 @@
         <artifactId>securitymodule</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.security</groupId>
+    <groupId>fish.payara.server.internal.security</groupId>
     <artifactId>security-ee</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -183,12 +183,12 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency> <!-- for AuditModule -->
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-ee-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -197,27 +197,27 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>ssl-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -239,7 +239,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -249,7 +249,7 @@
             <!-- Don't set scope as provided. See issue #5992 -->
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -258,12 +258,12 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.connectors</groupId>
+            <groupId>fish.payara.server.internal.connectors</groupId>
             <artifactId>connectors-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -276,12 +276,12 @@
 	    <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>libpam4j-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/security/ejb.security/pom.xml
+++ b/appserver/security/ejb.security/pom.xml
@@ -96,32 +96,32 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -151,12 +151,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-enabler</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/security/jacc.provider.inmemory/pom.xml
+++ b/appserver/security/jacc.provider.inmemory/pom.xml
@@ -89,7 +89,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/security/realm-stores/pom.xml
+++ b/appserver/security/realm-stores/pom.xml
@@ -79,7 +79,7 @@
             <version>${microprofile-config.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -94,7 +94,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/security/security-all/pom.xml
+++ b/appserver/security/security-all/pom.xml
@@ -65,12 +65,12 @@
     </developers>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/security/webintegration/pom.xml
+++ b/appserver/security/webintegration/pom.xml
@@ -51,7 +51,7 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.security</groupId>
+    <groupId>fish.payara.server.internal.security</groupId>
     <artifactId>websecurity</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>WebTier Security Integration</name>
@@ -114,47 +114,47 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>war-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/security/webservices.security/pom.xml
+++ b/appserver/security/webservices.security/pom.xml
@@ -78,37 +78,37 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-           <groupId>fish.payara.server.core.web</groupId>
+           <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -129,12 +129,12 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>websecurity</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/tests/payara-samples/asadmin/pom.xml
+++ b/appserver/tests/payara-samples/asadmin/pom.xml
@@ -55,34 +55,34 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>ldapbp-repackaged</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -91,7 +91,7 @@
             <artifactId>notification-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-stuck</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/tests/payara-samples/classloader-data-api/pom.xml
+++ b/appserver/tests/payara-samples/classloader-data-api/pom.xml
@@ -63,7 +63,7 @@
     <dependencies>
         <!-- Payara Dependencies -->
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>war-util</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-impl/pom.xml
+++ b/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-impl/pom.xml
@@ -55,19 +55,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>ldapbp-repackaged</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-test/pom.xml
+++ b/appserver/tests/payara-samples/samples/custom-loginmodule-realm/loginmodule-realm-test/pom.xml
@@ -64,13 +64,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>ldapbp-repackaged</artifactId>
                 </exclusion>
             </exclusions>

--- a/appserver/tests/payara-samples/samples/ejb-http-remoting/pom.xml
+++ b/appserver/tests/payara-samples/samples/ejb-http-remoting/pom.xml
@@ -86,7 +86,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>ldapbp-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
@@ -94,15 +94,15 @@
                     <artifactId>libpam4j-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>tiger-types</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>jmxremote_optional-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>opentracing-repackaged</artifactId>
                 </exclusion>
             </exclusions>

--- a/appserver/tests/payara-samples/samples/http/pom.xml
+++ b/appserver/tests/payara-samples/samples/http/pom.xml
@@ -60,7 +60,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/tests/payara-samples/samples/logging/pom.xml
+++ b/appserver/tests/payara-samples/samples/logging/pom.xml
@@ -74,17 +74,17 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/tests/payara-samples/samples/remote-ejb-tracing/pom.xml
+++ b/appserver/tests/payara-samples/samples/remote-ejb-tracing/pom.xml
@@ -99,23 +99,23 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>ldapbp-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>libpam4j-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>tiger-types</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>jmxremote_optional-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>opentracing-repackaged</artifactId>
                 </exclusion>
             </exclusions>

--- a/appserver/tests/payara-samples/samples/rolesPermitted/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesPermitted/pom.xml
@@ -57,7 +57,7 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>ldapbp-repackaged</artifactId>
                 </exclusion>
             </exclusions>

--- a/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
+++ b/appserver/tests/payara-samples/samples/rolesallowed-unprotected-methods/pom.xml
@@ -76,7 +76,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>ldapbp-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
@@ -84,15 +84,15 @@
                     <artifactId>libpam4j-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>tiger-types</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>jmxremote_optional-repackaged</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>fish.payara.server.core.packager</groupId>
+                    <groupId>fish.payara.server.internal.packager</groupId>
                     <artifactId>opentracing-repackaged</artifactId>
                 </exclusion>
             </exclusions>

--- a/appserver/tests/payara-samples/test-utils/pom.xml
+++ b/appserver/tests/payara-samples/test-utils/pom.xml
@@ -98,7 +98,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/appserver/transaction/internal-api/pom.xml
+++ b/appserver/transaction/internal-api/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.transaction</groupId>
     <artifactId>transaction-internal-api</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -85,19 +84,19 @@
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <!-- Dependency on StringManager -->
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/transaction/jta-xa/pom.xml
+++ b/appserver/transaction/jta-xa/pom.xml
@@ -90,7 +90,7 @@
             <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -105,7 +105,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/transaction/jta/pom.xml
+++ b/appserver/transaction/jta/pom.xml
@@ -107,27 +107,27 @@
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -140,7 +140,7 @@
             <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/appserver/transaction/jts/pom.xml
+++ b/appserver/transaction/jts/pom.xml
@@ -94,7 +94,7 @@
             <artifactId>jakarta.resource-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -104,17 +104,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -136,7 +136,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.orb</groupId>
+            <groupId>fish.payara.server.internal.orb</groupId>
             <artifactId>orb-connector</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/appserver/web/admin/pom.xml
+++ b/appserver/web/admin/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>web</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.web</groupId>
     <artifactId>web-cli</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -119,12 +118,12 @@
     
     <dependencies>
 	<dependency>
-        <groupId>fish.payara.server.core.flashlight</groupId>
+        <groupId>fish.payara.server.internal.flashlight</groupId>
         <artifactId>flashlight-framework</artifactId>
         <version>${project.version}</version>
         </dependency>
 	<dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>monitoring-core</artifactId>
         <version>${project.version}</version>
 	</dependency>
@@ -133,32 +132,32 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.grizzly</groupId>
+            <groupId>fish.payara.server.internal.grizzly</groupId>
             <artifactId>grizzly-config</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-	    <groupId>fish.payara.server.core.common</groupId>
+	    <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -171,7 +170,7 @@
             <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>amx-javaee</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/gf-web-connector/pom.xml
+++ b/appserver/web/gf-web-connector/pom.xml
@@ -48,7 +48,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.web</groupId>
     <artifactId>gf-web-connector</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -73,22 +72,22 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -98,12 +97,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/gf-web-connector/src/main/java/org/glassfish/web/sniffer/WebSniffer.java
+++ b/appserver/web/gf-web-connector/src/main/java/org/glassfish/web/sniffer/WebSniffer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2022] Payara Foundation and/or affiliates
+// Portions Copyright 2018-2025 Payara Foundation and/or its affiliates
 
 package org.glassfish.web.sniffer;
 
@@ -185,7 +185,7 @@ public class WebSniffer  extends GenericSniffer {
     // TODO(Sahoo): Ideally we should have separate sniffer for JSP, but since WebSniffer is already
     // handling JSPs, we must make sure that all JSP related modules get installed by WebSniffer as well.
     private String[] containerModuleNames = {
-        "fish.payara.server.core.web.glue",
+        "fish.payara.server.internal.web.glue",
         "org.glassfish.wasp.wasp"
     };
 

--- a/appserver/web/gf-weld-connector/pom.xml
+++ b/appserver/web/gf-weld-connector/pom.xml
@@ -56,17 +56,17 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/gui-plugin-common/pom.xml
+++ b/appserver/web/gui-plugin-common/pom.xml
@@ -48,7 +48,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.web</groupId>
     <artifactId>web-gui-plugin-common</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -73,12 +72,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>gf-web-connector</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/jersey-mvc-connector/pom.xml
+++ b/appserver/web/jersey-mvc-connector/pom.xml
@@ -64,17 +64,17 @@
             <artifactId>jersey-mvc-jsp</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>war-util</artifactId>
              <version>${project.version}</version>
         </dependency>

--- a/appserver/web/jsf-connector/pom.xml
+++ b/appserver/web/jsf-connector/pom.xml
@@ -72,7 +72,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
              <version>${project.version}</version>
         </dependency>
@@ -82,22 +82,22 @@
             <artifactId>jakarta.faces</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/jspcaching-connector/pom.xml
+++ b/appserver/web/jspcaching-connector/pom.xml
@@ -81,17 +81,17 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/jstl-connector/pom.xml
+++ b/appserver/web/jstl-connector/pom.xml
@@ -82,17 +82,17 @@
             <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
          <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>war-util</artifactId>
              <version>${project.version}</version>
         </dependency>

--- a/appserver/web/war-util-l10n/osgi.bundle
+++ b/appserver/web/war-util-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.web.war-util; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.web.war-util; bundle-version=${project.osgi.version}

--- a/appserver/web/war-util/pom.xml
+++ b/appserver/web/war-util/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.web</groupId>
     <artifactId>war-util</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -70,12 +69,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -96,22 +95,22 @@
             <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>gf-web-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-naming</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-ee-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -121,12 +120,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-ee</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -51,7 +51,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.web</groupId>
     <artifactId>web-core</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -106,37 +105,37 @@
             <artifactId>grizzly-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>war-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-naming</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -155,19 +154,19 @@
             <artifactId>jersey-container-servlet-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-stuck</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/web-embed/api/pom.xml
+++ b/appserver/web/web-embed/api/pom.xml
@@ -49,7 +49,7 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.web</groupId>
+    <groupId>fish.payara.server.internal.web</groupId>
     <artifactId>web-embed-api</artifactId>   
     <packaging>glassfish-jar</packaging> 
     
@@ -74,7 +74,7 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/web-glue-l10n/osgi.bundle
+++ b/appserver/web/web-glue-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or affiliates
+# Portions Copyright 2022-2025 Payara Foundation and/or affiliates
 
-Fragment-Host: fish.payara.server.core.web.glue; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.web.glue; bundle-version=${project.osgi.version}

--- a/appserver/web/web-glue/pom.xml
+++ b/appserver/web/web-glue/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.web</groupId>
     <artifactId>web-glue</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -110,12 +109,12 @@
             <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.flashlight</groupId>
+            <groupId>fish.payara.server.internal.flashlight</groupId>
             <artifactId>flashlight-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -124,42 +123,42 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>stats77</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>war-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-naming</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-javaee-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -176,72 +175,72 @@
             <artifactId>expressly</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>monitoring-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.transaction</groupId>
+            <groupId>fish.payara.server.internal.transaction</groupId>
             <artifactId>transaction-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-gui-plugin-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>websecurity</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-embed-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>gf-web-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-sse</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/web-ha/pom.xml
+++ b/appserver/web/web-ha/pom.xml
@@ -92,12 +92,12 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/web-naming/pom.xml
+++ b/appserver/web/web-naming/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.web</groupId>
     <artifactId>web-naming</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -100,7 +99,7 @@
         </dependency>
         <dependency>
             <!-- Needed for Startup service -->
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/web/web-sse/pom.xml
+++ b/appserver/web/web-sse/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.web</groupId>
     <artifactId>web-sse</artifactId>
     <packaging>glassfish-jar</packaging>
     

--- a/appserver/web/webtier-all/pom.xml
+++ b/appserver/web/webtier-all/pom.xml
@@ -66,23 +66,23 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-gui-plugin-common</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>websecurity</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -107,17 +107,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-cli</artifactId>
             <version>${project.version}</version>
     	</dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>gf-web-connector</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-embed-api</artifactId>
             <version>${project.version}</version>
     	</dependency>

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -103,7 +103,7 @@
             <artifactId>jakarta.faces</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -182,7 +182,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/webservices/connector/pom.xml
+++ b/appserver/webservices/connector/pom.xml
@@ -56,7 +56,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -69,12 +69,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -84,7 +84,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/webservices/jsr109-impl/pom.xml
+++ b/appserver/webservices/jsr109-impl/pom.xml
@@ -70,37 +70,37 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>container-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.web</groupId>
+            <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>web-glue</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -125,7 +125,7 @@
             <artifactId>jakarta.ejb-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -140,7 +140,7 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/webservices/metro-glue/pom.xml
+++ b/appserver/webservices/metro-glue/pom.xml
@@ -67,22 +67,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -96,7 +96,7 @@
             <artifactId>webservices-osgi</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/appserver/webservices/soap-tcp/pom.xml
+++ b/appserver/webservices/soap-tcp/pom.xml
@@ -73,12 +73,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.ejb</groupId>
+            <groupId>fish.payara.server.internal.ejb</groupId>
             <artifactId>ejb-internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>dol</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>nucleus-admin</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.admin</groupId>
     <artifactId>admin-cli</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>admin-cli</name>
@@ -132,7 +131,7 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -145,22 +144,22 @@
             <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>launcher</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/admin/config-api-l10n/osgi.bundle
+++ b/nucleus/admin/config-api-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.admin.config-api; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.admin.config-api; bundle-version=${project.osgi.version}

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -51,7 +51,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.admin</groupId>
     <artifactId>config-api</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>admin-config-api</name>
@@ -116,17 +115,17 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -138,7 +137,7 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/nucleus/admin/launcher-l10n/osgi.bundle
+++ b/nucleus/admin/launcher-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.admin.launcher; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.admin.launcher; bundle-version=${project.osgi.version}

--- a/nucleus/admin/launcher/pom.xml
+++ b/nucleus/admin/launcher/pom.xml
@@ -50,7 +50,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.server.core.admin</groupId>
     <artifactId>launcher</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>admin-launcher</name>
@@ -68,12 +67,12 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>logging</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/admin/monitor-l10n/osgi.bundle
+++ b/nucleus/admin/monitor-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.admin.monitoring-core; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.admin.monitoring-core; bundle-version=${project.osgi.version}

--- a/nucleus/admin/monitor/pom.xml
+++ b/nucleus/admin/monitor/pom.xml
@@ -50,7 +50,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.server.core.admin</groupId>
     <artifactId>monitoring-core</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -79,7 +78,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -88,12 +87,12 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.flashlight</groupId>
+            <groupId>fish.payara.server.internal.flashlight</groupId>
             <artifactId>flashlight-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -111,7 +110,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>amx-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/admin/rest/gf-restadmin-connector/pom.xml
+++ b/nucleus/admin/rest/gf-restadmin-connector/pom.xml
@@ -56,17 +56,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/admin/rest/rest-client/pom.xml
+++ b/nucleus/admin/rest/rest-client/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.admin</groupId>
     <artifactId>rest-client</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -62,7 +61,7 @@
             <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -69,12 +69,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>rest-client</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -87,12 +87,12 @@
             <artifactId>jakarta.el-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -127,7 +127,7 @@
             <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.flashlight</groupId>
+            <groupId>fish.payara.server.internal.flashlight</groupId>
             <artifactId>flashlight-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -142,7 +142,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/admin/rest/rest-service/src/main/resources/client/pom.template.xml
+++ b/nucleus/admin/rest/rest-service/src/main/resources/client/pom.template.xml
@@ -40,22 +40,22 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright 2018-2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.admin</groupId>
     <artifactId>rest-service-client</artifactId>
-    <version>{{payara.core.version}}</version>
+    <version>{{glassfish.version}}</version>
     
     <name>GlassFish Admin REST Service Client</name>
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>rest-client</artifactId>
-            <version>{{payara.core.version.version}}</version>
+            <version>{{glassfish.version}}</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/admin/server-mgmt/pom.xml
+++ b/nucleus/admin/server-mgmt/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.admin</groupId>
     <artifactId>server-mgmt</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -138,17 +137,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/admin/util-l10n/osgi.bundle
+++ b/nucleus/admin/util-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.admin.admin-util; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.admin.admin-util; bundle-version=${project.osgi.version}

--- a/nucleus/admin/util/pom.xml
+++ b/nucleus/admin/util/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.admin</groupId>
     <artifactId>admin-util</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -93,17 +92,17 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -115,18 +114,18 @@
                 uses of SSLUtils from the security module are instantiated
                 just-in-time only when needed, rather than being injected.
             -->
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-services</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/nucleus/cluster/admin/pom.xml
+++ b/nucleus/cluster/admin/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>cluster</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.cluster</groupId>
     <artifactId>cluster-admin</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -79,53 +78,53 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-ssh</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>trilead-ssh2-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/cluster/cli/pom.xml
+++ b/nucleus/cluster/cli/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>cluster</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.cluster</groupId>
     <artifactId>cluster-cli</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -90,47 +89,47 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>server-mgmt</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>launcher</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-ssh</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>ssl-impl</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/cluster/common/pom.xml
+++ b/nucleus/cluster/common/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>cluster</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.cluster</groupId>
     <artifactId>cluster-common</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -79,28 +78,28 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>j-interop-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/cluster/ssh/pom.xml
+++ b/nucleus/cluster/ssh/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>cluster</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.cluster</groupId>
     <artifactId>cluster-ssh</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -74,7 +73,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>trilead-ssh2-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -83,12 +82,12 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -99,12 +98,12 @@
             from NodeRunner.
         -->
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/common/amx-core/pom.xml
+++ b/nucleus/common/amx-core/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>amx-core</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -75,25 +74,25 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-mbeanserver</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/common/common-util/pom.xml
+++ b/nucleus/common/common-util/pom.xml
@@ -49,8 +49,7 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    
-    <groupId>fish.payara.server.core.common</groupId>
+
     <artifactId>common-util</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -99,7 +98,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/common/glassfish-api-l10n/osgi.bundle
+++ b/nucleus/common/glassfish-api-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.glassfish-api; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.common.glassfish-api; bundle-version=${project.osgi.version}

--- a/nucleus/common/glassfish-api/pom.xml
+++ b/nucleus/common/glassfish-api/pom.xml
@@ -50,8 +50,7 @@
         <artifactId>nucleus-common</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    
-    <groupId>fish.payara.server.core.common</groupId>
+
     <artifactId>glassfish-api</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -72,7 +71,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>scattered-archive-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -81,7 +80,7 @@
             <artifactId>hk2-runlevel</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.grizzly</groupId>
+            <groupId>fish.payara.server.internal.grizzly</groupId>
             <artifactId>nucleus-grizzly-all</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/common/internal-api-l10n/osgi.bundle
+++ b/nucleus/common/internal-api-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.common.internal-api; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.common.internal-api; bundle-version=${project.osgi.version}

--- a/nucleus/common/internal-api/pom.xml
+++ b/nucleus/common/internal-api/pom.xml
@@ -51,7 +51,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>internal-api</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -91,12 +90,12 @@
     </developers>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.hk2</groupId>
+            <groupId>fish.payara.server.internal.hk2</groupId>
             <artifactId>hk2-config</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.hk2</groupId>
+            <groupId>fish.payara.server.internal.hk2</groupId>
             <artifactId>config-types</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -109,34 +108,34 @@
             <artifactId>payara-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.grizzly</groupId>
+            <groupId>fish.payara.server.internal.grizzly</groupId>
             <artifactId>nucleus-grizzly-all</artifactId>
             <version>${project.version}</version>
             <!-- grizzly was bringing in the following old hk2 jar that we don't want on the classpath -->
             <exclusions>
                 <exclusion>
-                    <groupId>fish.payara.server.core.hk2</groupId>
+                    <groupId>fish.payara.server.internal.hk2</groupId>
                     <artifactId>config-types</artifactId>
                 </exclusion>
             </exclusions>
@@ -153,7 +152,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/common/mbeanserver-l10n/osgi.bundle
+++ b/nucleus/common/mbeanserver-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.glassfish-mbeanserver; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.common.glassfish-mbeanserver; bundle-version=${project.osgi.version}

--- a/nucleus/common/mbeanserver/pom.xml
+++ b/nucleus/common/mbeanserver/pom.xml
@@ -50,7 +50,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>glassfish-mbeanserver</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -76,19 +75,19 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>jmxremote_optional-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/common/scattered-archive-api/pom.xml
+++ b/nucleus/common/scattered-archive-api/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>nucleus-common</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>scattered-archive-api</artifactId>
     <packaging>glassfish-jar</packaging>
     

--- a/nucleus/common/simple-glassfish-api/pom.xml
+++ b/nucleus/common/simple-glassfish-api/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.common</groupId>
     <artifactId>simple-glassfish-api</artifactId>
     <packaging>glassfish-jar</packaging>
     

--- a/nucleus/core/api-exporter/pom.xml
+++ b/nucleus/core/api-exporter/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.nucleus</groupId>
     <artifactId>api-exporter</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>GlassFish API Exporter Module</name>

--- a/nucleus/core/bootstrap/pom.xml
+++ b/nucleus/core/bootstrap/pom.xml
@@ -51,7 +51,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.nucleus</groupId>
     <artifactId>glassfish</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -111,7 +110,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>fish.payara.server.core.common</groupId>
+                                    <groupId>fish.payara.server.internal.common</groupId>
                                     <artifactId>simple-glassfish-api</artifactId>
                                     <version>${project.version}</version>
                                     <overWrite>false</overWrite>
@@ -166,7 +165,7 @@
                 part of distribution. Making it a compile scoped dependency forces this jar
                 to be part of all distribution.
             -->
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -176,7 +175,7 @@
           <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/core/context-propagation/pom.xml
+++ b/nucleus/core/context-propagation/pom.xml
@@ -89,13 +89,13 @@
             <artifactId>hk2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/nucleus/core/kernel-l10n/osgi.bundle
+++ b/nucleus/core/kernel-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.nucleus.kernel; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.core.kernel; bundle-version=${project.osgi.version}

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -50,7 +50,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.nucleus</groupId>
     <artifactId>kernel</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -129,17 +128,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-services</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -149,12 +148,12 @@
 			<version>${project.version}</version>
 		</dependency-->
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -168,28 +167,28 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.grizzly</groupId>
+            <groupId>fish.payara.server.internal.grizzly</groupId>
             <artifactId>nucleus-grizzly-all</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.flashlight</groupId>
+            <groupId>fish.payara.server.internal.flashlight</groupId>
             <artifactId>flashlight-framework</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -207,23 +206,23 @@
 	    <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>logging</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 	<dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>api-exporter</artifactId>
         <version>${project.version}</version>
         </dependency>
@@ -234,12 +233,12 @@
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-stuck</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -257,7 +256,7 @@
             <artifactId>expressly</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>tiger-types</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/core/logging-l10n/osgi.bundle
+++ b/nucleus/core/logging-l10n/osgi.bundle
@@ -37,6 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright 2022 Payara Foundation and/or its affiliates 
+# Portions Copyright 2022-2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.core.logging; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.core.logging; bundle-version=${project.osgi.version}

--- a/nucleus/core/logging/pom.xml
+++ b/nucleus/core/logging/pom.xml
@@ -51,7 +51,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fish.payara.server.core.nucleus</groupId>
     <artifactId>logging</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -60,23 +59,23 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-ssh</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -86,7 +85,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -96,7 +95,7 @@
         </dependency>
         <!-- Used only for LogFilterForInstance -->
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>trilead-ssh2-repackaged</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/nucleus/deployment/admin/pom.xml
+++ b/nucleus/deployment/admin/pom.xml
@@ -106,27 +106,27 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/deployment/autodeploy/pom.xml
+++ b/nucleus/deployment/autodeploy/pom.xml
@@ -100,17 +100,17 @@
                 <artifactId>hk2</artifactId>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -120,7 +120,7 @@
           <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
             <type>jar</type>

--- a/nucleus/deployment/common/pom.xml
+++ b/nucleus/deployment/common/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.deployment</groupId>
     <artifactId>deployment-common</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -129,12 +128,12 @@
                 <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 	    <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -147,12 +146,12 @@
             <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/nucleus/diagnostics/diagnostics-api/pom.xml
+++ b/nucleus/diagnostics/diagnostics-api/pom.xml
@@ -59,7 +59,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/nucleus/flashlight/framework/pom.xml
+++ b/nucleus/flashlight/framework/pom.xml
@@ -50,7 +50,7 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
         <relativePath>../../common/pom.xml</relativePath>
     </parent>
-    <groupId>fish.payara.server.core.flashlight</groupId>
+    <groupId>fish.payara.server.internal.flashlight</groupId>
     <artifactId>flashlight-framework</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -101,7 +101,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/grizzly/config/pom.xml
+++ b/nucleus/grizzly/config/pom.xml
@@ -51,7 +51,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.grizzly</groupId>
     <artifactId>grizzly-config</artifactId>
     <name>grizzly-config</name>
     <packaging>glassfish-jar</packaging>
@@ -107,12 +106,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.hk2</groupId>
+            <groupId>fish.payara.server.internal.hk2</groupId>
             <artifactId>hk2-config</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.hk2</groupId>
+            <groupId>fish.payara.server.internal.hk2</groupId>
             <artifactId>config-types</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/grizzly/nucleus-grizzly-all/pom.xml
+++ b/nucleus/grizzly/nucleus-grizzly-all/pom.xml
@@ -51,7 +51,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.grizzly</groupId>
     <artifactId>nucleus-grizzly-all</artifactId>
     <name>Nucleus Grizzly jars Combining</name>
     <description>combining of all nucleus grizzly jars</description>
@@ -138,7 +137,7 @@
             <artifactId>tls-sni</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.grizzly</groupId>
+            <groupId>fish.payara.server.internal.grizzly</groupId>
             <artifactId>grizzly-config</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/hk2/config-generator/pom.xml
+++ b/nucleus/hk2/config-generator/pom.xml
@@ -77,7 +77,7 @@
             <artifactId>hk2-utils</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.hk2</groupId>
+            <groupId>fish.payara.server.internal.hk2</groupId>
             <artifactId>hk2-config</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/hk2/config-types/pom.xml
+++ b/nucleus/hk2/config-types/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.hk2</groupId>
     <artifactId>config-types</artifactId>
     <name>HK2 config types</name>
     <packaging>glassfish-jar</packaging>
@@ -101,7 +100,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.hk2</groupId>
+            <groupId>fish.payara.server.internal.hk2</groupId>
             <artifactId>hk2-config</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/hk2/hk2-config/pom.xml
+++ b/nucleus/hk2/hk2-config/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>glassfish-nucleus-hk2</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.hk2</groupId>
     <artifactId>hk2-config</artifactId>
     
     <name>HK2 configuration module</name>

--- a/nucleus/osgi-platforms/osgi-cli-interactive/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-interactive/pom.xml
@@ -72,7 +72,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/osgi-platforms/osgi-cli-remote/pom.xml
+++ b/nucleus/osgi-platforms/osgi-cli-remote/pom.xml
@@ -67,12 +67,12 @@
             <artifactId>osgi.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/osgi-platforms/osgi-container/pom.xml
+++ b/nucleus/osgi-platforms/osgi-container/pom.xml
@@ -82,12 +82,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/packager/external/j-interop/pom.xml
+++ b/nucleus/packager/external/j-interop/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.packager</groupId>
     <artifactId>j-interop-repackaged</artifactId>
     <name>j-interop repackaged as a module</name>
     <build>

--- a/nucleus/packager/external/jmxremote_optional/pom.xml
+++ b/nucleus/packager/external/jmxremote_optional/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.packager</groupId>
     <artifactId>jmxremote_optional-repackaged</artifactId>
     <name>jmxremote_optional repackaged as a module</name>
     <description>jmxremote_optional repackaged as a module</description>

--- a/nucleus/packager/external/ldapbp/pom.xml
+++ b/nucleus/packager/external/ldapbp/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.packager</groupId>
     <artifactId>ldapbp-repackaged</artifactId>
     <name>ldapbp repackaged as a module</name>
     <description>ldapbp repackaged as a module</description>

--- a/nucleus/packager/external/opentelemetry-repackaged/pom.xml
+++ b/nucleus/packager/external/opentelemetry-repackaged/pom.xml
@@ -51,8 +51,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-
-    <groupId>fish.payara.server.core.packager</groupId>
     <artifactId>opentelemetry-repackaged</artifactId>
     <name>Repackaged OpenTelemetry</name>
     <description>OpenTelemetry API and SDK repackaged as OSGi bundle</description>

--- a/nucleus/packager/external/opentracing-repackaged/pom.xml
+++ b/nucleus/packager/external/opentracing-repackaged/pom.xml
@@ -46,7 +46,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.packager</groupId>
     <artifactId>opentracing-repackaged</artifactId>
 
     <name>Repackaged OpenTracing</name>

--- a/nucleus/packager/external/tiger-types/pom.xml
+++ b/nucleus/packager/external/tiger-types/pom.xml
@@ -40,7 +40,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
 
-    <groupId>fish.payara.server.core.packager</groupId>
     <artifactId>tiger-types</artifactId>
 
     <name>Repackaged Tiger-Types</name>

--- a/nucleus/packager/external/trilead-ssh2/pom.xml
+++ b/nucleus/packager/external/trilead-ssh2/pom.xml
@@ -50,7 +50,6 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.packager</groupId>
     <artifactId>trilead-ssh2-repackaged</artifactId>
     <name>trilead-ssh2 repackaged as a module</name>
 

--- a/nucleus/packager/hazelcast-package/pom.xml
+++ b/nucleus/packager/hazelcast-package/pom.xml
@@ -56,7 +56,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <artifactId>hazelcast</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/packager/healthcheck-package/pom.xml
+++ b/nucleus/packager/healthcheck-package/pom.xml
@@ -53,7 +53,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -63,7 +63,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-stuck</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/packager/nucleus-cluster/pom.xml
+++ b/nucleus/packager/nucleus-cluster/pom.xml
@@ -60,37 +60,37 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-cli</artifactId>
             <version>${project.version}</version>
 	        <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-admin</artifactId>
             <version>${project.version}</version>
     	    <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-common</artifactId>
             <version>${project.version}</version>
 	        <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.cluster</groupId>
+            <groupId>fish.payara.server.internal.cluster</groupId>
             <artifactId>cluster-ssh</artifactId>
             <version>${project.version}</version>
 	        <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>j-interop-repackaged</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency> 
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>trilead-ssh2-repackaged</artifactId>
             <version>${project.version}</version>
 	        <optional>true</optional>

--- a/nucleus/packager/nucleus-common/pom.xml
+++ b/nucleus/packager/nucleus-common/pom.xml
@@ -69,7 +69,7 @@
            <optional>true</optional>
        </dependency>
         <dependency>
-    	    <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>monitoring-core</artifactId>
             <version>${project.version}</version>
            <optional>true</optional>

--- a/nucleus/packager/nucleus-grizzly/pom.xml
+++ b/nucleus/packager/nucleus-grizzly/pom.xml
@@ -62,7 +62,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.grizzly</groupId>
+            <groupId>fish.payara.server.internal.grizzly</groupId>
             <artifactId>nucleus-grizzly-all</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/nucleus/packager/nucleus-hk2/pom.xml
+++ b/nucleus/packager/nucleus-hk2/pom.xml
@@ -71,7 +71,7 @@
             <artifactId>hk2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.hk2</groupId>
+            <groupId>fish.payara.server.internal.hk2</groupId>
             <artifactId>hk2-config</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -104,7 +104,7 @@
             <artifactId>jakarta.inject</artifactId>
         </dependency>-->
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>tiger-types</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/packager/nucleus-jmx/pom.xml
+++ b/nucleus/packager/nucleus-jmx/pom.xml
@@ -56,19 +56,19 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-mbeanserver</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>amx-core</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>jmxremote_optional-repackaged</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/nucleus/packager/nucleus-management/pom.xml
+++ b/nucleus/packager/nucleus-management/pom.xml
@@ -68,7 +68,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>rest-client</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/nucleus/packager/nucleus/pom.xml
+++ b/nucleus/packager/nucleus/pom.xml
@@ -77,49 +77,49 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>api-exporter</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>glassfish</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.hk2</groupId>
+            <groupId>fish.payara.server.internal.hk2</groupId>
             <artifactId>config-types</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
@@ -142,7 +142,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
@@ -153,37 +153,37 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>launcher</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>logging</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>scattered-archive-api</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
@@ -194,7 +194,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.flashlight</groupId>
+            <groupId>fish.payara.server.internal.flashlight</groupId>
             <artifactId>flashlight-framework</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
@@ -218,31 +218,31 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>server-mgmt</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security-services</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>ssl-impl</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>ldapbp-repackaged</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/nucleus/packager/payara-executor-service-package/pom.xml
+++ b/nucleus/packager/payara-executor-service-package/pom.xml
@@ -53,7 +53,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/packager/requesttracing-package/pom.xml
+++ b/nucleus/packager/requesttracing-package/pom.xml
@@ -31,22 +31,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>opentracing-adapter</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>opentracing-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>opentelemetry-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/asadmin-audit/pom.xml
+++ b/nucleus/payara-modules/asadmin-audit/pom.xml
@@ -55,12 +55,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/asadmin-recorder/pom.xml
+++ b/nucleus/payara-modules/asadmin-recorder/pom.xml
@@ -67,12 +67,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/hazelcast-bootstrap/pom.xml
+++ b/nucleus/payara-modules/hazelcast-bootstrap/pom.xml
@@ -45,7 +45,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.payara-modules</groupId>
     <artifactId>hazelcast-bootstrap</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -70,7 +69,7 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -79,7 +78,7 @@
             <artifactId>hazelcast</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -88,7 +87,7 @@
             <artifactId>cache-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-cli</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/healthcheck-core/pom.xml
+++ b/nucleus/payara-modules/healthcheck-core/pom.xml
@@ -46,7 +46,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <artifactId>payara-nucleus-modules</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.payara-modules</groupId>
     <artifactId>healthcheck-core</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>Healthcheck Core services</name>
@@ -90,12 +89,12 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
             <artifactId>payara-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
             <type>jar</type>

--- a/nucleus/payara-modules/healthcheck-cpool/pom.xml
+++ b/nucleus/payara-modules/healthcheck-cpool/pom.xml
@@ -78,7 +78,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/healthcheck-stuck/pom.xml
+++ b/nucleus/payara-modules/healthcheck-stuck/pom.xml
@@ -48,7 +48,6 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
         <artifactId>payara-nucleus-modules</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.payara-modules</groupId>
     <artifactId>healthcheck-stuck</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>Healthcheck Stuck Threads</name>
@@ -67,7 +66,7 @@ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>healthcheck-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/notification-cdi-eventbus-core/pom.xml
+++ b/nucleus/payara-modules/notification-cdi-eventbus-core/pom.xml
@@ -57,13 +57,13 @@
             <artifactId>payara-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/notification-core/pom.xml
+++ b/nucleus/payara-modules/notification-core/pom.xml
@@ -75,12 +75,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>logging</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -94,7 +94,7 @@
             <artifactId>jakarta.jakartaee-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/notification-eventbus-core/pom.xml
+++ b/nucleus/payara-modules/notification-eventbus-core/pom.xml
@@ -56,13 +56,13 @@
             <artifactId>payara-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/pom.xml
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/pom.xml
@@ -70,32 +70,32 @@
             <artifactId>hk2-runlevel</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.nucleus</groupId>
+            <groupId>fish.payara.server.internal.core</groupId>
             <artifactId>kernel</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.resources</groupId>
+            <groupId>fish.payara.server.internal.resources</groupId>
             <artifactId>resources-connector</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/opentracing-adapter/pom.xml
+++ b/nucleus/payara-modules/opentracing-adapter/pom.xml
@@ -45,8 +45,7 @@
         <artifactId>payara-nucleus-modules</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    
-    <groupId>fish.payara.server.core.payara-modules</groupId>
+
     <artifactId>opentracing-adapter</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -55,17 +54,17 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>requesttracing-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>opentracing-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.packager</groupId>
+            <groupId>fish.payara.server.internal.packager</groupId>
             <artifactId>opentelemetry-repackaged</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/payara-executor-service/pom.xml
+++ b/nucleus/payara-modules/payara-executor-service/pom.xml
@@ -45,7 +45,6 @@
         <artifactId>payara-nucleus-modules</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.payara-modules</groupId>
     <artifactId>payara-executor-service</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -57,12 +56,12 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/phonehome-bootstrap/pom.xml
+++ b/nucleus/payara-modules/phonehome-bootstrap/pom.xml
@@ -68,17 +68,17 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
             <type>jar</type>

--- a/nucleus/payara-modules/requesttracing-core/pom.xml
+++ b/nucleus/payara-modules/requesttracing-core/pom.xml
@@ -46,7 +46,6 @@
         <artifactId>payara-nucleus-modules</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.payara-modules</groupId>
     <artifactId>requesttracing-core</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>Request Tracing Core services</name>
@@ -103,7 +102,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -117,7 +116,7 @@
             <artifactId>payara-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -137,7 +136,7 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>payara-executor-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/payara-modules/service-exemplar/pom.xml
+++ b/nucleus/payara-modules/service-exemplar/pom.xml
@@ -71,22 +71,22 @@
             <artifactId>hk2-runlevel</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.payara-modules</groupId>
+            <groupId>fish.payara.server.internal.payara-modules</groupId>
             <artifactId>hazelcast-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -408,7 +408,7 @@
                             <rules>
                                 <requireJavaVersion>
                                     <version>[${jdk.version},)</version>
-                                    <message>You need at least JDK11</message>
+                                    <message>You need at least JDK21</message>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.6.3,)</version>

--- a/nucleus/resources-l10n/osgi.bundle
+++ b/nucleus/resources-l10n/osgi.bundle
@@ -37,5 +37,6 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright 2025 Payara Foundation and/or its affiliates
 
-Fragment-Host: fish.payara.server.internal.nucleus-resources; bundle-version=${project.osgi.version}
+Fragment-Host: fish.payara.server.internal.resourcebase.resources.nucleus-resources; bundle-version=${project.osgi.version}

--- a/nucleus/resources/pom.xml
+++ b/nucleus/resources/pom.xml
@@ -49,7 +49,7 @@
         <artifactId>payara-nucleus-parent</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.resourcebase.resources</groupId>
+    <groupId>fish.payara.server.internal.resourcebase.resources</groupId>
     <artifactId>nucleus-resources</artifactId>    
     <packaging>glassfish-jar</packaging>
     
@@ -88,7 +88,7 @@
 	    <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/security/core/pom.xml
+++ b/nucleus/security/core/pom.xml
@@ -50,7 +50,6 @@
         <artifactId>nucleus-security</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.security</groupId>
     <artifactId>security</artifactId>
     <packaging>glassfish-jar</packaging>
 
@@ -176,32 +175,32 @@
             <artifactId>hk2</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>ssl-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.deployment</groupId>
+            <groupId>fish.payara.server.internal.deployment</groupId>
             <artifactId>deployment-common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/security/services/pom.xml
+++ b/nucleus/security/services/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>nucleus-security</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.security</groupId>
     <artifactId>security-services</artifactId>
     <packaging>glassfish-jar</packaging>
     
@@ -66,27 +65,27 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.security</groupId>
+            <groupId>fish.payara.server.internal.security</groupId>
             <artifactId>security</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/security/ssl-impl/pom.xml
+++ b/nucleus/security/ssl-impl/pom.xml
@@ -49,7 +49,6 @@
         <artifactId>nucleus-security</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
-    <groupId>fish.payara.server.core.security</groupId>
     <artifactId>ssl-impl</artifactId>
     <packaging>glassfish-jar</packaging>
     <name>GlassFish SSL Implementation Module</name>
@@ -66,12 +65,12 @@
     </developers>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/test-utils/utils-ng/pom.xml
+++ b/nucleus/test-utils/utils-ng/pom.xml
@@ -66,7 +66,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/test-utils/utils/pom.xml
+++ b/nucleus/test-utils/utils/pom.xml
@@ -49,7 +49,6 @@
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fish.payara.server.core.test-utils</groupId>
     <artifactId>utils</artifactId>
     <name>Test utilities</name>
     <properties>
@@ -79,7 +78,7 @@
             <artifactId>hk2-junitrunner</artifactId>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -89,7 +88,7 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -136,13 +136,13 @@ of COPY_LIB map constant.)
     </build>
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils-ng</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -158,7 +158,7 @@ of COPY_LIB map constant.)
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>rest-client</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/nucleus/tests/admin/src/addon/modules/test-progress-status-commands/pom.xml
+++ b/nucleus/tests/admin/src/addon/modules/test-progress-status-commands/pom.xml
@@ -79,17 +79,17 @@
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.admin</groupId>
+            <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>config-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/nucleus/tests/quicklook/pom.xml
+++ b/nucleus/tests/quicklook/pom.xml
@@ -81,19 +81,19 @@ utilities are in the NucleusTestUtils class.
     
     <dependencies>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>common-util</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.common</groupId>
+            <groupId>fish.payara.server.internal.common</groupId>
             <artifactId>glassfish-mbeanserver</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>fish.payara.server.core.test-utils</groupId>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
             <artifactId>utils-ng</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,26 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
+            <releases>
+                <enabled>${payara-nexus-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${payara-nexus-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>jakarta-releases</id>
+            <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+            <releases>
+                <enabled>${jakarta-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${jakarta-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -145,6 +165,26 @@
             </releases>
             <snapshots>
                 <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
+            <releases>
+                <enabled>${payara-nexus-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${payara-nexus-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>jakarta-releases</id>
+            <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+            <releases>
+                <enabled>${jakarta-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${jakarta-staging.repo.snapshots.enabled}</enabled>
             </snapshots>
         </pluginRepository>
     </pluginRepositories>
@@ -215,6 +255,10 @@
         <deploy.skip>false</deploy.skip>
         <javadoc.skip>true</javadoc.skip>
         <source.skip>true</source.skip>
+        <jakarta-staging.repo.releases.enabled>false</jakarta-staging.repo.releases.enabled>
+        <jakarta-staging.repo.snapshots.enabled>false</jakarta-staging.repo.snapshots.enabled>
+        <payara-nexus-staging.repo.releases.enabled>false</payara-nexus-staging.repo.releases.enabled>
+        <payara-nexus-staging.repo.snapshots.enabled>false</payara-nexus-staging.repo.snapshots.enabled>
 
         <!-- BOM-referenced versions -->
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
@@ -451,46 +495,18 @@
 
         <profile>
             <id>payara-nexus-staging</id>
-            <repositories>
-                <repository>
-                    <id>payara-nexus-staging</id>
-                    <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>payara-nexus-staging</id>
-                    <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
+            <properties>
+                <payara-nexus-staging.repo.releases.enabled>true</payara-nexus-staging.repo.releases.enabled>
+                <payara-nexus-staging.repo.snapshots.enabled>true</payara-nexus-staging.repo.snapshots.enabled>
+            </properties>
         </profile>
 
         <profile>
             <id>jakarta-staging</id>
-            <repositories>
-                <repository>
-                    <id>jakarta-releases</id>
-                    <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
+            <properties>
+                <jakarta-staging.repo.releases.enabled>true</jakarta-staging.repo.releases.enabled>
+                <jakarta-staging.repo.snapshots.enabled>true</jakarta-staging.repo.snapshots.enabled>
+            </properties>
         </profile>
 
         <profile>


### PR DESCRIPTION
## Description
Follow-up to https://github.com/payara/Payara/pull/7318

Removes the "core" Maven group ID.
Also adjusts the fragment hosts and some other files which are based off of these IDs. This includes fixing the incorrect fragment-host defined for nucleus/resources-l10n

This is done to help avoid any conflicts that we may end up with the old Core module version and the Enterprise module version as they now share the same Maven GAV.

Also includes the extra change introduced [here](https://github.com/payara/Payara/pull/7321), with the addition of the `jakarta-staging` repository.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Wiped maven repo and built the server: Server, Micro, Embedded, and Docker all resolve.
Started Payara Server and loaded admin console - no explosions.

### Testing Environment
Windows 11, Maven 3.9.9, Zulu JDK 21.0.6

## Documentation
Later™

## Notes for Reviewers
Trust Me™
