### PR TITLE
FISH-11207 Updated woodstock jsf to 6.0.1.payara-p1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,8 +277,8 @@
         <webservices.version>4.0.4</webservices.version>
         <santuario.version>4.0.0</santuario.version>
         <woodstox.version>7.1.0</woodstox.version>
-        <woodstock-jsf.version>6.0.1</woodstock-jsf.version>
-        <woodstock-jsf-suntheme.version>6.0.1</woodstock-jsf-suntheme.version>
+        <woodstock-jsf.version>6.0.1.payara-p1</woodstock-jsf.version>
+        <woodstock-jsf-suntheme.version>6.0.1.payara-p1</woodstock-jsf-suntheme.version>
         <angus-activation.version>2.0.2</angus-activation.version>
         <istack-commons-runtime.version>4.2.0</istack-commons-runtime.version>
         <jline.version>3.30.0</jline.version>


### PR DESCRIPTION
## Description
Fixes broken Admin UI styling in Payara 7

Rebased the patched Payara Admin UI styling on Glassfish Woodstock 6.0.1 for Payara 7

## Important Info
### Blockers
[https://github.com/payara/patched-src-glassfish-woodstock/pull/4]

## Testing

### Testing Performed
git clone git@github.com:jtarry-payara/patched-src-glassfish-woodstock.git
cd patched-src-glassfish-woodstock
git checkout 6.0.1.payara-p1
mvn clean install

git clone git@github.com:jtarry-payara/Payara.git
cd Payara
git checkout FISH-11207-adminui-woodstock-patch-6.0.1.payara-p1
mvn clean install -Pjakarta-staging -T 16

### Testing Environment
Ubuntu 24.04
openjdk 21.0.7
Maven 3.9.9

## Notes for Reviewers
Also updated copyright year to 2025 
