### PR TITLE
FISH-11198 Fix Missing Message for Empty Deployment Group Name

### DIFF
--- a/appserver/admingui/cluster/src/main/java/fish/payara/cluster/admingui/PayaraClusterHandlers.java
+++ b/appserver/admingui/cluster/src/main/java/fish/payara/cluster/admingui/PayaraClusterHandlers.java
@@ -49,22 +49,24 @@ import org.glassfish.admingui.common.util.GuiUtil;
 
 public class PayaraClusterHandlers {
 
-    @Handler(id = "py.generateInstanceNameIfRequired",
+    @Handler(id = "py.generateAutoNameIfRequired",
             input = {
-                    @HandlerInput(name = "name", type = String.class, required = true),
-                    @HandlerInput(name = "autoname", type = Boolean.class, required = true)
+                @HandlerInput(name = "name", type = String.class, required = true),
+                @HandlerInput(name = "autoname", type = Boolean.class, required = true),
+                @HandlerInput(name = "emptyErrorMsg", type = String.class, required = true)
             },
             output = {
-                    @HandlerOutput(name = "instanceName", type = String.class)})
-    public static void generateInstanceNameIfRequired(HandlerContext handlerCtx) {
+                @HandlerOutput(name = "instanceName", type = String.class)})
+    public static void generateAutoNameIfRequired(HandlerContext handlerCtx) {
         String instanceName = (String) handlerCtx.getInputValue("name");
         Boolean autoname = (Boolean) handlerCtx.getInputValue("autoname");
+        String emptyErrorMsg = (String) handlerCtx.getInputValue("emptyErrorMsg");
 
         if (GuiUtil.isEmpty(instanceName)) {
             if (autoname) {
                 instanceName = NameGenerator.generateName();
             } else {
-                GuiUtil.prepareAlert("error", "No instance name provided, and Auto Name not enabled", null);
+                GuiUtil.prepareAlert("error", emptyErrorMsg, null);
                 handlerCtx.getFacesContext().renderResponse();
             }
         }

--- a/appserver/admingui/cluster/src/main/resources/dg/dgNew.jsf
+++ b/appserver/admingui/cluster/src/main/resources/dg/dgNew.jsf
@@ -81,7 +81,7 @@
             <sun:button id="newButton" text="$resource{i18n.button.OK}"
                 onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) {submitAndDisable(this, '$resource{i18n.button.Processing}');}; return false;" >
             <!command
-                py.generateInstanceNameIfRequired(name="#{pageSession.name}", autoname="#{pageSession.autoNameSelected}", instanceName="#{pageSession.name}");
+                py.generateAutoNameIfRequired(name="#{pageSession.name}", autoname="#{pageSession.autoNameSelected}", instanceName="#{pageSession.name}", emptyErrorMsg="$resource{i18ncs.dg.error.noname}");
                 if (!#{pageSession.autoNameSelected}) {
                     setAttribute(key="nameToCheck" value="#{pageSession.name}");
                     gfj.checkNameExist();

--- a/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
+++ b/appserver/admingui/cluster/src/main/resources/org/glassfish/cluster/admingui/Strings.properties
@@ -450,3 +450,6 @@ general.serverNameCol=Server Name
 autoName=Auto Name
 autoName.helpDg=When enabled, will generate a name for your deployment group if none is provided, or will otherwise resolve any name conflicts. 
 autoName.help=When enabled, will generate a name for your instance if none is provided, or will otherwise resolve any name conflicts. 
+
+instance.error.noname=No instance name provided and Auto Name is not enabled.
+dg.error.noname=No deployment group name provided and Auto Name is not enabled.

--- a/appserver/admingui/cluster/src/main/resources/shared/instanceNew.inc
+++ b/appserver/admingui/cluster/src/main/resources/shared/instanceNew.inc
@@ -51,7 +51,7 @@
             <sun:button id="newButton" text="$resource{i18n.button.OK}"
                 onClick="if (guiValidate('#{reqMsg}','#{reqInt}','#{reqPort}')) {submitAndDisable(this, '$resource{i18n.button.Processing}');}; return false;" >
             <!command
-                py.generateInstanceNameIfRequired(name="#{pageSession.name}", autoname="#{pageSession.autoNameSelected}", instanceName="#{pageSession.name}");
+                py.generateAutoNameIfRequired(name="#{pageSession.name}", autoname="#{pageSession.autoNameSelected}", instanceName="#{pageSession.name}", emptyErrorMsg="$resource{i18ncs.instance.error.noname}");
 
                 if (!#{pageSession.autoNameSelected}) {
                     setAttribute(key="nameToCheck" value="#{pageSession.name}");


### PR DESCRIPTION
## Description
There was same message for missing name of Instance and Deployment Group. This fix makes them separate.
Also i18n was used instead of a hardcoded message.

## Testing

### Testing Performed
Steps to Reproduce:
* Go to deployment groups
* Click “New…”
* Do NOT enter Deployment Group Name nor click Auto Name
* Click OK
* A message “No deployment group name provided and Auto Name is not enabled.”

Similarly with Instances, the message will be "No instance name provided and Auto Name is not enabled.".

### Testing Environment
Linux, OpenJDK 21