### PR TITLE
FISH-11208 cannot switch view in JVM Report

### DIFF
--- a/appserver/admingui/common/src/main/resources/appServer/jvmReport.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/jvmReport.jsf
@@ -58,6 +58,8 @@
     />
     <sun:html id="html2"> 
         <sun:head id="propertyhead" title="JVM Report" >
+            <sun:script url="/jakarta.faces.resource/jsf.js.jsf?ln=jakarta.faces" />
+            <sun:script url="/resource/js/adminjsf.js" />
         </sun:head>
         <sun:body id="body3">
             <sun:form id="propertyForm">
@@ -110,7 +112,7 @@
                             </sun:property>                          
                         </sun:propertySheetSection>
                         <sun:propertySheetSection id="reportPropertySection">
-                            <sun:property id="ReportProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" readOnly="#{true)" >
+                            <sun:property id="ReportProp"  labelAlign="left" noWrap="#{false}" overlapLabel="#{false}" readOnly="#{true}" >
                              "<pre><font size="3" /> 
                                 <sun:staticText id="Report" text="#{pageSession.report.data.message}"/>
                                 <sun:staticText id="Report1" text="#{pageSession.report.data.subReports[0].properties.message}"/>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
FISH-11208 cannot switch view in JVM Report

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

Added adminjsf.js and jsf.js script into the page so the ajax works.

Previously would complain about admingui.js not defined, then ajax wouldn't work.
## Important Info
## Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

AdminUI > Server > JVM Report > change views