### PR TITLE
FISH-10888 FISH-7941 Add session HttpOnly and Secure flags to virtual…

### DIFF
--- a/appserver/admingui/web/src/main/resources/configuration/virtualServerAttrs.inc
+++ b/appserver/admingui/web/src/main/resources/configuration/virtualServerAttrs.inc
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- web/configuration/virtualServerAttrs.inc -->
 #include "/common/applications/applicationHandlers.inc"
@@ -68,6 +69,17 @@
         <sun:property id="ssoCookieHttpOnly"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.vs.ssoCookieHttpOnly}" helpText="$resource{i18n_web.vs.ssoCookieHttpOnlyHelp}">
             <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['ssoCookieHttpOnly']}"  selectedValue="true" />
         </sun:property>
+
+        <sun:property id="sessionCookieHttpOnly"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.vs.sessionCookieHttpOnly}" helpText="$resource{i18n_web.vs.sessionCookieHttpOnlyHelp}">
+            <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['sessionCookieHttpOnly']}"  selectedValue="true" />
+        </sun:property>
+
+#         <sun:property id="sessionCookieSecure"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.vs.sessionCookieSecure}" helpText="$resource{i18n_web.vs.sessionCookieSecureHelp}">
+#             <sun:checkbox label="$resource{i18n.common.Enabled}" selected="#{pageSession.valueMap['sessionCookieSecure']}"  selectedValue="true" />
+#         </sun:property>
+        <sun:property id="sessionCookieSecure"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.vs.sessionCookieSecure}" helpText="$resource{i18n_web.vs.sessionCookieSecureHelp}">
+             <sun:dropDown id="cookieSecure"  selected="#{pageSession.valueMap['sessionCookieSecure']}" labels={"$resource{i18n_web.vs.sessionCookieSecure.dynamic}","$resource{i18n_web.vs.alwaysEnable}","$resource{i18n_web.vs.alwaysDisable}"} values={"dynamic","true","false"} />
+         </sun:property>
 
         <sun:property id="nwProps"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.vs.NetworkListeners}" helpText="$resource{i18n_web.vs.NetworkListenersHelp}">
             <sun:listbox id="nw" immediate="#{true}" multiple="#{true}"  rows="$int{4}" 

--- a/appserver/admingui/web/src/main/resources/configuration/virtualServerButtons.inc
+++ b/appserver/admingui/web/src/main/resources/configuration/virtualServerButtons.inc
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- configuration/virtualServerButtons.inc -->
 #include "/common/shared/commonHandlers.inc"
@@ -83,7 +84,7 @@
                             convertToFalse="#{pageSession.convertToFalseList}"
                             onlyUseAttrs="#{pageSession.onlyUseAttrs}"
                     );
-                    setPageSessionAttribute(key="onlyUseAttrs" value={"ssoEnabled", "ssoCookieHttpOnly", "accessLoggingEnabled", "docroot", "accessLog"})
+                    setPageSessionAttribute(key="onlyUseAttrs" value={"ssoEnabled", "ssoCookieHttpOnly", "sessionCookieHttpOnly", "sessionCookieSecure", "accessLoggingEnabled", "docroot", "accessLog"})
                     gf.createEntity(endpoint="#{pageSession.selfUrl}/#{pageSession.valueMap['id']}"
                             attrs="#{pageSession.valueMap}"
                             onlyUseAttrs="#{pageSession.onlyUseAttrs}"

--- a/appserver/admingui/web/src/main/resources/configuration/virtualServerEdit.jsf
+++ b/appserver/admingui/web/src/main/resources/configuration/virtualServerEdit.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- configuration/virtualServerEdit.jsf -->
 
@@ -65,7 +66,8 @@
         gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}.json", valueMap="#{pageSession.valueMap}");
         gf.restRequest(endpoint="#{pageSession.selfUrl}/property.json" method="GET" result="#{requestScope.propTable}");
         setPageSessionAttribute(key="tableList" value="#{requestScope.propTable.data.extraProperties.properties}");
-        setPageSessionAttribute(key="convertToFalseList" value={"ssoCookieHttpOnly"});
+        setPageSessionAttribute(key="convertToFalseList" value={"ssoCookieHttpOnly", "sessionCookieHttpOnly"});
+        setPageSessionAttribute(key="sessionCookieSecure" value="dynamic");
         //set the following for including buttons.inc
         setPageSessionAttribute(key="edit" value="#{true}" );
         setPageSessionAttribute(key="showDefaultButton" value="#{true}" );

--- a/appserver/admingui/web/src/main/resources/configuration/virtualServerNew.jsf
+++ b/appserver/admingui/web/src/main/resources/configuration/virtualServerNew.jsf
@@ -39,6 +39,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2025 Payara Foundation and/or its affiliates -->
 
 <!-- configuration/virtualServerNew.jsf" -->
 
