### PR TITLE
FISH-11236 Add sorting for @Find annotation and unify sorting into co…

### DIFF
--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/RepositoryImpl.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/RepositoryImpl.java
@@ -39,10 +39,12 @@
  */
 package fish.payara.jakarta.data.core.cdi.extension;
 
+import fish.payara.jakarta.data.core.util.DataParameter;
 import fish.payara.jakarta.data.core.util.DeleteOperationUtility;
 import fish.payara.jakarta.data.core.util.FindOperationUtility;
 import fish.payara.jakarta.data.core.util.QueryOperationUtility;
 import jakarta.data.Limit;
+import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.page.Page;
@@ -155,23 +157,16 @@ public class RepositoryImpl<T> implements InvocationHandler {
     }
 
     public Object processFindOperation(Object[] args, QueryData dataForQuery) {
-        Limit limit = null;
         Annotation[][] parameterAnnotations = dataForQuery.getMethod().getParameterAnnotations();
         boolean evaluatePages = Page.class.equals(dataForQuery.getMethod().getReturnType());
-        if (args != null) {
-            for (Object arg : args) {
-                if (arg instanceof Limit) {
-                    limit = (Limit) arg;
-                }
-            }
-        }
+        DataParameter dataParameter = extractDataParameter(args);
 
         if (parameterAnnotations.length > 0) {
             Object returnObject = FindOperationUtility.processFindByOperation(
                     args, getEntityManager(this.applicationName),
-                    dataForQuery, limit, evaluatePages);
+                    dataForQuery, dataParameter, evaluatePages);
 
-            if (returnObject != null && (returnObject instanceof List<?>)) {
+            if (returnObject instanceof List<?>) {
                 List<Object> resultList = (List<Object>) returnObject;
                 return processReturnType(dataForQuery, resultList);
             } else {
@@ -181,7 +176,7 @@ public class RepositoryImpl<T> implements InvocationHandler {
         } else {
             // For "findAll" operations
             return FindOperationUtility.processFindAllOperation(dataForQuery.getDeclaredEntityClass(), getEntityManager(this.applicationName),
-                    extractOrderByClause(dataForQuery.getMethod()), dataForQuery.getEntityMetadata(), limit
+                    extractOrderByClause(dataForQuery.getMethod()), dataForQuery.getEntityMetadata(), dataParameter
             );
         }
     }
@@ -408,21 +403,28 @@ public class RepositoryImpl<T> implements InvocationHandler {
     }
 
     public Object processQueryOperation(Object[] args, QueryData dataForQuery) throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        DataParameter dataParameter = extractDataParameter(args);
+        return QueryOperationUtility.processQueryOperation(args, dataForQuery,
+                getEntityManager(this.applicationName), getTransactionManager(), dataParameter);
+    }
+
+    private DataParameter extractDataParameter(Object[] args) {
         Limit limit = null;
         List<Sort<?>> sortList = new ArrayList<>();
         if (args != null) {
             for (Object arg : args) {
-                if (arg instanceof Limit) {
-                    limit = (Limit) arg;
-                } else if (arg instanceof Sort) {
-                    sortList.add((Sort<?>) arg);
-                } else if (arg instanceof Sort[]) {
-                    Collections.addAll(sortList, (Sort<?>[]) arg);
+                if (arg instanceof Limit l) {
+                    limit = l;
+                } else if (arg instanceof Sort<?> sort) {
+                    sortList.add(sort);
+                } else if (arg instanceof Order<?> order) {
+                    order.forEach(sortList::add);
+                }else if (arg instanceof Sort<?>[] sorts) {
+                    Collections.addAll(sortList, sorts);
                 }
             }
         }
-        return QueryOperationUtility.processQueryOperation(args, dataForQuery,
-                getEntityManager(this.applicationName), getTransactionManager(), limit, sortList);
+        return new DataParameter(limit, sortList);
     }
 
     public Object processQueryByNameOperation(Object[] args, QueryData dataForQuery) {

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
@@ -41,6 +41,7 @@ package fish.payara.jakarta.data.core.util;
 
 import fish.payara.jakarta.data.core.cdi.extension.EntityMetadata;
 import fish.payara.jakarta.data.core.cdi.extension.QueryData;
+import jakarta.data.Sort;
 import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.NonUniqueResultException;
 import jakarta.data.page.Page;
@@ -261,6 +262,59 @@ public class DataCommonOperationUtility {
             return null;
         } else {
             return Long.valueOf(returnValue);
+        }
+    }
+
+    public static String handleSort(EntityMetadata entityMetadata, List<Sort<?>> sortList, String query, boolean isFindOperation) {
+        StringBuilder sortedQuery = new StringBuilder(query);
+        if (!sortList.isEmpty()) {
+            appendSortQuery(entityMetadata, sortList, sortedQuery, isFindOperation);
+        }
+        return sortedQuery.toString();
+    }
+
+    public static void handleSort(EntityMetadata entityMetadata, List<Sort<?>> sortList, StringBuilder query, boolean isFindOperation) {
+        if (!sortList.isEmpty()) {
+            appendSortQuery(entityMetadata, sortList, query, isFindOperation);
+        }
+    }
+
+    private static void appendSortQuery(EntityMetadata entityMetadata, List<Sort<?>> sortList, StringBuilder sortedQuery, boolean isFindOperation) {
+        if (sortedQuery.toString().toUpperCase().contains("ORDER")) {
+            throw new IllegalArgumentException("The query cannot contain multiple ORDER BY keywords : '" + sortedQuery + "'");
+        }
+        sortedQuery.append(" ORDER BY ");
+        boolean firstItem = true;
+        for (Sort<?> sort : sortList) {
+            String propertyName = sort.property();
+            if (!entityMetadata.getAttributeNames().containsKey(propertyName.toLowerCase())) {
+                throw new IllegalArgumentException("The attribute " + propertyName +
+                        " is not mapped on the entity " + entityMetadata.getEntityName());
+            }
+            propertyName = entityMetadata.getAttributeNames().get(propertyName.toLowerCase());
+            if (!firstItem) {
+                sortedQuery.append(", ");
+            }
+            if (sort.ignoreCase()) {
+                sortedQuery.append("LOWER(");
+            }
+
+
+            if (isFindOperation && propertyName.charAt(propertyName.length() - 1) != ')') {
+                sortedQuery.append("o.");
+            }
+
+            sortedQuery.append(propertyName);
+            if (sort.ignoreCase()) {
+                sortedQuery.append(")");
+            }
+            if (sort.isAscending()) {
+                sortedQuery.append(" ASC");
+            }
+            if (sort.isDescending()) {
+                sortedQuery.append(" DESC");
+            }
+            firstItem = false;
         }
     }
 }

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataParameter.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataParameter.java
@@ -1,0 +1,10 @@
+package fish.payara.jakarta.data.core.util;
+
+import jakarta.data.Limit;
+import jakarta.data.Sort;
+
+import java.util.List;
+
+public record DataParameter(Limit limit, List<Sort<?>> sortList) {
+
+}

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/FindOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/FindOperationUtility.java
@@ -54,13 +54,12 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static fish.payara.jakarta.data.core.util.QueryOperationUtility.getIndexFromMap;
+import static fish.payara.jakarta.data.core.util.DataCommonOperationUtility.handleSort;
 
 /**
  * Utility class used to process Jakarta Data find operations
@@ -70,14 +69,18 @@ public class FindOperationUtility {
     public static final List<Class<?>> parametersToExclude = List.of(PageRequest.class, Limit.class, Order.class, Sort.class, Sort[].class);
 
     public static Stream<?> processFindAllOperation(Class<?> entityClass, EntityManager em, String orderByClause,
-                                                    EntityMetadata entityMetadata, Limit limit) {
+                                                    EntityMetadata entityMetadata, DataParameter dataParameter) {
         String qlString = createBaseFindQuery(entityClass, orderByClause, entityMetadata);
+        List<Sort<?>> sortList = dataParameter.sortList();
+        if (!sortList.isEmpty()) {
+            qlString = handleSort(entityMetadata, sortList, qlString, true);
+        }
         Query query = em.createQuery(qlString);
-        verifyLimit(limit, query);
+        verifyLimit(dataParameter.limit(), query);
         return query.getResultStream();
     }
 
-    public static Object processFindByOperation(Object[] args, EntityManager em, QueryData dataForQuery, Limit limit, boolean evaluatePages) {
+    public static Object processFindByOperation(Object[] args, EntityManager em, QueryData dataForQuery, DataParameter dataParameter, boolean evaluatePages) {
         StringBuilder builder = new StringBuilder();
         builder.append(createBaseFindQuery(dataForQuery.getDeclaredEntityClass(),
                 null, dataForQuery.getEntityMetadata()));
@@ -108,6 +111,10 @@ public class FindOperationUtility {
         if (hasWhere) {
             builder.append(")");
         }
+        List<Sort<?>> sortList = dataParameter.sortList();
+        if (!sortList.isEmpty()) {
+            handleSort(dataForQuery.getEntityMetadata(), sortList, builder, dataForQuery.getQueryType() == QueryType.FIND);
+        }
 
         dataForQuery.setQueryString(builder.toString());
 
@@ -123,7 +130,7 @@ public class FindOperationUtility {
                 }
             }
 
-            verifyLimit(limit, query);
+            verifyLimit(dataParameter.limit(), query);
 
             return query.getResultList();
         }
@@ -134,56 +141,16 @@ public class FindOperationUtility {
                                            Method method, StringBuilder builder, boolean hasWhere, Map<Integer, String> patternPositions) {
         PageRequest pageRequest = null;
         Object returnValue = null;
-        List<Sort<Object>> orders = new ArrayList<>();
         createCountQuery(dataForQuery, hasWhere, dataForQuery.getQueryString().indexOf("WHERE"));
         //evaluating parameters for pagination
         for (Object param : args) {
             if (param instanceof PageRequest) { //Get info for PageRequest
                 pageRequest = (PageRequest) param;
-            } else if (param instanceof Order) { //Get info for orders
-                Iterable<Sort<Object>> order = (Iterable<Sort<Object>>) param;
-                preprocessOrder(orders, order, dataForQuery);
-            } else if (param instanceof Sort) {
-                preprocessOrder(orders, dataForQuery, (Sort<Object>) param);
-            } else if (param instanceof Sort[]) {
-                preprocessOrder(orders, dataForQuery, (Sort<Object>[]) param);
+                break;
             }
         }
 
         StringBuilder orderQuery = null;
-
-        //We can't have a combinaton of sort from Query annotation value and parameters
-        if (patternPositions != null && patternPositions.containsValue("ORDER") && orders.size() > 0) {
-            throw new IllegalArgumentException("You can't add multiple sort parameters with Order By from the Query value");
-        }
-
-        //create order query
-        for (Sort<?> sort : orders) {
-            if (orderQuery == null) {
-                orderQuery = new StringBuilder(" ORDER BY ");
-            } else {
-                orderQuery.append(", ");
-            }
-
-            String propertyName = sort.property();
-            if (sort.ignoreCase()) {
-                orderQuery.append("LOWER(");
-            }
-
-            if (propertyName.charAt(propertyName.length() - 1) != ')' && dataForQuery.getQueryType().equals(QueryType.FIND)) {
-                orderQuery.append("o.");
-            }
-
-            orderQuery.append(propertyName);
-
-            if (sort.ignoreCase()) {
-                orderQuery.append(")");
-            }
-
-            if (sort.isDescending()) {
-                orderQuery.append(" DESC");
-            }
-        }
 
         if (pageRequest.mode() == PageRequest.Mode.OFFSET) {
             builder.append(orderQuery != null ? orderQuery.toString() : "");
@@ -195,35 +162,6 @@ public class FindOperationUtility {
         }
 
         return returnValue;
-    }
-
-    public static void preprocessOrder(List<Sort<Object>> orders, Iterable<Sort<Object>> order, QueryData dataForQuery) {
-        for (Sort<Object> sort : order) {
-            if (sort == null) {
-                throw new MappingException("sort is null");
-            } else {
-                orders.add(validateSort(sort, dataForQuery.getEntityMetadata(), sort.property()));
-            }
-        }
-    }
-
-    public static void preprocessOrder(List<Sort<Object>> sorts, QueryData dataForQuery, Sort<Object>... sortArray) {
-        for (Sort<Object> sort : sortArray) {
-            if (sort == null) {
-                throw new MappingException("sort is null");
-            }
-            sorts.add(validateSort(sort, dataForQuery.getEntityMetadata(), sort.property()));
-        }
-    }
-
-    public static <T> Sort<T> validateSort(Sort<T> sort, EntityMetadata entityMetadata, String attributeName) {
-        String name = preprocessAttributeName(entityMetadata, attributeName);
-        if (name.equals(sort.property())) {
-            return sort;
-        } else {
-            return sort.isAscending() ? sort.ignoreCase() ? Sort.ascIgnoreCase(name) : Sort.asc(name)
-                    : sort.ignoreCase() ? Sort.descIgnoreCase(name) : Sort.desc(name);
-        }
     }
 
     public static void createCountQuery(QueryData dataForQuery, boolean hasWhere, int wherePosition) {

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/QueryOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/QueryOperationUtility.java
@@ -74,6 +74,7 @@ import java.util.StringJoiner;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import static fish.payara.jakarta.data.core.util.DataCommonOperationUtility.handleSort;
 import static fish.payara.jakarta.data.core.util.DataCommonOperationUtility.processReturnQueryUpdate;
 import static fish.payara.jakarta.data.core.util.FindOperationUtility.excludeParameter;
 import static fish.payara.jakarta.data.core.util.FindOperationUtility.getSingleEntityName;
@@ -93,7 +94,7 @@ public class QueryOperationUtility {
     private static Predicate<Character> updatePredicate = c -> c == 'U' || c == 'u';
 
     public static Object processQueryOperation(Object[] args, QueryData dataForQuery, EntityManager entityManager,
-                                               TransactionManager transactionManager, Limit limit, List<Sort<?>> sortList) throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+                                               TransactionManager transactionManager, DataParameter dataParameter) throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
         Method method = dataForQuery.getMethod();
         Query queryAnnotation = method.getAnnotation(Query.class);
         String mappedQuery = queryAnnotation.value();
@@ -129,8 +130,9 @@ public class QueryOperationUtility {
         if (!evaluatePages) {
             for (Map.Entry<String, Set<String>> entry : queryMapping.entrySet()) {
                 String query = entry.getKey();
+                List<Sort<?>> sortList = dataParameter.sortList();
                 if (!sortList.isEmpty()) {
-                    query = handleSort(sortList, query);
+                    query = handleSort(dataForQuery.getEntityMetadata(), sortList, query, false);
                 }
                 jakarta.persistence.Query q = entityManager.createQuery(query);
                 validateParameters(dataForQuery, entry.getValue(), queryAnnotation.value());
@@ -146,6 +148,7 @@ public class QueryOperationUtility {
                         }
                     }
                 }
+                Limit limit = dataParameter.limit();
                 if (limit != null) {
                     q.setFirstResult((int) (limit.startAt() - 1));
                     q.setMaxResults(limit.maxResults());
@@ -165,6 +168,12 @@ public class QueryOperationUtility {
             }
         } else {
             for (Map.Entry<String, Set<String>> entry : queryMapping.entrySet()) {
+
+                List<Sort<?>> sortList = dataParameter.sortList();
+                if (!sortList.isEmpty()) {
+                    String query = handleSort(dataForQuery.getEntityMetadata(), sortList, entry.getKey(), false);
+                    dataForQuery.setQueryString(query);
+                }
                 validateParameters(dataForQuery, entry.getValue(), queryAnnotation.value());
             }
             objectToReturn = processPagination(entityManager, dataForQuery, args,
@@ -596,33 +605,5 @@ public class QueryOperationUtility {
             }
         }
         return queryArgs;
-    }
-
-    private static String handleSort(List<Sort<?>> sortList, String query) {
-        StringBuilder sortedQuery = new StringBuilder(query);
-        if (!sortList.isEmpty()) {
-            sortedQuery.append(" ORDER BY ");
-            boolean firstItem = true;
-            for (Sort<?> sort : sortList) {
-                if (!firstItem) {
-                    sortedQuery.append(", ");
-                }
-                if (sort.ignoreCase()) {
-                    sortedQuery.append("LOWER(");
-                }
-                sortedQuery.append(sort.property());
-                if (sort.ignoreCase()) {
-                    sortedQuery.append(")");
-                }
-                if (sort.isAscending()) {
-                    sortedQuery.append(" ASC");
-                }
-                if (sort.isDescending()) {
-                    sortedQuery.append(" DESC");
-                }
-                firstItem = false;
-            }
-        }
-        return sortedQuery.toString();
     }
 }


### PR DESCRIPTION
…mmon location

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This PR introduces sorting for the `@Find` annotation and it also moves the sorting into one unified location for the`@Query` and `@Find` annotations (including pagination)


## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Download and deploy [JakartaDataReproducer.zip](https://github.com/user-attachments/files/20949797/JakartaDataReproducer.zip)

1. Insert people into repository 
http://localhost:8080/api/personas/insertPersonasStream

2. Verify sortings
#### Query
http://localhost:8080/api/personas/findPersonWithQuerySorted/{property}
http://localhost:8080/api/personas/findPersonWithQuerySorted/{property}/{property2}
http://localhost:8080/api/personas/findPersonWithQuerySorted/{property}/{property2}/{property3}
query params = direction (ASC | DESC), ignoreCase (true|false)

#### Query with pagination
http://localhost:8080/api/personas/findPersonWithQuerySortedPageable/{property}/{property2}
query params = direction (ASC | DESC), ignoreCase (true|false), pageNumber (int), size (int)

#### Find
http://localhost:8080/api/personas/findPersonWithFindSorted/{property}
http://localhost:8080/api/personas/findPersonWithFindSorted/{property}/{property2}
http://localhost:8080/api/personas/findPersonWithFindSorted/{property}/{property2}/{property3}
query params = direction (ASC | DESC), ignoreCase (true|false)

#### Find with pagination
http://localhost:8080/api/personas/findPersonWithFindSortedPageable/{property}/{property2}
query params = direction (ASC | DESC), ignoreCase (true|false), pageNumber (int), size (int)

As an example for pagination with `@Find`
http://localhost:8080/api/personas/findPersonWithFindSortedPageable/id/lastname?direction=ASC&ignoreCase=FALSE&page=1&size=10
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.5, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.5-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "15.5", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
Tried my best to keep the current behaviour regarding pagination, while extracting the sorting.

Not sure if the following is valid:
```
for (Map.Entry<String, Set<String>> entry : queryMapping.entrySet()) {

                List<Sort<?>> sortList = dataParameter.sortList();
                if (!sortList.isEmpty()) {
                    String query = handleSort(dataForQuery.getEntityMetadata(), sortList, entry.getKey(), false);
                    dataForQuery.setQueryString(query);
                }
                validateParameters(dataForQuery, entry.getValue(), queryAnnotation.value());
            }
```

Can / should there be mutliple query mappings?