### PR TITLE
FISH-11137 Add warlibs support to add-library command.

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/AddLibraryCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/AddLibraryCommand.java
@@ -96,7 +96,7 @@ public class AddLibraryCommand implements AdminCommand {
     @Param(primary=true, multiple=true)
     File[] files = null;
 
-    @Param(optional=true, acceptableValues="common, app")
+    @Param(optional=true, acceptableValues="common, app, war")
     String type = "common";
 
     @Inject
@@ -123,6 +123,9 @@ public class AddLibraryCommand implements AdminCommand {
 
         if (type.equals("app")) {
             libDir = new File(libDir, "applibs");
+        }
+        else if (type.equals("war")) {
+            libDir = new File(libDir, "warlibs");
         }
 
         // rename or copy the library file to the appropriate 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/AddLibraryCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/AddLibraryCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright 2017-2022 Payara Foundation and/or affiliates
+ * Portions Copyright 2017-2025 Payara Foundation and/or affiliates
  */
 
 package org.glassfish.deployment.admin;

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/add-library.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/add-library.1
@@ -4,7 +4,7 @@ NAME
        add-library - adds one or more library JAR files to GlassFish Server
 
 SYNOPSIS
-           add-library [--help] [--type={common|ext|app}] [--upload={false|true}]
+           add-library [--help] [--type={common|ext|app|war}] [--upload={false|true}]
 
            library-file-path [library-file-path ... ]
 

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/add-library.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/add-library.1
@@ -56,6 +56,10 @@ OPTIONS
                Adds the library files to the application-specific class loader
                directory, domain-dir/lib/applibs.
 
+           war
+               Adds the library files to the war-packaged class loader directory,
+               domain-dir/lib/warlibs.
+
            For more information about these directories, see "Class Loaders"
            in Oracle GlassFish Server Application Development Guide.
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-11137

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
1. Built the [example project](https://github.com/flowlogix/cdi-scanning).
2. Used `asadmin add-library --type=war <filename>` for the example library.
3. Verified the warlib was sent to the correct folder (domain1/lib/warlibs)
4. Restarted the server.
5. Deployed the example application from the example project.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 21.0.3, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: UTF-8
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
