### PR TITLE
Align REST Monitoring WAR Version

### DIFF
--- a/appserver/packager/rest-monitoring/pom.xml
+++ b/appserver/packager/rest-monitoring/pom.xml
@@ -53,7 +53,6 @@
 
     <properties>
         <temp.dir>${project.build.directory}/dependency</temp.dir>
-        <rest.monitoring.version>1.0.0-Beta</rest.monitoring.version>
     </properties>
 
     <build>
@@ -110,7 +109,7 @@
         <dependency>
             <groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
             <artifactId>rest-monitoring-war</artifactId>
-            <version>${rest.monitoring.version}</version>
+            <version>${project.version}</version>
             <type>war</type>
             <optional>true</optional>
         </dependency>

--- a/appserver/packager/rest-monitoring/pom.xml
+++ b/appserver/packager/rest-monitoring/pom.xml
@@ -2,7 +2,7 @@
 <!--
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
+++ b/appserver/payara-appserver-modules/rest-monitoring/rest-monitoring-war/pom.xml
@@ -49,7 +49,6 @@
     <artifactId>rest-monitoring-war</artifactId>
     <packaging>war</packaging>
     <name>Rest Monitoring War</name>
-    <version>1.0.0-Beta</version>
     
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -602,7 +602,7 @@ Parent is ${project.parent}</echo>
             <dependency>
                 <groupId>fish.payara.api</groupId>
                 <artifactId>payara-bom</artifactId>
-                <!-- A workaround for case when module redefines its version (rest-monitoring-war) -->
+                <!-- A workaround for case when module redefines its version -->
                 <version>${project.parent.version}</version>
                 <type>pom</type>
                 <scope>import</scope>


### PR DESCRIPTION
## Description
This shouldn't be 1.0.0-Beta anymore really - the inherited dependencies and build config has changed over time

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* Started the server
* Set all monitoring levels to _High_ and enabled the monitoring service at _Admin Console > Configurations > server-config > Monitoring_ 
* Set _AMX_ to true under Set all monitoring levels to _High_ and enabled the monitoring service at _Admin Console > Configurations > server-config > Monitoring > JMX_ 
* Enabled REST Monitoring at Set all monitoring levels to _High_ and enabled the monitoring service at _Admin Console > Configurations > server-config > Monitoring > JMX > REST_
* Restarted the domain
* Pinged http://localhost:4848/rest-monitoring/rest/read/java.lang:type=Memory - got data.

### Testing Environment
Windows 11, Zulu JDK 21.0.6, Maven 3.9.9

## Documentation
Later™

## Notes for Reviewers
None
