### PR TITLE
FISH-11296 Initial CDI Persistence Extension

### DIFF
--- a/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
+++ b/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
@@ -37,7 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022-2024] Payara Foundation and/or affiliates
+// Portions Copyright 2022-2025 Payara Foundation and/or affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package com.sun.enterprise.container.common.impl;
 
@@ -65,8 +66,10 @@ import com.sun.enterprise.deployment.ResourceDescriptor;
 import com.sun.enterprise.deployment.ResourceEnvReferenceDescriptor;
 import com.sun.enterprise.deployment.ResourceReferenceDescriptor;
 import com.sun.enterprise.deployment.ServiceReferenceDescriptor;
+import com.sun.enterprise.deployment.types.EntityManagerReference;
 import com.sun.enterprise.naming.spi.NamingObjectFactory;
 import com.sun.enterprise.naming.spi.NamingUtils;
+import jakarta.persistence.EntityManager;
 import org.glassfish.concurro.cdi.ConcurrencyManagedCDIBeans;
 import org.glassfish.api.admin.ProcessEnvironment;
 import org.glassfish.api.invocation.ApplicationEnvironment;
@@ -855,25 +858,25 @@ public class ComponentEnvManagerImpl
         return invMgr.peekAppEnvironment();
     }
 
-   
+    public FactoryForEntityManagerWrapper createFactoryForEntityManager(EntityManagerReference descriptor) {
+        return new FactoryForEntityManagerWrapper(descriptor, this);
+    }
 
-   
+    public FactoryForEntityManagerFactoryWrapper createFactoryForEntityManagerFactory(String unitName) {
+        return new FactoryForEntityManagerFactoryWrapper(unitName, invMgr, this);
+    }
 
