### PR TITLE
FISH-10996 Fix Aggregate Javadoc Generation

### DIFF
--- a/appserver/admingui/faces-compat/pom.xml
+++ b/appserver/admingui/faces-compat/pom.xml
@@ -198,6 +198,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,8 @@
         <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
         <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
+        <!-- Be careful updating to a higher version - an issue affecting 3.10.0-3.11.2 causes the aggregate jar to be empty -->
+        <maven.javadoc.plugin.version>3.8.0</maven.javadoc.plugin.version>
         <maven.install.plugin.version>3.1.4</maven.install.plugin.version>
         <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
         <maven.failsafe.plugin.version>3.5.3</maven.failsafe.plugin.version>
@@ -388,6 +389,9 @@
                     <value>true</value>
                 </property>
             </activation>
+            <properties>
+                <javadoc.skip>false</javadoc.skip>
+            </properties>
             <build>
                 <finalName>payara-${project.version}</finalName>
                 <plugins>


### PR DESCRIPTION
## Description
There appears to be an issue with all versions higher than 3.10.0 that causes the aggregate JAR to be empty.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
* Create empty build repo for testing: `mkdir D:\Downloads\Maven2`
* Create empty deployment repo for testing: `mkdir D:\Downloads\Maven3`
* Built and deploy the server using these directories: `mvn clean deploy -PBuildEmbedded "-Dmaven.repo.local=D:\Downloads\Maven2" "-DaltDeploymentRepository=local::file:///D:\Downloads\Maven3" -DskipTests -T 1C` - javadoc for payara-api is correctly generated (not an empty jar) and deployed as expected
* Generate the aggregate Server javadoc: `mvn pre-site -Pjavadoc "-Dmaven.repo.local=D:\Downloads\Maven2"` - javadoc (available under `Payara/target`) is correctly generated (not an empty jar), containing docs for the `com`, `org`, and `fish` package namespaces

### Testing Environment
Windows 11, Zulu JDK 11.0.26, Maven 3.9.9

## Documentation
None

## Notes for Reviewers
None
