### PR TITLE
FISH-11604 Not extracting entity types from Iterable parameter/return types

### DIFF
--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
@@ -100,29 +100,23 @@ public class DataCommonOperationUtility {
             return results.stream();
         } else if (evaluateReturnTypeVoidPredicate.test(returnType)) {
             return null;
-        } else if (returnType.equals(Optional.class)) {
-            if (results.isEmpty()) {
-                return Optional.empty();
-            } else {
-                if (results.size() > 1) {
-                    throw new NonUniqueResultException("There are more than one result for the query");
-                }
-                return Optional.ofNullable(results.get(0));
-            }
-        } else if (returnType.equals(dataForQuery.getDeclaredEntityClass())) {
-            if (results.isEmpty()) {
-                throw new EmptyResultException("There are no results for the query");
-            }
-
-            if (results.size() > 1) {
+        } else if (results.size() > 1) {
+            if (returnType.equals(Optional.class) || returnType.equals(dataForQuery.getDeclaredEntityClass())) {
                 throw new NonUniqueResultException("There are more than one result for the query");
             }
-
-            return results.getFirst();
-        } else if (!results.isEmpty()) {
             return results;
+        } else if (returnType.equals(Optional.class)) {
+            return results.isEmpty() ? Optional.empty() : Optional.ofNullable(results.get(0));
         }
-        return null;
+        else {
+            if (results.isEmpty()) {
+                if (returnType.equals(dataForQuery.getDeclaredEntityClass())) {
+                    throw new EmptyResultException("There are no results for the query");
+                }
+                return null;
+            }
+            return results.getFirst();
+        }
     }
 
     public static EntityManager getEntityManager(String applicationName) {

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
@@ -209,7 +209,7 @@ public class DataCommonOperationUtility {
     public static Class<?> findEntityTypeInMethod(Method method) {
         Class<?> returnType = method.getReturnType();
         if (!void.class.equals(returnType) && !Void.class.equals(returnType)) {
-            if (Collection.class.isAssignableFrom(returnType)
+            if (Iterable.class.isAssignableFrom(returnType)
                     || Stream.class.isAssignableFrom(returnType)
                     || Optional.class.isAssignableFrom(returnType) || Page.class.isAssignableFrom(returnType)) {
                 Type genericReturnType = method.getGenericReturnType();
@@ -227,7 +227,7 @@ public class DataCommonOperationUtility {
         for (Parameter param : method.getParameters()) {
             Class<?> paramType = param.getType();
             if (!paramType.isPrimitive() && !paramType.equals(String.class)) {
-                if (Collection.class.isAssignableFrom(paramType)
+                if (Iterable.class.isAssignableFrom(paramType)
                         || Stream.class.isAssignableFrom(paramType)) {
                     Type paramGenericType = param.getParameterizedType();
                     if (paramGenericType instanceof ParameterizedType) {


### PR DESCRIPTION

## Description
Because Iterable types are considered like entity types themselves, this results in multiple results in DataCommonOperationUtility#processReturnType being rejected by single object return validations in that method.

## Testing
### New tests
None

### Testing Performed
Manually tested http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/personas/updatePersonaIterable now works.

Also manually tested all endpoints on payara/Payara/pull/7494 .

### Testing Environment
Zulu 21.0.7, Windows 11, apache-maven-3.9.9

## Notes for Reviewers
The 2nd commit is not necessary to fix the issue, but maybe an improvement?