### PR TITLE
Change createTempDir to use Java nio Files package

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CheckpointHelper.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CheckpointHelper.java
@@ -42,6 +42,7 @@ package com.sun.enterprise.v3.admin;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -508,15 +509,8 @@ public class CheckpointHelper {
         }
     }
 
-    private File createTempDir(final String prefix, final String suffix) throws IOException {
-        File temp = File.createTempFile(prefix, suffix);
-        if ( ! temp.delete()) {
-            throw new IOException("Cannot delete temp file " + temp.getAbsolutePath());
-        }
-        if ( ! temp.mkdirs()) {
-            throw new IOException("Cannot create temp directory" + temp.getAbsolutePath());
-        }
-        return temp;
+    private File createTempDir(final String prefix) throws IOException {
+            return Files.createTempDirectory(prefix).toFile();
     }
 
     private static final String CONTENT_TYPE_NAME = "Content-Type";


### PR DESCRIPTION
## Description
This PR changes the createTempDir method in CheckpointHelper.java to use Files.createTempDirectory for safer and more modern temporary directory creation. Removes potential race condition and simplifies the code by leveraging the atomic directory creation provided by the Java nio files package


## Documentation
Similar thing was done here: https://github.com/openkm/document-management-system/commit/c069e4d73ab8864345c25119d8459495f45453e1