@@ -63,7 +64,8 @@
         mapPut(map="#{pageSession.valueMap}" key="ssoEnabled" value="inherit");
         mapPut(map="#{pageSession.valueMap}" key="accessLoggingEnabled" value="inherit");
         mapPut(map="#{pageSession.valueMap}" key="accessLog" value="");
-        setPageSessionAttribute(key="convertToFalseList" value={"ssoCookieHttpOnly"});
+        setPageSessionAttribute(key="convertToFalseList" value={"ssoCookieHttpOnly", "sessionCookieHttpOnly"});
+        setPageSessionAttribute(key="sessionCookieSecure" value="dynamic");
         setPageSessionAttribute(key="edit" value="#{false}" );
         setPageSessionAttribute(key="showDefaultButton" value="#{true}" );
         setPageSessionAttribute(key="showCancelButton" value="#{true}" );

--- a/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
+++ b/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
@@ -37,7 +37,7 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
-# Portions Copyright [2016-2023] [Payara Foundation and/or its affiliates.]
+# Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates.]
 
 button.GetStatistics=Get Statistics
 
@@ -448,6 +448,12 @@ vs.StateDisabled=Disabled -- Virtual server inactive; return code 403 (refused t
 vs.ssoCookieHttpOnly=SSO Cookie Http Only:
 ## do not translate SSO, Http Only, and JSESSIONIDSSO
 vs.ssoCookieHttpOnlyHelp=Support for HttpOnly flag for JSESSIONIDSSO cookie
+
+vs.sessionCookieHttpOnly=Session Cookie Http Only:
+vs.sessionCookieHttpOnlyHelp=Support for HttpOnly flag for JSESSIONID cookie
+vs.sessionCookieSecure=Session Cookie Secure:
+vs.sessionCookieSecureHelp=Support for Secure flag for JSESSIONID cookie
+vs.sessionCookieSecure.dynamic=Dynamic
 
 vs.ContextRootTableColumn=Context Root(s)
 vs.NetworkListeners=Network Listeners:

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/SessionCookieConfigImpl.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/SessionCookieConfigImpl.java
@@ -37,9 +37,10 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019-2022] Payara Foundation and/or affiliates
+// Portions Copyright [2019-2025] Payara Foundation and/or affiliates
 package org.apache.catalina.core;
 
+import org.apache.catalina.Container;
 import org.apache.catalina.LogFacade;
 import static org.apache.catalina.core.Constants.COOKIE_DOMAIN_ATTR;
 import static org.apache.catalina.core.Constants.COOKIE_HTTP_ONLY_ATTR;
