### PR TITLE
FISH-6961 Dont add URL to jdbc connection pool properties

### DIFF
--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/DMManagedConnectionFactory.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/DMManagedConnectionFactory.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2021] Payara Foundation and/or affiliates
+// Portions Copyright [2018-2025] Payara Foundation and/or affiliates
 
 package com.sun.gjc.spi;
 
@@ -134,12 +134,14 @@ public class DMManagedConnectionFactory extends ManagedConnectionFactoryImpl {
                 logFine("More than one value for key : " + key);
             }
             String prop = getParsedKey(key);
-            driverProps.put(prop, value);
+
             if(prop.equalsIgnoreCase("URL")) {
                 if(spec.getDetail(DataSourceSpec.URL) == null) {
                     setConnectionURL(value);
                 }
+                continue;
             }
+            driverProps.put(prop, value);
         }
         try {
             if (cxRequestInfo != null) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This URL property was being passed to the Trino JDBC Driver and blocking the ping from Payara. We don't need to pass this URL property to the driver.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Tested Trino JDBC Driver ping from Payara
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: C:\Maven\apache-maven-3.9.9
Java version: 11.0.19, vendor: Eclipse Adoptium, runtime: C:\Java\jdk-11.0.19+7
Default locale: en_GB, platform encoding: Cp1252
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"
## Documentation
<!-- Link documentation if a PR exists -->
n/s
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a