### PR TITLE
FISH-11682 Re-enable Tests

### DIFF
--- a/appserver/tests/payara-samples/samples/client-certificate-validator/pom.xml
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/pom.xml
@@ -58,4 +58,11 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/appserver/tests/payara-samples/samples/http/pom.xml
+++ b/appserver/tests/payara-samples/samples/http/pom.xml
@@ -65,5 +65,14 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/payara-samples/samples/pom.xml
+++ b/appserver/tests/payara-samples/samples/pom.xml
@@ -64,7 +64,7 @@
         <module>jaxrs-rolesallowed</module>
         <module>jaxrs-rolesallowed-servlet</module>
         <module>jaxws-security</module>
-        <!--module>jaxws-tracing</module-->
+        <module>jaxws-tracing</module>
         <module>legacy-mode-empty-beans-xml</module>
         <module>microprofile-config</module>
         <module>microprofile-endpoints</module>
@@ -75,17 +75,17 @@
         <module>rolesPermitted</module>
         <module>realm-identity-stores</module>
         <module>jakartaee-namespace-transformer</module>
-        <!--module>http</module-->
+        <module>http</module>
         <module>logging</module>
         <module>ejb-http-remoting</module>
         <module>remote-ejb-tracing</module>
         <module>rolesallowed-unprotected-methods</module>
         <module>microprofile-rc-ft</module>
         <module>multiple-keystores</module>
-        <!--module>client-certificate-validator</module-->
+        <module>client-certificate-validator</module>
         <!-- Skip - this test needs to be run repeatedly for around 60 minutes to be effective -->
         <!--<module>corba-read-timeout</module>-->
-        <!--module>microprofile-rest-client</module-->
+        <module>microprofile-rest-client</module>
         <module>concurrency</module>
         <module>reproducers</module>
         <module>opentelemetry</module>


### PR DESCRIPTION
## Description
Re-enable tests which seem to have been disabled since EE10

Ports across fix from https://github.com/payara/Payara/pull/7534

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran tests locally against payara-server-managed profile

### Testing Environment
Windows 11, Maven 3.9.10, Zulu JDK 11.0.27

## Documentation
N/A

## Notes for Reviewers
None
