### PR TITLE
FISH-11605 Query operation failed to return array of data

### DIFF
--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/QueryOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/QueryOperationUtility.java
@@ -372,6 +372,14 @@ public class QueryOperationUtility {
 
     private static Object processReturnType(QueryData data, List<?> resultList) {
         Class<?> returnType = data.getMethod().getReturnType();
+        if (returnType.isArray()) {
+            Class<?> componentType = returnType.getComponentType();
+            Object array = java.lang.reflect.Array.newInstance(componentType, resultList.size());
+            for (int i = 0; i < resultList.size(); i++) {
+                java.lang.reflect.Array.set(array, i, resultList.get(i));
+            }
+            return array;
+        }
         if (List.class.isAssignableFrom(returnType)) return resultList;
         if (Stream.class.isAssignableFrom(returnType)) return resultList.stream();
         if (Optional.class.isAssignableFrom(returnType)) return resultList.stream().findFirst();


### PR DESCRIPTION
## Description
When testing the `@Query` annotation for the following endpoint: `http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/personas/findPersonByLastNameWithQueryLimited/Valdez/5`  got the error: `java.lang.ClassCastException: class fish.payara.server.jakartadatareproducer.model.Person cannot be cast to class [Lfish.payara.server.jakartadatareproducer.model.Person; (fish.payara.server.jakartadatareproducer.model.Person and [Lfish.payara.server.jakartadatareproducer.model.Person; are in unnamed module of loader org.glassfish.web.loader.WebappClassLoader @2fa53dd9)`

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
1. http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/personas/insertPersonasRandom/10
2. Choose 1 surname which repeats
3. Fill SURNAME_CHOSEN_HERE and call http://localhost:8080/JakartaDataReproducer-1.0-SNAPSHOT/api/personas/findPersonByLastNameWithQueryLimited/SURNAME_CHOSEN_HERE/5
4. Should return limited rows

### Testing Environment
Zulu JDK 21 on Windows 11 with Maven 3.9.9

## Notes for Reviewers
None
