### PR TITLE
FISH-11618 bugfix(cdi-provider): getBundleDescriptor() added a check for non-exi…

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/GlassFishWeldProvider.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/GlassFishWeldProvider.java
@@ -163,7 +163,10 @@ public class GlassFishWeldProvider implements CDIProvider {
 
     private static BundleDescriptor getBundleDescriptor() {
         BundleDescriptor bundle = null;
-        Object componentEnv = invocationManager.getCurrentInvocation().getJNDIEnvironment();
+        Object componentEnv = null;
+        if (!invocationManager.isInvocationStackEmpty()) {
+            componentEnv = invocationManager.getCurrentInvocation().getJNDIEnvironment();
+        }
         if( componentEnv instanceof EjbDescriptor) {
             bundle = (BundleDescriptor)
                     ((EjbDescriptor) componentEnv).getEjbBundleDescriptor().


### PR DESCRIPTION
…stent invocation

## Description
This is a bug fix. `getBundleDescriptor()` was causing a NPE during asynchronous operations
because invocation stack was null.
The fix lets CDI use an existing fallback method of finding out the correct WAR via current ClassLoader.

fixes #7492

## Testing
Tested with both reproducers for the attached issue.
