### PR TITLE
FISH-11591 Jakarta Data - Add resolution for multiple persistence units

### DIFF
--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/AmbiguousPersistenceUnitException.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/AmbiguousPersistenceUnitException.java
@@ -39,8 +39,8 @@
  */
 package fish.payara.jakarta.data.core.util;
 
-public class UnambiguousPersistenceUnitException extends RuntimeException {
-    public UnambiguousPersistenceUnitException(String message) {
+public class AmbiguousPersistenceUnitException extends RuntimeException {
+    public AmbiguousPersistenceUnitException(String message) {
         super(message);
     }
 }

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
@@ -64,13 +64,13 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+
 import org.glassfish.internal.api.Globals;
 import org.glassfish.internal.data.ApplicationInfo;
 import org.glassfish.internal.data.ApplicationRegistry;
@@ -124,10 +124,26 @@ public class DataCommonOperationUtility {
         ApplicationInfo applicationInfo = applicationRegistry.get(applicationName);
         List<EntityManagerFactory> factoryList = applicationInfo.getTransientAppMetaData(EntityManagerFactory.class.toString(), List.class);
         if (factoryList.size() == 1) {
-            EntityManagerFactory factory = factoryList.get(0);
+            EntityManagerFactory factory = factoryList.getFirst();
             return factory.createEntityManager();
         }
-        return null;
+
+        List<EntityManagerFactory> result = factoryList.stream().filter(factory -> {
+            Map<String, Object> properties = factory.getProperties();
+            if (properties == null || properties.isEmpty()) {
+                return false;
+            }
+            if (!properties.containsKey("fish.payara.jakarta.data.usePU")) {
+                return false;
+            }
+            return Boolean.parseBoolean((String) properties.get("fish.payara.jakarta.data.usePU"));
+        }).toList();
+
+        if (result.size() == 1) {
+            EntityManagerFactory factory = result.getFirst();
+            return factory.createEntityManager();
+        }
+        throw new UnambiguousPersistenceUnitException(String.format("Multiple persistence units found for application '%s', try setting the 'fish.payara.jakarta.data.usePU' property to true", applicationName));
     }
 
     public static ApplicationRegistry getRegistry() {

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
@@ -145,7 +145,8 @@ public class DataCommonOperationUtility {
             EntityManagerFactory factory = result.getFirst();
             return factory.createEntityManager();
         }
-        throw new AmbiguousPersistenceUnitException(String.format("Multiple persistence units found for application '%s', try setting the '%s' property to true", applicationName, PERSISTENCE_UNIT_ENABLED_PROPERTY));
+
+        throw new AmbiguousPersistenceUnitException(String.format("For the application '%s', specify a single persistence unit for Jakarta Data by setting the property '%s' to 'true' in persistence.xml.", applicationName, PERSISTENCE_UNIT_ENABLED_PROPERTY));
     }
 
     public static ApplicationRegistry getRegistry() {

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
@@ -146,7 +146,7 @@ public class DataCommonOperationUtility {
             return factory.createEntityManager();
         }
 
-        throw new AmbiguousPersistenceUnitException(String.format("For the application '%s', specify a single persistence unit for Jakarta Data by setting the property '%s' to 'true' in persistence.xml.", applicationName, PERSISTENCE_UNIT_ENABLED_PROPERTY));
+        throw new AmbiguousPersistenceUnitException(String.format("For the application '%s', specify a single persistence unit for Jakarta Data by setting the property '%s' to 'true' in its persistence.xml.", applicationName, PERSISTENCE_UNIT_ENABLED_PROPERTY));
     }
 
     public static ApplicationRegistry getRegistry() {

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/DataCommonOperationUtility.java
@@ -80,6 +80,8 @@ import org.glassfish.internal.data.ApplicationRegistry;
  */
 public class DataCommonOperationUtility {
 
+    private static final String PERSISTENCE_UNIT_ENABLED_PROPERTY = "fish.payara.data.usePU";
+
     public static Predicate<Class<?>> evaluateReturnTypeVoidPredicate = returnType -> void.class.equals(returnType)
             || Void.class.equals(returnType);
 
@@ -133,17 +135,17 @@ public class DataCommonOperationUtility {
             if (properties == null || properties.isEmpty()) {
                 return false;
             }
-            if (!properties.containsKey("fish.payara.jakarta.data.usePU")) {
+            if (!properties.containsKey(PERSISTENCE_UNIT_ENABLED_PROPERTY)) {
                 return false;
             }
-            return Boolean.parseBoolean((String) properties.get("fish.payara.jakarta.data.usePU"));
+            return Boolean.parseBoolean((String) properties.get(PERSISTENCE_UNIT_ENABLED_PROPERTY));
         }).toList();
 
         if (result.size() == 1) {
             EntityManagerFactory factory = result.getFirst();
             return factory.createEntityManager();
         }
-        throw new UnambiguousPersistenceUnitException(String.format("Multiple persistence units found for application '%s', try setting the 'fish.payara.jakarta.data.usePU' property to true", applicationName));
+        throw new AmbiguousPersistenceUnitException(String.format("Multiple persistence units found for application '%s', try setting the '%s' property to true", applicationName, PERSISTENCE_UNIT_ENABLED_PROPERTY));
     }
 
     public static ApplicationRegistry getRegistry() {

--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/UnambiguousPersistenceUnitException.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/util/UnambiguousPersistenceUnitException.java
@@ -1,0 +1,46 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/main/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.jakarta.data.core.util;
+
+public class UnambiguousPersistenceUnitException extends RuntimeException {
+    public UnambiguousPersistenceUnitException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Introduces a new property "fish.payara.data.usePU" to specify the persistence unit to use when multiple are present.

Only uses the one which is true, if there are multiple, an exception is thrown.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Added another persistence unit:
```
<persistence-unit name="pu2" transaction-type="JTA">
        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
        <jta-data-source>jdbc/__default</jta-data-source>

        <properties>
            <property name="fish.payara.jakarta.data.usePU" value="true"/>
        </properties>
    </persistence-unit>
```
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