-  
+    public class FactoryForEntityManagerWrapper implements NamingObjectProxy {
 
-    private class FactoryForEntityManagerWrapper
-        implements NamingObjectProxy {
-
-        private final EntityManagerReferenceDescriptor refDesc;
+        private final EntityManagerReference refDesc;
         private final ComponentEnvManager compEnvMgr;
 
-        FactoryForEntityManagerWrapper(EntityManagerReferenceDescriptor refDesc,
-            ComponentEnvManager compEnvMgr) {
+        FactoryForEntityManagerWrapper(EntityManagerReference refDesc, ComponentEnvManager compEnvMgr) {
             this.refDesc = refDesc;
             this.compEnvMgr = compEnvMgr;
         }
 
-        public Object create(Context ctx) {
+        public EntityManager create(Context ctx) {
             EntityManagerWrapper emWrapper = new EntityManagerWrapper(txManager, invMgr, compEnvMgr, callFlowAgent);
             emWrapper.initializeEMWrapper(refDesc.getUnitName(),
                     refDesc.getPersistenceContextType(),

--- a/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/FactoryForEntityManagerFactoryWrapper.java
+++ b/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/FactoryForEntityManagerFactoryWrapper.java
@@ -37,6 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2025 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package com.sun.enterprise.container.common.impl;
 
@@ -45,11 +47,8 @@ import com.sun.enterprise.naming.spi.NamingObjectFactory;
 import org.glassfish.api.invocation.InvocationManager;
 
 import javax.naming.Context;
-import javax.naming.NamingException;
 
-
-public class FactoryForEntityManagerFactoryWrapper
-    implements NamingObjectFactory {
+public class FactoryForEntityManagerFactoryWrapper implements NamingObjectFactory {
 
     InvocationManager invMgr;
 
@@ -68,9 +67,7 @@ public class FactoryForEntityManagerFactoryWrapper
         return false;
     }
 
-    public Object create(Context ic)
-        throws NamingException {
-
+    public EntityManagerFactoryWrapper create(Context ic) {
         return new EntityManagerFactoryWrapper(unitName, invMgr, compEnvMgr);
     }
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/EntityManagerReferenceDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/EntityManagerReferenceDescriptor.java
@@ -37,7 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Copyright [2020] Payara Foundation and/or affiliates
+// Copyright 2020-2025 Payara Foundation and/or affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package com.sun.enterprise.deployment;
 
@@ -73,6 +74,10 @@ public class EntityManagerReferenceDescriptor extends EnvironmentProperty implem
     }
 
     public EntityManagerReferenceDescriptor() {}
+
+    public EntityManagerReferenceDescriptor(String unitName) {
+        this.unitName = unitName;
+    }
 
     @Override
     public void setUnitName(String unitName) {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/PersistenceUnitNode.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/node/PersistenceUnitNode.java
@@ -37,7 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2020] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2017-2025 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package com.sun.enterprise.deployment.node;
 
@@ -135,6 +136,8 @@ public class PersistenceUnitNode extends DeploymentDescriptorNode {
         table.put(PersistenceTagNames.CLASS, "addClass");
         table.put(PersistenceTagNames.SHARED_CACHE_MODE, "setSharedCacheMode");
         table.put(PersistenceTagNames.VALIDATION_MODE, "setValidationMode");
+        table.put(PersistenceTagNames.SCOPE, "setScope");
+        table.put(PersistenceTagNames.QUALIFIER, "addQualifier");
         this.dispatchTable = table;
     }
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/PersistenceTagNames.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/PersistenceTagNames.java
@@ -37,6 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2025 Payara Foundation and/or its affiliates
+// Payara Foundation and/or its affiliates elects to include this software in this distribution under the GPL Version 2 license
 
 package com.sun.enterprise.deployment.xml;
 
@@ -46,23 +48,25 @@ package com.sun.enterprise.deployment.xml;
  */
 public interface PersistenceTagNames extends TagNames {
 
-    public static String PERSISTENCE = "persistence";
-    public static String PERSISTENCE_UNIT = "persistence-unit";
-    public static String DESCRIPTION = "description";
-    public static String PROVIDER = "provider";
-    public static String JTA_DATA_SOURCE = "jta-data-source";
-    public static String NON_JTA_DATA_SOURCE = "non-jta-data-source";
-    public static String JAR_FILE = "jar-file";
-    public static String MAPPING_FILE = "mapping-file";
-    public static String CLASS = "class";
-    public static String EXCLUDE_UNLISTED_CLASSES = "exclude-unlisted-classes";
-    public static String PROPERTIES = "properties";
-    public static String PROPERTY = "property";
-    public static String PROPERTY_NAME = "name";
-    public static String PROPERTY_VALUE = "value";
-    public static String NAME = "name";
-    public static String TRANSACTION_TYPE = "transaction-type";
-    public static String SHARED_CACHE_MODE = "shared-cache-mode";
-    public static String VALIDATION_MODE = "validation-mode";
+    String PERSISTENCE = "persistence";
+    String PERSISTENCE_UNIT = "persistence-unit";
+    String DESCRIPTION = "description";
+    String PROVIDER = "provider";
+    String JTA_DATA_SOURCE = "jta-data-source";
+    String NON_JTA_DATA_SOURCE = "non-jta-data-source";
+    String JAR_FILE = "jar-file";
+    String MAPPING_FILE = "mapping-file";
+    String CLASS = "class";
+    String EXCLUDE_UNLISTED_CLASSES = "exclude-unlisted-classes";
+    String PROPERTIES = "properties";
+    String PROPERTY = "property";
+    String PROPERTY_NAME = "name";
+    String PROPERTY_VALUE = "value";
+    String NAME = "name";
+    String TRANSACTION_TYPE = "transaction-type";
+    String SHARED_CACHE_MODE = "shared-cache-mode";
+    String VALIDATION_MODE = "validation-mode";
+    String SCOPE = "scope";
+    String QUALIFIER = "qualifier";
 
 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/persistence/AnnotationInvocationHandler.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/persistence/AnnotationInvocationHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.cdi.persistence;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class AnnotationInvocationHandler implements InvocationHandler, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Class<?> type;
+
+    AnnotationInvocationHandler(Class<?> type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return type.isInstance(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return type.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "@" + type.getName();
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        switch (method.getName()) {
+            case "annotationType":
+                return type;
+            case "equals":
+                return args.length > 0 && equals(args[0]);
+            case "hashCode":
+                return hashCode();
+            case "toString":
+                return toString();
+            default:
+                return null;
+        }
+    }
+}

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/persistence/PersistenceExtension.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/persistence/PersistenceExtension.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.cdi.persistence;
+
+import com.sun.enterprise.container.common.impl.ComponentEnvManagerImpl;
+import com.sun.enterprise.deployment.EntityManagerReferenceDescriptor;
+import com.sun.enterprise.deployment.PersistenceUnitDescriptor;
+import com.sun.enterprise.deployment.PersistenceUnitsDescriptor;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.configurator.BeanConfigurator;
+import jakarta.persistence.Cache;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.persistence.SchemaManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Metamodel;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+
+import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.data.ApplicationInfo;
+
+public class PersistenceExtension implements Extension  {
+
+    public void afterBean(final @Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
+        var container = Globals.get(InvocationManager.class).getCurrentInvocation().getContainer();
+
+        if (container instanceof ApplicationInfo applicationInfo) {
+            var persistenceUnits = applicationInfo.getMetaData(PersistenceUnitsDescriptor.class);
+
+            if (persistenceUnits != null) {
+                for (PersistenceUnitDescriptor descriptor : persistenceUnits.getPersistenceUnitDescriptors()) {
+                    addBeanForEntityManager(afterBeanDiscovery, descriptor);
+                    addBeanForEntityManagerFactory(afterBeanDiscovery, descriptor);
+
+                    addBeanForCriteriaBuilder(afterBeanDiscovery, descriptor);
+                    addBeanForPersistenceUnitUtil(afterBeanDiscovery, descriptor);
+                    addBeanForCache(afterBeanDiscovery, descriptor);
+                    addBeanForSchemaManager(afterBeanDiscovery, descriptor);
+                    addBeanForMetamodel(afterBeanDiscovery, descriptor);
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addBeanForEntityManager(AfterBeanDiscovery afterBeanDiscovery, PersistenceUnitDescriptor descriptor) {
+        var bean = addQualifiedBean(afterBeanDiscovery, descriptor, EntityManager.class);
+
+        if (descriptor.getScope() != null) {
+            bean.scope((Class<? extends Annotation>) loadClass(descriptor.getScope()));
+        }
+
+        bean.createWith(e -> createEntityManager(descriptor.getName()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addBeanForEntityManagerFactory(AfterBeanDiscovery afterBeanDiscovery, PersistenceUnitDescriptor descriptor) {
+        var bean = addQualifiedBean(afterBeanDiscovery, descriptor, EntityManagerFactory.class);
+
+        if (descriptor.getScope() != null) {
+            bean.scope((Class<? extends Annotation>) loadClass(descriptor.getScope()));
+        }
+
+        bean.createWith(e -> createEntityManagerFactory(descriptor.getName()));
+    }
+
+    private void addBeanForCriteriaBuilder(AfterBeanDiscovery afterBeanDiscovery, PersistenceUnitDescriptor descriptor) {
+        addQualifiedBean(afterBeanDiscovery, descriptor, CriteriaBuilder.class)
+                .scope(Dependent.class)
+                .createWith(e -> getEntityManagerFactory(descriptor).getCriteriaBuilder());
+    }
+
+    private void addBeanForPersistenceUnitUtil(AfterBeanDiscovery afterBeanDiscovery, PersistenceUnitDescriptor descriptor) {
+        addQualifiedBean(afterBeanDiscovery, descriptor, PersistenceUnitUtil.class)
+                .scope(Dependent.class)
+                .createWith(e -> getEntityManagerFactory(descriptor).getPersistenceUnitUtil());
+    }
+
+    private void addBeanForCache(AfterBeanDiscovery afterBeanDiscovery, PersistenceUnitDescriptor descriptor) {
+        addQualifiedBean(afterBeanDiscovery, descriptor, Cache.class)
+                .scope(Dependent.class)
+                .createWith(e -> getEntityManagerFactory(descriptor).getCache());
+    }
+
+    private void addBeanForSchemaManager(AfterBeanDiscovery afterBeanDiscovery, PersistenceUnitDescriptor descriptor) {
+        addQualifiedBean(afterBeanDiscovery, descriptor, SchemaManager.class)
+                .scope(Dependent.class)
+                .createWith(e -> getEntityManagerFactory(descriptor).getSchemaManager());
+    }
+
+    private void addBeanForMetamodel(AfterBeanDiscovery afterBeanDiscovery, PersistenceUnitDescriptor descriptor) {
+        addQualifiedBean(afterBeanDiscovery, descriptor, Metamodel.class)
+                .scope(Dependent.class)
+                .createWith(e -> getEntityManagerFactory(descriptor).getMetamodel());
+    }
+
+    private EntityManagerFactory getEntityManagerFactory(PersistenceUnitDescriptor descriptor) {
+        return CDI.current().select(EntityManagerFactory.class, descriptor.getQualifiers().stream().map(
+                e -> createAnnotationInstance(loadClass(e))).toArray(Annotation[]::new)).get();
+    }
+
+    private BeanConfigurator<Object> addQualifiedBean(AfterBeanDiscovery afterBeanDiscovery, PersistenceUnitDescriptor descriptor, Type type) {
+        var bean = afterBeanDiscovery.addBean().addType(type);
+
+        for (String qualifierClassName : descriptor.getQualifiers()) {
+            bean.addQualifier(createAnnotationInstance(loadClass(qualifierClassName)));
+        }
+
+        return bean;
+    }
+
+    private EntityManager createEntityManager(String unitName) {
+        return Globals.get(ComponentEnvManagerImpl.class).createFactoryForEntityManager(
+                new EntityManagerReferenceDescriptor(unitName)).create(null);
+
+    }
+
+    private EntityManagerFactory createEntityManagerFactory(String unitName) {
+        return Globals.get(ComponentEnvManagerImpl.class).createFactoryForEntityManagerFactory(unitName).create(null);
+
+    }
+
+    private Class<?> loadClass(String className) {
+        try {
+            return Thread.currentThread().getContextClassLoader().loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Annotation createAnnotationInstance(Class<?> type) {
+        return (Annotation) Proxy.newProxyInstance(type.getClassLoader(), new Class[] { type },
+                new AnnotationInvocationHandler(type));
+    }
+
+}

--- a/appserver/web/weld-integration/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/appserver/web/weld-integration/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,2 +1,3 @@
 org.glassfish.cdi.transaction.TransactionalExtension
 org.glassfish.cdi.transaction.TransactionScopedContextExtension
+org.glassfish.cdi.persistence.PersistenceExtension


### PR DESCRIPTION
## Description
Initial CDI Persistence Extension.

Not fully passing the TCK yet, but an incremental improvement from not passing at all.

Failures still to resolve:
* ServletEMLookupTest#injectUtilitiesUsingQualifier

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran the `ee.jakarta.tck.persistence.ee.cdi.ServletEMLookupTest` Persistence Platform TCK test

```
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0
```

Kicked off TCK runs (pending results):
* "Passing" Platform: [JakartaEE-11-TCK#242](https://jenkins.payara.fish/view/TCKs/job/JakartaEE-11-TCK/242/)
* "Passing" Web Profile: [JakartaEE-11-TCK#243](https://jenkins.payara.fish/view/TCKs/job/JakartaEE-11-TCK/243/)
* Persistence (not currently included in "passing"): [JakartaEE-11-TCK#244](https://jenkins.payara.fish/view/TCKs/job/JakartaEE-11-TCK/244/)

### Testing Environment
Windows 11, Maven 3.9.10, Zulu Java 21.0.7

## Documentation
N/A

## Notes for Reviewers
None
