### PR TITLE
FISH-11369 Fix for EJB TCK covariant test

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/TypeUtil.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/TypeUtil.java
@@ -37,7 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019] Payara Foundation and/or affiliates
+// Portions Copyright 2019-2025 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package com.sun.enterprise.deployment.util;
 
@@ -489,6 +490,10 @@ public class TypeUtil {
      */
     private static boolean sameReturnTypes(Method m1, Method m2) {
         if(m1.getReturnType().equals(m2.getReturnType())) {
+            return true;
+        }
+
+        if (m1.getReturnType().isAssignableFrom(m2.getReturnType())) {
             return true;
         }
 


### PR DESCRIPTION
## Description
Fixes the `com.sun.ts.tests.ejb30.tx.session.stateless.cm.covariant.ClientTest` test in the EJB Platform TCK

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the test on my EJB TCK branch: https://github.com/payara/jakartaee-10-tck-runners/pull/182

### Testing Environment
OpenSUSE Tumbleweed WSL, Maven 3.9.10, Zulu Java 21.0.7

## Documentation
N/A

## Notes for Reviewers
None
