### PR TITLE
FISH-10997 Fix Flashlight Module Parents

### DIFF
--- a/appserver/flashlight/btrace/pom.xml
+++ b/appserver/flashlight/btrace/pom.xml
@@ -40,16 +40,15 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>fish.payara.server.internal.common</groupId>
-        <artifactId>common</artifactId>
+        <groupId>fish.payara.server.internal.flashlight</groupId>
+        <artifactId>glassfish-flashlight</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
-        <relativePath>../../common/pom.xml</relativePath>
     </parent>
-    <groupId>fish.payara.server.internal.flashlight</groupId>
     <artifactId>btrace-jars</artifactId>
     <name>btrace jar files</name>
     <!--

--- a/appserver/flashlight/client/pom.xml
+++ b/appserver/flashlight/client/pom.xml
@@ -45,12 +45,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>fish.payara.server.internal.common</groupId>
-        <artifactId>common</artifactId>
+        <groupId>fish.payara.server.internal.flashlight</groupId>
+        <artifactId>glassfish-flashlight</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
-        <relativePath>../../common/pom.xml</relativePath>
     </parent>
-    <groupId>fish.payara.server.internal.flashlight</groupId>
     <artifactId>flashlight-client</artifactId>
     <packaging>glassfish-jar</packaging>
     

--- a/nucleus/flashlight/agent/pom.xml
+++ b/nucleus/flashlight/agent/pom.xml
@@ -40,17 +40,15 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright 2018-2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>fish.payara.server.internal.common</groupId>
-        <artifactId>nucleus-common</artifactId>
+        <groupId>fish.payara.server.internal.flashlight</groupId>
+        <artifactId>nucleus-flashlight</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
-        <relativePath>../../common/pom.xml</relativePath>
     </parent>
-    <groupId>fish.payara.server.internal.flashlight</groupId>
     <artifactId>flashlight-agent</artifactId>
     <name>flashlight-agent</name>
     <build>

--- a/nucleus/flashlight/flashlight-extra-jdk-packages/pom.xml
+++ b/nucleus/flashlight/flashlight-extra-jdk-packages/pom.xml
@@ -40,17 +40,15 @@
     holder.
 
 -->
-<!-- Portions Copyright [2018-2019] [Payara Foundation and/or its affiliates] -->
+<!-- Portions Copyright 2018-2025 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>fish.payara.server.internal.common</groupId>
-        <artifactId>nucleus-common</artifactId>
+        <groupId>fish.payara.server.internal.flashlight</groupId>
+        <artifactId>nucleus-flashlight</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
-        <relativePath>../../common/pom.xml</relativePath>
     </parent>
-    <groupId>fish.payara.server.internal.flashlight</groupId>
     <artifactId>flashlight-extra-jdk-packages</artifactId>
     <name>GlassFish Flashlight Extra JDK Pkgs</name>
     

--- a/nucleus/flashlight/framework/pom.xml
+++ b/nucleus/flashlight/framework/pom.xml
@@ -45,12 +45,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>fish.payara.server.internal.common</groupId>
-        <artifactId>nucleus-common</artifactId>
+        <groupId>fish.payara.server.internal.flashlight</groupId>
+        <artifactId>nucleus-flashlight</artifactId>
         <version>7.2025.1.Alpha2-SNAPSHOT</version>
-        <relativePath>../../common/pom.xml</relativePath>
     </parent>
-    <groupId>fish.payara.server.internal.flashlight</groupId>
     <artifactId>flashlight-framework</artifactId>
     <packaging>glassfish-jar</packaging>
     


### PR DESCRIPTION
## Description
They were pointing at nucleus common and appserver common, which provide no extra config on top of their own parents. I assume they were moved out of these directories at some point and erroneously retained the original parent.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Wiped maven repo.
Built server - everything resolved.

### Testing Environment
Windows 11, Zulu JDK 21.0.6, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
None
