### PR TITLE
FISH-10839 Clear stored session data

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/security/AdminConsoleAuthModule.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/security/AdminConsoleAuthModule.java
@@ -99,7 +99,7 @@ public class AdminConsoleAuthModule implements ServerAuthModule {
 
     private static final String SAVED_SUBJECT = "Saved_Subject";
     private static final String USER_NAME = "userName";
-    private static final String ORIG_REQUEST_PATH = "origRequestPath";
+    private static final String ORIG_REQUEST_PATH = "__origRequestPath";
     private static final String RESPONSE_TYPE = "application/json";
 
     /**
@@ -369,6 +369,9 @@ public class AdminConsoleAuthModule implements ServerAuthModule {
         try {
             // Redirect...
             String origRequest = (String) session.getAttribute(ORIG_REQUEST_PATH);
+            //clear session attribute for security reason
+            session.removeAttribute(ORIG_REQUEST_PATH);
+
             // Explicitly test for favicon.ico, as Firefox seems to ask for this on
             // every page
             if (origRequest == null || "/favicon.ico".equals(origRequest)) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

FISH-10839 Clear stored session data

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

I have added two "_" to the `ORIG_REQUEST_PATH` as suggested and after log in, I have removed the attribute `ORIG_REQUEST_PATH` from the session.

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

I added log outputs as I could not get a reproducer to work using servlets. The log output is:

`[#|2025-05-19T14:20:44.249+0100|INFO|Payara 6.2025.3|org.glassfish.admingui|_ThreadID=129;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1747660844249;_LevelValue=800;|
   ORIG_REQUEST_PATH set to: /favicon.ico|#]

[#|2025-05-19T14:20:44.250+0100|INFO|Payara 6.2025.3|org.glassfish.admingui|_ThreadID=129;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1747660844250;_LevelValue=800;|
  Hello after remove the request is: /favicon.ico Get attribute returns: null|#]`

I added a log for before it is removed and after. 

