### PR TITLE
FISH-11414 Downgrade JLine to 3.30.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <woodstock-jsf-suntheme.version>5.0.0.payara-p1</woodstock-jsf-suntheme.version>
         <angus-activation.version>1.1.0</angus-activation.version>
         <istack-commons-runtime.version>4.2.0</istack-commons-runtime.version>
-        <jline.version>3.30.4</jline.version>
+        <jline.version>3.30.0</jline.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <microprofile-release.version>6.1</microprofile-release.version>
         <payara-arquillian-container.version>3.1</payara-arquillian-container.version>

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <woodstock-jsf-suntheme.version>5.0.0.payara-p1</woodstock-jsf-suntheme.version>
         <angus-activation.version>1.1.0</angus-activation.version>
         <istack-commons-runtime.version>4.2.0</istack-commons-runtime.version>
-        <jline.version>3.30.0</jline.version>
+        <jline.version>3.30.2</jline.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <microprofile-release.version>6.1</microprofile-release.version>
         <payara-arquillian-container.version>3.1</payara-arquillian-container.version>


### PR DESCRIPTION
## Description
Partially revert https://github.com/payara/Payara/pull/7447 by downgrading to 3.30.2.

JLine 3.30.4 and 3.30.3 seem to cause issues with the terminal specifically in Linux (including Git Bash and WSL). Powershell seems OK

There seems to be issues with displaying the prompts and the output of some commands (though it does still accept input). For example:

```
### Not prompting for password input
admin change-admin-password
Enter admin user name [default: admin]>

password
password
andrew@Pandrex-PC:~/Git/Payara> 

### No output shown
asadmin list-log-attributes
Authentication failed with password from login store: /home/andrew/.gfclient/pass
Enter admin password for user "admin">
andrew@Pandrex-PC:~/Git/Payara>
```

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the commands listed in the description - log attributes were displayed and the change-admin-password command correctly prompted for input.

### Testing Environment
WSL

## Documentation
N/A

## Notes for Reviewers
None