@@ -67,10 +68,10 @@ public class SessionCookieConfigImpl implements SessionCookieConfig {
 
     private static final ResourceBundle rb = LogFacade.getLogger().getResourceBundle();
 
-    private static final boolean DEFAULT_HTTP_ONLY = false;
+    private final boolean DEFAULT_HTTP_ONLY;
     private static final int DEFAULT_MAX_AGE = -1;
     private static final String DEFAULT_NAME = "JSESSIONID";
-    private static final boolean DEFAULT_SECURE = false;
+    private final String DEFAULT_SECURE;
     private static final String RESERVED_CHAR = ";, ";
 
     /**
@@ -78,6 +79,15 @@ public class SessionCookieConfigImpl implements SessionCookieConfig {
      */
     public SessionCookieConfigImpl(StandardContext ctx) {
         this.ctx = ctx;
+        Container parent = ctx.getParent();
+        if (parent instanceof SessionCookieConfigSource) {
+            SessionCookieConfigSource source = (SessionCookieConfigSource) parent;
+            DEFAULT_HTTP_ONLY = source.isSessionCookieHttpOnly();
+            DEFAULT_SECURE = source.getSessionCookieSecure();
+        } else {
+            DEFAULT_HTTP_ONLY = true;
+            DEFAULT_SECURE = "dynamic";
+        }
     }
 
     /**
@@ -233,7 +243,15 @@ public class SessionCookieConfigImpl implements SessionCookieConfig {
     @Override
     public boolean isSecure() {
         String value = getAttribute(COOKIE_SECURE_ATTR);
-        return value == null ? DEFAULT_SECURE : Boolean.parseBoolean(value);
+        if (value != null) {
+            return Boolean.parseBoolean(value);
+        }
+        if (DEFAULT_SECURE.equals("DYNAMIC")) {
+            // Return false as Request.configureSessionCookie() already checks if
+            // the request is secure.
+            return false;
+        }
+        return Boolean.parseBoolean(DEFAULT_SECURE);
     }
 
     @Override
@@ -343,4 +361,7 @@ public class SessionCookieConfigImpl implements SessionCookieConfig {
         return false;
     }
 
+    public String getDefaultSecure() {
+        return DEFAULT_SECURE;
+    }
 }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/SessionCookieConfigSource.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/SessionCookieConfigSource.java
@@ -1,0 +1,45 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.apache.catalina.core;
+
+public interface SessionCookieConfigSource {
+    boolean isSessionCookieHttpOnly();
+    String getSessionCookieSecure();
+}

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
@@ -96,6 +96,7 @@ import org.apache.catalina.authenticator.AuthenticatorBase;
 import org.apache.catalina.authenticator.SingleSignOn;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
+import org.apache.catalina.core.SessionCookieConfigSource;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.core.StandardHost;
 import org.apache.catalina.deploy.ErrorPage;
@@ -177,7 +178,7 @@ import com.sun.web.security.RealmAdapter;
 /**
  * Standard implementation of a virtual server (aka virtual host) in the Payara Server.
  */
-public class VirtualServer extends StandardHost implements org.glassfish.embeddable.web.VirtualServer {
+public class VirtualServer extends StandardHost implements org.glassfish.embeddable.web.VirtualServer, SessionCookieConfigSource {
 
     private static final String SSO_MAX_IDLE = "sso-max-inactive-seconds";
     private static final String SSO_REAP_INTERVAL = "sso-reap-interval-seconds";
@@ -425,6 +426,16 @@ public class VirtualServer extends StandardHost implements org.glassfish.embedda
 
     public void setDomain(Domain domain) {
         this.domain = domain;
+    }
+
+    @Override
+    public String getSessionCookieSecure() {
+        return vsBean.getSessionCookieSecure();
+    }
+
+    @Override
+    public boolean isSessionCookieHttpOnly() {
+        return Boolean.parseBoolean(vsBean.getSessionCookieHttpOnly());
     }
 
     @Override

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/session/WebSessionCookieConfig.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/session/WebSessionCookieConfig.java
@@ -62,7 +62,7 @@ public final class WebSessionCookieConfig extends SessionCookieConfigImpl {
     }
 
     // default web.xml(secure=false) = glassfish-web.xml(cookieSecure=dynamic)
-    private CookieSecureType secureCookieType = CookieSecureType.DYNAMIC;
+    private CookieSecureType secureCookieType = CookieSecureType.valueOf(getDefaultSecure().toUpperCase());
     private CookieSameSiteType sameSiteCookie = null;
 
     public WebSessionCookieConfig(StandardContext context) {

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/VirtualServer.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/VirtualServer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2025] Payara Foundation and/or affiliates
 
 package com.sun.enterprise.config.serverbeans;
 
@@ -317,6 +317,17 @@ public interface VirtualServer extends ConfigBeanProxy, PropertyBag {
     String getSsoCookieHttpOnly();
 
     void setSsoCookieHttpOnly(String value);
+
+    @Attribute(defaultValue = "true")
+    String getSessionCookieHttpOnly();
+
+    void setSessionCookieHttpOnly(String value);
+
+    @Attribute(defaultValue = "dynamic")
+    @Pattern(regexp = "(true|false|dynamic)")
+    String getSessionCookieSecure();
+
+    void setSessionCookieSecure(String value);
 
     @DuckTyped
     void addNetworkListener(String name) throws PropertyVetoException;


### PR DESCRIPTION
… server. Set the default HttpOnly attribute to true

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
resolves #6253
This PR changes the default HttpOnly flag for the JSESSIONID cookie from `false` to `true`

This also introduce the functionality to change the default HttpOnly and Secure flags for the JSESSIONID cookie.
These options can be set via the admin console or the `set` command:

### Admin Console
![image](https://github.com/user-attachments/assets/e232dead-f063-479b-919b-db204c9bde8d)

### Set command
* `set configs.config.server-config.http-service.virtual-server.$+{virtual-server-name}+.session-cookie-http-only=true/false`
* `set configs.config.server-config.http-service.virtual-server.$+{virtual-server-name}+.session-cookie-secure=true/false/dynamic`

Dynamic will set the secure flag depending on if the http connection is secure
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
[hello-world.zip](https://github.com/user-attachments/files/20340869/hello-world.zip)

Used the attached application and tested various combinations.

For example (on Payara Micro): 
Created preboot command file with: `set configs.config.server-config.http-service.virtual-server.server.session-cookie-http-only=false`

Deployed application `java -jar payara-micro.jar --prebootcommandfile preboot.txt --deploy ~/Downloads/hello-world/target/hello-world-0.1-SNAPSHOT.war`

Visited `http://localhost:8080/hello-world-0.1-SNAPSHOT/resources/hello`

Verified http-only flag was false for the JSESSIONID cookie: 
![image](https://github.com/user-attachments/assets/5bfaff2e-26ab-4136-8fd3-3cf10483dc72)



You can modify the glassfish-web.xml and the preboot command file to verify different combinations.  (glassfish-web.xml will override the default value)


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 11.0.26, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/11.0.26-zulu/zulu-11.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "15.1.1", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
https://github.com/payara/Payara-Documentation/pull/599
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
