### PR TITLE
FISH-11055 Upgrade Mojarra to 4.0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <snakeyaml.version>2.4</snakeyaml.version>
         <jakarta.servlet.jsp.jstl.version>3.0.1</jakarta.servlet.jsp.jstl.version>
-        <mojarra.version>4.0.9.payara-p1</mojarra.version>
+        <mojarra.version>4.0.11.payara-p1</mojarra.version>
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
         <jakarta.mvc.version>2.1.0</jakarta.mvc.version>
         <krazo.version>3.0.1</krazo.version>


### PR DESCRIPTION
## Description
Reapplies our outstanding patches on top of 4.0.11, and reverts two PRs which cause issues by removing no-args constructors

## Important Info
### Blockers
https://github.com/payara/patched-src-mojarra/pull/27

## Testing
### New tests
None

### Testing Performed
Built the server, started the DAS, loaded the admin console - no explosions.
Tested the reproducer from FISH-11055, error is not encountered:
```
java -jar .\appserver\extras\payara-micro\payara-micro-distribution\target\payara-micro.jar --autobindhttp D:\Downloads\payara-test-app\target\payara-test-app.war

curl http://localhost:8080/payara-test-app/index.xhtml
```

### Testing Environment
Windows 11, Zulu JDK 11.0.27, Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
Letting Jenkins run against the SNAPSHOT, will adjust once tests have passed.
