### PR TITLE
FISH-11209 Existing realms don't display properties

### DIFF
--- a/appserver/admingui/common/src/main/resources/security/realms/realmEdit.jsf
+++ b/appserver/admingui/common/src/main/resources/security/realms/realmEdit.jsf
@@ -45,7 +45,7 @@
 #include "/security/realms/realmEditInitPage.inc"
 
 <!composition template="/templates/default.layout"  guiTitle="$resource{i18nc.realm.EditPageTitle}"
-    guiOnLoad="initClassname('#{myOption}', false);">
+guiOnLoad="require(['webui/suntheme/inputTextField'], function() { initClassname('#{myOption}', true); });">
 <!define name="content">
     <event>
     <!beforeCreate

--- a/appserver/admingui/common/src/main/resources/security/realms/realmNew.jsf
+++ b/appserver/admingui/common/src/main/resources/security/realms/realmNew.jsf
@@ -68,7 +68,7 @@
     setPageSessionAttribute(key="helpKey" value="$resource{help_common.realmNew}");
 />
     
-<!composition template="/templates/default.layout"  guiTitle="$resource{i18nc.realm.NewPageTitle}" guiOnLoad="initClassname('#{myOption}', true);" >
+<!composition template="/templates/default.layout"  guiTitle="$resource{i18nc.realm.NewPageTitle}" guiOnLoad="require(['webui/suntheme/inputTextField'], function() { initClassname('#{myOption}', true); });">
 <!define name="content">
     <event>
     <!beforeCreate


### PR DESCRIPTION

FISH-11209 Existing realms don't display properties

## Description

changed guiOnLoad in the realms jsf page so it has the require webui. This waits for webui to be loaded before executing the code resulting in the properties showing and getting rid of the webui not defined error.

## Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

Tested by going to server-config > security > realms  > any realm and checking properties. Also created a new realm with different properties.