### PR TITLE
FISH-10886 Build compatibility with Java 17

### DIFF
--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -138,5 +138,17 @@
             <artifactId>opentracing-api</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 

--- a/appserver/jdbc/jdbc-runtime/pom.xml
+++ b/appserver/jdbc/jdbc-runtime/pom.xml
@@ -73,7 +73,7 @@
                     <classpathDependencyExcludes>
                         <classpathDependencyExcludes>fish.payara.server.internal.core:kernel</classpathDependencyExcludes>
                     </classpathDependencyExcludes>
-                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/appserver/jdbc/jdbc-runtime/pom.xml
+++ b/appserver/jdbc/jdbc-runtime/pom.xml
@@ -73,11 +73,12 @@
                     <classpathDependencyExcludes>
                         <classpathDependencyExcludes>fish.payara.server.internal.core:kernel</classpathDependencyExcludes>
                     </classpathDependencyExcludes>
+                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>fish.payara.server.internal.connectors</groupId>

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/RecoveryManager.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/RecoveryManager.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation]
+// Portions Copyright 2016-2024 Payara Foundation and/or its affiliates.
 //----------------------------------------------------------------------------
 //
 // Module:      RecoveryManager.java
@@ -242,7 +242,6 @@ public class RecoveryManager {
      * @param localTID   The local identifier for the transaction.
      * @param coord      The Coordinator for the transaction.
      * @param timeout    The timeout for the transaction.
-     * @param log        The log object for the transaction.
      *
      * @return  Indicates success of the operation.
      *
@@ -1479,7 +1478,7 @@ public class RecoveryManager {
     /**
     *  Waits for resync to complete with timeout.
     *
-    * @param cmtTimeout Container managed transaction timeout
+    * @param cmtTimeOut Container managed transaction timeout
     *
     * @return
     *
@@ -1907,7 +1906,7 @@ class ResyncThread extends Thread  {
      * @see
      */
     public void run() {
-        yield();
+        Thread.yield();
 
 	if(_logger.isLoggable(Level.FINE))
 	{

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -86,6 +86,15 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -194,6 +194,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens=java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/eventbus/EventBus.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/eventbus/EventBus.java
@@ -120,7 +120,7 @@ public class EventBus implements EventListener, MonitoringDataSource {
     /**
      * Adds a message receiver to listen to message send on the Hazelcast EventBus
      * @param topic The name of the topic to recive messages on
-     * @param mr A {@link MessageReciever} to listen for messages
+     * @param mr A {@link fish.payara.nucleus.eventbus.MessageReceiver} to listen for messages
      * @return true if successfully registered, false otherwise (i.e. if Hazelcast
      * is not enabled)
      */
@@ -147,7 +147,7 @@ public class EventBus implements EventListener, MonitoringDataSource {
     /**
      * Stops a message receiver from listening to messages on the specified topic
      * @param topic The name of the topic that messages have been received on
-     * @param mr The {@link MessageReciever} to stop listening for messages
+     * @param mr The {@link fish.payara.nucleus.eventbus.MessageReceiver} to stop listening for messages
      */
     public void removeMessageReceiver(String topic, MessageReceiver<?> mr) {
         TopicListener tl = messageReceivers.get(topic);

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryStrategy.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/DomainDiscoveryStrategy.java
@@ -81,6 +81,7 @@ import java.util.logging.Logger;
  * of host-aware partitioning and custom API-based discovery strategy
  *
  * @author lprimak
+ * @author steve
  */
 public final class DomainDiscoveryStrategy extends AbstractDiscoveryStrategy {
     private final boolean hostAwarePartitioning;
@@ -97,7 +98,6 @@ public final class DomainDiscoveryStrategy extends AbstractDiscoveryStrategy {
      * Provides a Discovery SPI implementation for Hazelcast that uses knowledge
      * of the domain topology to build out the cluster and discover members
      * @since 5.0
-     * @author steve
      */
     @Override
     public Iterable<DiscoveryNode> discoverNodes() {

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -278,7 +278,7 @@ public class HazelcastCore implements EventListener, ConfigListener {
     /**
      * Gets the JCache provider used by Hazelcast
      * @return
-     * @see <a href=http://docs.hazelcast.org/docs/3.8.6/javadoc/com/hazelcast/cache/HazelcastCachingProvider.html">HazelcastCachingProvider</a>
+     * @see <a href="http://docs.hazelcast.org/docs/3.8.6/javadoc/com/hazelcast/cache/HazelcastCachingProvider.html">HazelcastCachingProvider</a>
      */
     public CachingProvider getCachingProvider() {
         bootstrapHazelcast();

--- a/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/source/DirConfigSourceTest.java
+++ b/nucleus/payara-modules/nucleus-microprofile/config-service/src/test/java/fish/payara/nucleus/microprofile/config/source/DirConfigSourceTest.java
@@ -119,6 +119,8 @@ public class DirConfigSourceTest {
     @Test
     public void testFindDir_NotExistingPath() throws IOException {
         // given
+        // Need to set instanceRoot property to something else we hit a NPE - this property Should™ always be set
+        System.setProperty("com.sun.aas.instanceRoot", testDirectory.toString());
         MicroprofileConfigConfiguration config = mock(MicroprofileConfigConfiguration.class);
         when(configService.getMPConfig()).thenReturn(config);
         when(config.getSecretDir()).thenReturn(DirConfigSource.DEFAULT_DIR);

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/audit/BaseAuditManager.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/audit/BaseAuditManager.java
@@ -193,7 +193,6 @@ public class BaseAuditManager<T extends BaseAuditModule> implements AuditManager
      * Add the given audit module to the list of loaded audit module.
      * Adding the same name twice will override previous one.
      * @param name of auditModule
-     * @param am an instance of a class extending BaseAuditModule that has been 
      * successfully loaded into the system.
      * @exception 
      */
@@ -284,7 +283,6 @@ public class BaseAuditManager<T extends BaseAuditModule> implements AuditManager
     
     /**
      * logs the authentication call for all the loaded modules.
-     * @see com.sun.appserv.security.BaseAuditModule.authentication
      */
     @Override
     public void authentication(final String user, final String realm, final boolean success){

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/ldap/CustomSocketFactory.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/ldap/CustomSocketFactory.java
@@ -93,7 +93,7 @@ public class CustomSocketFactory extends SocketFactory implements Comparator<Soc
      * The cause of the issue is that new implementation from blocking mechanism during creation of socket connections
      * is setting a positive value for the parameter connectTimeout instead of using -1 (as previous versions did)
      * to control the creation. For more information about the changes please check
-     * @see < href="https://github.com/openjdk/jdk/pull/6568">jdk connection timeout pr</>
+     * @see <a href="https://github.com/openjdk/jdk/pull/6568">jdk connection timeout pr</a>
      * @return Socket instance with default ssl context
      * @throws IOException
      */

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateAuditModule.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateAuditModule.java
@@ -83,11 +83,13 @@ import org.glassfish.config.support.TargetType;
  *        [--port 4848|4849] [--secure | -s] [--user admin_user] 
  *        [--passwordfile file_name] [--property (name=value)
  *        [:name=value]*] [--target target(Default server)] audit_module_name
- *  
+ *
  * domain.xml element example
+ * {@code
  * <audit-module classname="com.foo.security.Audit" name="AM">
  *     <property name="auditOn" value="false"/>
  * </audit-module>
+ * }
  *
  * @author Nandini Ektare
  */

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateAuthRealm.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateAuthRealm.java
@@ -100,15 +100,19 @@ import javax.security.auth.login.Configuration;
  *        [--echo=false] [--target target(Default server)] auth_realm_name
  *
  * domain.xml element example
+ * {@code
  * <auth-realm name="file"
  *   classname="com.sun.enterprise.security.auth.realm.file.FileRealm">
  *   <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile"/>
  *   <property name="jaas-context" value="fileRealm"/>
  * </auth-realm>
+ * }
  *       Or
+ * {@code
  * <auth-realm name="certificate"
  *   classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm">
  * </auth-realm>
+ * }
  *
  * @author Nandini Ektare
  */

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateJACCProvider.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateJACCProvider.java
@@ -84,8 +84,10 @@ import org.jvnet.hk2.config.types.Property;
  *
  *
  * domain.xml element example
- *   <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl">
+ * {@code
+ *    <jacc-provider policy-provider="fish.payara.security.jacc.provider.PolicyProviderImpl" name="default" policy-configuration-factory-provider="fish.payara.security.jacc.provider.PolicyConfigurationFactoryImpl">
  *   </jacc-provider>
+ * }
  *
  */
 @Service(name="create-jacc-provider")

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateMessageSecurityProvider.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateMessageSecurityProvider.java
@@ -94,6 +94,7 @@ import org.glassfish.config.support.TargetType;
  *  
  * domain.xml element example
  *  
+ * {@code
  *  <message-security-config auth-layer="SOAP">
  *      <!-- turned off by default -->
  *      <provider-config class-name="com.sun.wss.provider.ClientSecAuthModule" 
@@ -106,6 +107,7 @@ import org.glassfish.config.support.TargetType;
  *      <property name="debug" value="false"/>
  *      </provider-config>
  *  </message-security-config>
+ *  }
  *
  *  @author Nandini Ektare
  */

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreatePasswordAlias.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreatePasswordAlias.java
@@ -65,17 +65,20 @@ import jakarta.inject.Inject;
  *        [--secure | -s] [--user admin_user] [--passwordfile file_name] aliasname
  *  
  * Result of the command is that:
- * <domain-dir>/<domain-name>/config/domain-passwords file gets appended with 
+ * {@code <domain-dir>/<domain-name>/config/domain-passwords }
+ * file gets appended with
  * the entry of the form: aliasname=<password encrypted with masterpassword>
  *
  * A user can use this aliased password now in setting passwords in domain.xml.
  * Benefit is it is in NON-CLEAR-TEXT
  *
  * domain.xml example entry is:
+ * {@code
  * <provider-config class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" 
  *                  provider-id="XWS_ClientProvider" provider-type="client">
  *      <property name="password" value="${ALIAS=myalias}/>
- * </provider-config> 
+ * </provider-config>
+ * }
  *
  * @author Nandini Ektare
  */

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/common/ClientSecurityContext.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/common/ClientSecurityContext.java
@@ -74,8 +74,8 @@ public final class ClientSecurityContext extends AbstractSecurityContext {
     /**
      * This creates a new ClientSecurityContext object.
      *
-     * @param The name of the user.
-     * @param The Credentials of the user.
+     * @param username name of the user.
+     * @param subject Credentials of the user.
      */
     public ClientSecurityContext(String username, Subject subject) {
         this.callerPrincipal = new PrincipalImpl(username);
@@ -101,7 +101,7 @@ public final class ClientSecurityContext extends AbstractSecurityContext {
     /**
      * This method sets the SecurityContext to be stored here.
      *
-     * @param The Security Context that should be stored.
+     * @param clientSecurityContext The Security Context that should be stored.
      */
     public static void setCurrent(ClientSecurityContext clientSecurityContext) {
         if (isPerThreadAuth) {


### PR DESCRIPTION
## Description
Allows to build and start Payara6 with Java 17.

Inc. fixes to JavaDoc comments which the plugin was rejecting. A mix of genuine syntax errors, as well as a JavaDoc plug-in bug with Java 17: https://bugs.openjdk.org/browse/JDK-8281944
I was not using OpenJDK for my build however, but the symptom and workaround applies, it seems.

## Important Info
### Blockers
None

## Testing
### New tests
No new tests included.


### Testing Performed
Manually tested build with Java 11 (to avoid regression) & 17. Also built with Jenkins.


### Testing Environment
Oracle JDK "17.0.15" 2025-04-15 LTS , Maven 3.9.9, Windows 11.
Jenkins: Zulu JDK 11.x & Zulu JDK 17.x

## Notes for Reviewers
Some unit tests are throwing exceptions but do not register as test failures, nor stop the build.

Example stacktraces:

```
[INFO] Running org.glassfish.web.loader.WebappClassLoaderTest
May 09, 2025 4:05:17 PM org.glassfish.web.loader.WebappClassLoader closeJARs
SEVERE: null
java.lang.reflect.InaccessibleObjectException: Unable to make field private java.util.WeakHashMap java.net.URLClassLoader.closeables accessible: module java.base does not "opens java.net" to unnamed module @2f686d1f
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
        at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
        at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
        at org.glassfish.web.loader.WebappClassLoader.closeJARs(WebappClassLoader.java:2138)
        at org.glassfish.web.loader.WebappClassLoaderTest.lambda$check_findResources_thread_safety$5(WebappClassLoaderTest.java:140)
        at org.glassfish.web.loader.WebappClassLoaderTest.lambda$waitAndDo$6(WebappClassLoaderTest.java:211)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:842) 
```


```
May 09, 2025 4:19:32 PM org.glassfish.concurrent.runtime.ContextSetupProviderImpl initialiseServices
INFO: Error retrieving OpenTracing service during initialisation of Concurrent Context - NullPointerException
java.lang.NullPointerException: Cannot invoke "org.glassfish.hk2.api.ServiceLocator.getService(java.lang.Class, java.lang.annotation.Annotation[])" because the return value of "org.glassfish.internal.api.Globals.getDefaultHabitat()" is null
        at org.glassfish.concurrent.runtime.ContextSetupProviderImpl.initialiseServices(ContextSetupProviderImpl.java:573)
        at org.glassfish.concurrent.runtime.ContextSetupProviderImpl.<init>(ContextSetupProviderImpl.java:168)
        at org.glassfish.concurrent.runtime.ConcurrentRuntime.createContextServiceImpl(ConcurrentRuntime.java:371)
        at org.glassfish.concurrent.runtime.ConcurrentRuntime.createContextService(ConcurrentRuntime.java:192)
        at org.glassfish.concurrent.runtime.ConcurrentRuntime.getContextService(ConcurrentRuntime.java:183)
        at org.glassfish.concurrent.runtime.ConcurrentRuntimeTest.testParseContextInfo_disabled(ConcurrentRuntimeTest.java:133)
```
