### PR TITLE
FISH-11465 Existing Realms Don’t Display Any Properties, Just Name - Fix Missing Properties

### DIFF
--- a/appserver/admingui/common/src/main/resources/security/realms/realmAttrs.inc
+++ b/appserver/admingui/common/src/main/resources/security/realms/realmAttrs.inc
@@ -84,7 +84,7 @@
         </sun:propertySheetSection>
     </sun:propertySheet>
 "<br><br>
-    <sun:propertySheetSection id="fileSection" visible="#{false}" label="$resource{i18nc.realm.specificProps}" >
+    <sun:propertySheetSection id="fileSection" visible="#{attrMap.classname eq 'com.sun.enterprise.security.auth.realm.file.FileRealm'}" label="$resource{i18nc.realm.specificProps}">
         <!afterCreate
             getClientId(component="$this{component}" clientId=>$page{fileSectionId});
         />
@@ -99,7 +99,7 @@
         </sun:property> 
     </sun:propertySheetSection>
 
-    <sun:propertySheetSection id="certSection" visible="#{false}" label="$resource{i18nc.realm.specificProps}">
+    <sun:propertySheetSection id="certSection" visible="#{attrMap.classname eq 'com.sun.enterprise.security.auth.realm.certificate.CertificateRealm'}" label="$resource{i18nc.realm.specificProps}">
         <!afterCreate
             getClientId(component="$this{component}" clientId=>$page{certSectionId});
         />  
@@ -108,7 +108,7 @@
         </sun:property> 
     </sun:propertySheetSection>
 
-    <sun:propertySheetSection id="ldapSection" visible="#{false}" label="$resource{i18nc.realm.specificProps}">
+    <sun:propertySheetSection id="ldapSection" visible="#{attrMap.classname eq 'com.sun.enterprise.security.auth.realm.ldap.LDAPRealm'}" label="$resource{i18nc.realm.specificProps}">
         <!afterCreate
             getClientId(component="$this{component}" clientId=>$page{ldapSectionId});
         />
@@ -126,7 +126,7 @@
         </sun:property> 
     </sun:propertySheetSection>
 
-    <sun:propertySheetSection id="solarisSection" visible="#{false}" label="$resource{i18nc.realm.specificProps}">
+    <sun:propertySheetSection id="solarisSection" visible="#{attrMap.classname eq 'com.sun.enterprise.security.auth.realm.solaris.SolarisRealm'}" label="$resource{i18nc.realm.specificProps}">
         <!afterCreate
             getClientId(component="$this{component}" clientId=>$page{solarisSectionId});
         />  
@@ -138,7 +138,7 @@
         </sun:property> 
     </sun:propertySheetSection>
 
-    <sun:propertySheetSection id="pamSection" visible="#{false}" label="$resource{i18nc.realm.specificProps}">
+    <sun:propertySheetSection id="pamSection" visible="#{attrMap.classname eq 'com.sun.enterprise.security.auth.realm.pam.PAMRealm'}" label="$resource{i18nc.realm.specificProps}">
         <!afterCreate
             getClientId(component="$this{component}" clientId=>$page{pamSectionId});
         />
@@ -147,7 +147,7 @@
         </sun:property>
     </sun:propertySheetSection>
 
-    <sun:propertySheetSection id="jdbcSection" visible="#{false}" label="$resource{i18nc.realm.specificProps}">
+    <sun:propertySheetSection id="jdbcSection" visible="#{attrMap.classname eq 'com.sun.enterprise.security.auth.realm.jdbc.JDBCRealm'}" label="$resource{i18nc.realm.specificProps}">
         <!afterCreate
             getClientId(component="$this{component}" clientId=>$page{jdbcSectionId});
         />  


### PR DESCRIPTION
FISH-11465 changed realmAttrs so that the extra properties are set to visible if the condition is met (if the realm class name = the specific section)

## Description

in `realmAttrs` the extra properties visibility was set to false which resulted in them not showing. I have changed it so that the extra properties are visible if the class matches. It makes sure it displays the correct section relating to the class name.

## Important Info
## Testing
### Testing Performed

Run Payara 6, Security > Realms > fileRealm > make sure extra properties is visible > change something & save > reload realm to make sure change is made

