### PR TITLE
FISH-11585 Fix Resource Adapter Transaction Recovery Race Condition

### DIFF
--- a/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
@@ -409,7 +409,7 @@ public class JavaEETransactionManagerJTSDelegate
     }
 
     public void initRecovery(boolean force) {
-        _logger.log(Level.FINE, "Initialising transaction recovery from JavaEETransactionManagerJTSDelegate");
+        _logger.log(Level.FINER, "Initialising transaction recovery from JavaEETransactionManagerJTSDelegate");
         TransactionServiceProperties.initRecovery(force);
     }
 

--- a/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
@@ -409,6 +409,7 @@ public class JavaEETransactionManagerJTSDelegate
     }
 
     public void initRecovery(boolean force) {
+        _logger.log(Level.FINE, "Initialising transaction recovery from JavaEETransactionManagerJTSDelegate");
         TransactionServiceProperties.initRecovery(force);
     }
 

--- a/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation]
+// Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 package com.sun.enterprise.transaction.jts;
 
 import java.util.Arrays;

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionManagerImpl.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionManagerImpl.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2025 Payara Foundation and/or its affiliates
 
 package com.sun.jts.jta;
 

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionManagerImpl.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionManagerImpl.java
@@ -206,6 +206,7 @@ public class TransactionManagerImpl implements TransactionManager {
             // This will release locks in RecoveryManager which were created
             // by RecoveryManager.initialize() call in the TransactionFactoryImpl constructor
             // if startup recovery didn't happen yet.
+            _logger.log(Level.FINE, "Initialising transaction recovery from TransactionManagerImpl");
             TransactionServiceProperties.initRecovery(true);
 
             // V2-commented-out transactionStates = new Hashtable();

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionManagerImpl.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionManagerImpl.java
@@ -207,7 +207,7 @@ public class TransactionManagerImpl implements TransactionManager {
             // This will release locks in RecoveryManager which were created
             // by RecoveryManager.initialize() call in the TransactionFactoryImpl constructor
             // if startup recovery didn't happen yet.
-            _logger.log(Level.FINE, "Initialising transaction recovery from TransactionManagerImpl");
+            _logger.log(Level.FINER, "Initialising transaction recovery from TransactionManagerImpl");
             TransactionServiceProperties.initRecovery(true);
 
             // V2-commented-out transactionStates = new Hashtable();

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -322,7 +322,7 @@ public class TransactionServiceProperties {
                         interval = Integer.parseInt(value);
                     }
                     new RecoveryHelperThread(serviceLocator, interval,
-                            Boolean.parseBoolean(properties.getProperty("delay-recovery-lookup", "false")))
+                            Boolean.parseBoolean(properties.getProperty("delay-recovery-lookup")))
                             .start();
                 }
                 // Release all locks

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -90,6 +90,8 @@ public class TransactionServiceProperties {
     private static volatile boolean orbAvailable = false;
     private static volatile boolean recoveryInitialized = false;
 
+    private static final String LAZY_RECOVERY_LOOKUP_PROPERTY = "pending-txn-lazy-lookup";
+
     public static synchronized Properties getJTSProperties (ServiceLocator serviceLocator, boolean isORBAvailable) {
         if (orbAvailable == isORBAvailable && properties != null) {
             // We will need to update the properties if ORB availability changed
@@ -165,9 +167,9 @@ public class TransactionServiceProperties {
                                 }
                             }
 
-                        } else if (name.equals("pending-txn-lazy-lookup")) {
+                        } else if (name.equals(LAZY_RECOVERY_LOOKUP_PROPERTY)) {
                             if (isValueSet(value)) {
-                                jtsProperties.put("pending-txn-lazy-lookup", value);
+                                jtsProperties.put(LAZY_RECOVERY_LOOKUP_PROPERTY, value);
                             }
                         }
                     }
@@ -326,7 +328,7 @@ public class TransactionServiceProperties {
                         interval = Integer.parseInt(value);
                     }
                     new RecoveryHelperThread(serviceLocator, interval,
-                            Boolean.parseBoolean(properties.getProperty("pending-txn-lazy-lookup")))
+                            Boolean.parseBoolean(properties.getProperty(LAZY_RECOVERY_LOOKUP_PROPERTY)))
                             .start();
                 }
                 // Release all locks
@@ -369,8 +371,8 @@ public class TransactionServiceProperties {
             ResourceRecoveryManager recoveryManager = null;
             if (!lazyLookup) {
                 _logger.log(Level.FINE,
-                        "pending-txn-lazy-lookup is not enabled: looking up {0} service before pending-txn-cleanup-interval, {1}, has elapsed",
-                        new Object[]{ResourceRecoveryManager.class.getSimpleName(), interval});
+                        "{0} is not enabled: looking up {1} service before pending-txn-cleanup-interval, {2}, has elapsed",
+                        new Object[]{LAZY_RECOVERY_LOOKUP_PROPERTY, ResourceRecoveryManager.class.getSimpleName(), interval});
                 recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
             }
             if (interval <= 0) {
@@ -389,8 +391,8 @@ public class TransactionServiceProperties {
                     if (recoveryManager == null) {
                         if (lazyLookup) {
                             _logger.log(Level.FINE,
-                                    "pending-txn-lazy-lookup is enabled: looking up {0} service after pending-txn-cleanup-interval, {1}, has elapsed",
-                                    new Object[]{ResourceRecoveryManager.class.getSimpleName(), interval});
+                                    "{0} is enabled: looking up {1} service after pending-txn-cleanup-interval, {2}, has elapsed",
+                                    new Object[]{LAZY_RECOVERY_LOOKUP_PROPERTY, ResourceRecoveryManager.class.getSimpleName(), interval});
                         }
 
                         recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -322,7 +322,7 @@ public class TransactionServiceProperties {
                         interval = Integer.parseInt(value);
                     }
                     new RecoveryHelperThread(serviceLocator, interval,
-                            Boolean.parseBoolean(properties.getProperty("delay-recovery-lookup")))
+                            Boolean.parseBoolean(properties.getProperty("lazy-lookup")))
                             .start();
                 }
                 // Release all locks
@@ -351,19 +351,19 @@ public class TransactionServiceProperties {
     private static class RecoveryHelperThread extends Thread {
         private int interval;
         private ServiceLocator serviceLocator;
-        private boolean delayLookup;
+        private boolean lazyLookup;
 
-        RecoveryHelperThread(ServiceLocator serviceLocator, int interval, boolean delayRecoveryLookup) {
+        RecoveryHelperThread(ServiceLocator serviceLocator, int interval, boolean lazyLookup) {
             setName("Recovery Helper Thread");
             setDaemon(true);
             this.serviceLocator = serviceLocator;
             this.interval = interval;
-            this.delayLookup = delayRecoveryLookup;
+            this.lazyLookup = lazyLookup;
         }
 
         public void run() {
             ResourceRecoveryManager recoveryManager = null;
-            if (!delayLookup) {
+            if (!lazyLookup) {
                 recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
             }
             if (interval <= 0) {

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -165,6 +165,10 @@ public class TransactionServiceProperties {
                                 }
                             }
 
+                        } else if (name.equals("pending-txn-lazy-lookup")) {
+                            if (isValueSet(value)) {
+                                jtsProperties.put("pending-txn-lazy-lookup", value);
+                            }
                         }
                     }
 

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation]
+// Portions Copyright 2016-2025 Payara Foundation and/or its affiliates
 
 package com.sun.jts.jta;
 
@@ -358,7 +358,6 @@ public class TransactionServiceProperties {
         }
 
         public void run() {
-            ResourceRecoveryManager recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
             if (interval <= 0) {
                 // Only start the recovery thread if the interval value is set, and set to a positive value
                 return;
@@ -369,9 +368,14 @@ public class TransactionServiceProperties {
                        + "tx is enabled with interval " + interval);
             }
             int prevSize = 0;
+            ResourceRecoveryManager recoveryManager = null;
             try {
                 while(true) {
                     Thread.sleep(interval*1000L);
+                    if (recoveryManager == null) {
+                        recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
+                    }
+
                     if (!RecoveryManager.isIncompleteTxRecoveryRequired()) {
                         if (_logger.isLoggable(Level.FINE))
                             _logger.log(Level.FINE, "Incomplete transaction recovery is "

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -386,7 +386,7 @@ public class TransactionServiceProperties {
                     if (!RecoveryManager.isIncompleteTxRecoveryRequired()) {
                         if (_logger.isLoggable(Level.FINE))
                             _logger.log(Level.FINE, "Incomplete transaction recovery is "
-                                    + "not requeired,  waiting for the next interval");
+                                    + "not required,  waiting for the next interval");
                         continue;
                     }
                     if (RecoveryManager.sizeOfInCompleteTx() <= prevSize) {

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -364,6 +364,8 @@ public class TransactionServiceProperties {
         public void run() {
             ResourceRecoveryManager recoveryManager = null;
             if (!lazyLookup) {
+                _logger.log(Level.FINE,
+                        "pending-txn-lazy-lookup is not enabled: looking up {0} service before pending-txn-cleanup-interval, {1}, has elapsed", new Object[]{ResourceRecoveryManager.class.getSimpleName(), interval});
                 recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
             }
             if (interval <= 0) {
@@ -380,6 +382,11 @@ public class TransactionServiceProperties {
                 while(true) {
                     Thread.sleep(interval*1000L);
                     if (recoveryManager == null) {
+                        if (lazyLookup) {
+                            _logger.log(Level.FINE,
+                                    "pending-txn-lazy-lookup is enabled: looking up {0} service after pending-txn-cleanup-interval, {1}, has elapsed", new Object[]{ResourceRecoveryManager.class.getSimpleName(), interval});
+                        }
+
                         recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
                     }
 

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -374,6 +374,10 @@ public class TransactionServiceProperties {
                         "{0} is not enabled: looking up {1} service before pending-txn-cleanup-interval, {2}, has elapsed",
                         new Object[]{LAZY_RECOVERY_LOOKUP_PROPERTY, ResourceRecoveryManager.class.getSimpleName(), interval});
                 recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
+            } else {
+                _logger.log(Level.FINE,
+                        "{0} is enabled: looking up {1} service after pending-txn-cleanup-interval, {2}, has elapsed",
+                        new Object[]{LAZY_RECOVERY_LOOKUP_PROPERTY, ResourceRecoveryManager.class.getSimpleName(), interval});
             }
             if (interval <= 0) {
                 // Only start the recovery thread if the interval value is set, and set to a positive value
@@ -389,12 +393,6 @@ public class TransactionServiceProperties {
                 while(true) {
                     Thread.sleep(interval*1000L);
                     if (recoveryManager == null) {
-                        if (lazyLookup) {
-                            _logger.log(Level.FINE,
-                                    "{0} is enabled: looking up {1} service after pending-txn-cleanup-interval, {2}, has elapsed",
-                                    new Object[]{LAZY_RECOVERY_LOOKUP_PROPERTY, ResourceRecoveryManager.class.getSimpleName(), interval});
-                        }
-
                         recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
                     }
 

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -365,7 +365,8 @@ public class TransactionServiceProperties {
             ResourceRecoveryManager recoveryManager = null;
             if (!lazyLookup) {
                 _logger.log(Level.FINE,
-                        "pending-txn-lazy-lookup is not enabled: looking up {0} service before pending-txn-cleanup-interval, {1}, has elapsed", new Object[]{ResourceRecoveryManager.class.getSimpleName(), interval});
+                        "pending-txn-lazy-lookup is not enabled: looking up {0} service before pending-txn-cleanup-interval, {1}, has elapsed",
+                        new Object[]{ResourceRecoveryManager.class.getSimpleName(), interval});
                 recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
             }
             if (interval <= 0) {
@@ -384,7 +385,8 @@ public class TransactionServiceProperties {
                     if (recoveryManager == null) {
                         if (lazyLookup) {
                             _logger.log(Level.FINE,
-                                    "pending-txn-lazy-lookup is enabled: looking up {0} service after pending-txn-cleanup-interval, {1}, has elapsed", new Object[]{ResourceRecoveryManager.class.getSimpleName(), interval});
+                                    "pending-txn-lazy-lookup is enabled: looking up {0} service after pending-txn-cleanup-interval, {1}, has elapsed",
+                                    new Object[]{ResourceRecoveryManager.class.getSimpleName(), interval});
                         }
 
                         recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -381,6 +381,7 @@ public class TransactionServiceProperties {
             }
             if (interval <= 0) {
                 // Only start the recovery thread if the interval value is set, and set to a positive value
+                _logger.log(Level.FINE, "pending-txn-cleanup-interval is set to < 0: skipping recovery for incomplete tx");
                 return;
             }
 

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -328,7 +328,7 @@ public class TransactionServiceProperties {
                         interval = Integer.parseInt(value);
                     }
                     new RecoveryHelperThread(serviceLocator, interval,
-                            Boolean.parseBoolean(properties.getProperty(LAZY_RECOVERY_LOOKUP_PROPERTY)))
+                            Boolean.parseBoolean(properties.getProperty(LAZY_RECOVERY_LOOKUP_PROPERTY, "true")))
                             .start();
                 }
                 // Release all locks

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -322,7 +322,7 @@ public class TransactionServiceProperties {
                         interval = Integer.parseInt(value);
                     }
                     new RecoveryHelperThread(serviceLocator, interval,
-                            Boolean.parseBoolean(properties.getProperty("delayed-recovery-lookup", "false")))
+                            Boolean.parseBoolean(properties.getProperty("delay-recovery-lookup", "false")))
                             .start();
                 }
                 // Release all locks
@@ -351,19 +351,19 @@ public class TransactionServiceProperties {
     private static class RecoveryHelperThread extends Thread {
         private int interval;
         private ServiceLocator serviceLocator;
-        private boolean delayedLookup;
+        private boolean delayLookup;
 
-        RecoveryHelperThread(ServiceLocator serviceLocator, int interval, boolean delayedRecoveryLookup) {
+        RecoveryHelperThread(ServiceLocator serviceLocator, int interval, boolean delayRecoveryLookup) {
             setName("Recovery Helper Thread");
             setDaemon(true);
             this.serviceLocator = serviceLocator;
             this.interval = interval;
-            this.delayedLookup = delayedRecoveryLookup;
+            this.delayLookup = delayRecoveryLookup;
         }
 
         public void run() {
             ResourceRecoveryManager recoveryManager = null;
-            if (!delayedLookup) {
+            if (!delayLookup) {
                 recoveryManager = serviceLocator.getService(ResourceRecoveryManager.class);
             }
             if (interval <= 0) {

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/jta/TransactionServiceProperties.java
@@ -322,7 +322,7 @@ public class TransactionServiceProperties {
                         interval = Integer.parseInt(value);
                     }
                     new RecoveryHelperThread(serviceLocator, interval,
-                            Boolean.parseBoolean(properties.getProperty("lazy-lookup")))
+                            Boolean.parseBoolean(properties.getProperty("pending-txn-lazy-lookup")))
                             .start();
                 }
                 // Release all locks

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2022 Payara Foundation and/or its affiliates.
+// Portions Copyright 2022-2025 Payara Foundation and/or its affiliates.
 
 package org.glassfish.api.event;
 
@@ -60,12 +60,14 @@ public final class EventTypes<T> {
     // stock events.
     public static final String POST_SERVER_INIT_NAME = "post_server_init";
     public static final String SERVER_STARTUP_NAME = "server_startup";
+    public static final String SERVER_STARTED_NAME = "server_started";
     public static final String SERVER_READY_NAME = "server_ready";
     public static final String PREPARE_SHUTDOWN_NAME = "prepare_shutdown";
     public static final String SERVER_SHUTDOWN_NAME = "server_shutdown";
 
     public static final EventTypes<?> POST_SERVER_INIT = create(POST_SERVER_INIT_NAME);
     public static final EventTypes<?> SERVER_STARTUP = create(SERVER_STARTUP_NAME);
+    public static final EventTypes<?> SERVER_STARTED = create(SERVER_STARTED_NAME);
     public static final EventTypes<?> SERVER_READY = create(SERVER_READY_NAME);
     public static final EventTypes<?> SERVER_SHUTDOWN = create(SERVER_SHUTDOWN_NAME);
     public static final EventTypes<?> PREPARE_SHUTDOWN = create(PREPARE_SHUTDOWN_NAME);

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
@@ -68,13 +68,15 @@ public final class EventTypes<T> {
     public static final EventTypes<?> POST_SERVER_INIT = create(POST_SERVER_INIT_NAME);
     public static final EventTypes<?> SERVER_STARTUP = create(SERVER_STARTUP_NAME);
     /**
-     * SERVER_STARTED is only used if `fish.payara.delay-server-ready` system property is set.
+     * SERVER_STARTED is only used if `fish.payara.ready-after-applications` system property is set.
      * When set, this will fire where SERVER_READY would normally fire in `AppServerStartup#postStartUpJob`.
      * In this case, SERVER_READY will instead fire once all `DeployPreviousApplicationsRunLevel` services
      * have initialised.
      *
-     * This is a side effect of us changing the run levels to apply a structured order to the post-boot and deployment
-     * services in FISH-6588 (introduced in version 5.47.0) to prevent a race between post-boot scripts
+     * This will be enabled by default in Community (opt-out instead of opt-in).
+     *
+     * This is to counter a side effect of us changing the run levels to apply a structured order to the post-boot and
+     * deployment services in FISH-6588 (introduced in version 5.47.0) to prevent a race between post-boot scripts
      * and previously deployed applications; all of these services used to run at the same `StartupRunLevel`
      * and so would've been initialised by the time the `SERVER_READY` event would've fired.
       */

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
@@ -68,15 +68,13 @@ public final class EventTypes<T> {
     public static final EventTypes<?> POST_SERVER_INIT = create(POST_SERVER_INIT_NAME);
     public static final EventTypes<?> SERVER_STARTUP = create(SERVER_STARTUP_NAME);
     /**
-     * SERVER_STARTED is only used if `fish.payara.ready-after-applications` system property is set.
+     * SERVER_STARTED is only used if `fish.payara.ready-after-applications` system property is set to false.
      * When set, this will fire where SERVER_READY would normally fire in `AppServerStartup#postStartUpJob`.
      * In this case, SERVER_READY will instead fire once all `DeployPreviousApplicationsRunLevel` services
      * have initialised.
      *
-     * This will be enabled by default in Community (opt-out instead of opt-in).
-     *
      * This is to counter a side effect of us changing the run levels to apply a structured order to the post-boot and
-     * deployment services in FISH-6588 (introduced in version 5.47.0) to prevent a race between post-boot scripts
+     * deployment services in FISH-6588 (introduced in version 6.2022.2) to prevent a race between post-boot scripts
      * and previously deployed applications; all of these services used to run at the same `StartupRunLevel`
      * and so would've been initialised by the time the `SERVER_READY` event would've fired.
       */

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/EventTypes.java
@@ -67,6 +67,17 @@ public final class EventTypes<T> {
 
     public static final EventTypes<?> POST_SERVER_INIT = create(POST_SERVER_INIT_NAME);
     public static final EventTypes<?> SERVER_STARTUP = create(SERVER_STARTUP_NAME);
+    /**
+     * SERVER_STARTED is only used if `fish.payara.delay-server-ready` system property is set.
+     * When set, this will fire where SERVER_READY would normally fire in `AppServerStartup#postStartUpJob`.
+     * In this case, SERVER_READY will instead fire once all `DeployPreviousApplicationsRunLevel` services
+     * have initialised.
+     *
+     * This is a side effect of us changing the run levels to apply a structured order to the post-boot and deployment
+     * services in FISH-6588 (introduced in version 5.47.0) to prevent a race between post-boot scripts
+     * and previously deployed applications; all of these services used to run at the same `StartupRunLevel`
+     * and so would've been initialised by the time the `SERVER_READY` event would've fired.
+      */
     public static final EventTypes<?> SERVER_STARTED = create(SERVER_STARTED_NAME);
     public static final EventTypes<?> SERVER_READY = create(SERVER_READY_NAME);
     public static final EventTypes<?> SERVER_SHUTDOWN = create(SERVER_SHUTDOWN_NAME);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  *
- * Portions Copyright [2017-2022] [Payara Foundation and/or its affiliates]
+ * Portions Copyright 2017-2025 Payara Foundation and/or its affiliates
  */
 
 package com.sun.enterprise.v3.server;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -167,10 +167,12 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
     
     private final static String THREAD_POLICY_PROPERTY = "org.glassfish.startupThreadPolicy";
     private final static String MAX_STARTUP_THREAD_PROPERTY = "org.glassfish.maxStartupThreads";
-    
+
     private final static String POLICY_FULLY_THREADED = "FULLY_THREADED";
     private final static String POLICY_USE_NO_THREADS = "USE_NO_THREADS";
-    
+
+    private final static String DELAY_SERVER_READY_PROPERTY = "fish.payara.delay-server-ready";
+
     private final static int DEFAULT_STARTUP_THREADS = 4;
     private final static String FELIX_PLATFORM = "Felix";
     private final static String STATIC_PLATFORM = "Static";
@@ -368,7 +370,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
                 (startupFinishTime - initFinishTime) + " ms");
         }
 
-        if (Boolean.parseBoolean(System.getProperty("fish.payara.delay-server-ready"))) {
+        if (Boolean.parseBoolean(System.getProperty(DELAY_SERVER_READY_PROPERTY))) {
             if (!proceedTo(DeployPreviousApplicationsRunLevel.VAL)) {
                 appInstanceListener.stopRecordingTimes();
                 return false;
@@ -441,7 +443,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
         }
 
         env.setStatus(ServerEnvironment.Status.started);
-        if (Boolean.parseBoolean(System.getProperty("fish.payara.delay-server-ready"))) {
+        if (Boolean.parseBoolean(System.getProperty(DELAY_SERVER_READY_PROPERTY))) {
             events.send(new Event(EventTypes.SERVER_STARTED), false);
         } else {
             events.send(new Event(EventTypes.SERVER_READY), false);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -367,8 +367,9 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
             appInstanceListener.stopRecordingTimes();
             return false;
         }
-        
-        if (!postStartupJob()) {
+
+        boolean readyAfterApplications = Boolean.parseBoolean(System.getProperty(READY_AFTER_APPLICATIONS_PROPERTY));
+        if (!postStartupJob(readyAfterApplications)) {
             appInstanceListener.stopRecordingTimes();
             return false;
         }
@@ -380,7 +381,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
                 (startupFinishTime - initFinishTime) + " ms");
         }
 
-        if (Boolean.parseBoolean(System.getProperty(READY_AFTER_APPLICATIONS_PROPERTY))) {
+        if (readyAfterApplications) {
             if (!proceedTo(DeployPreviousApplicationsRunLevel.VAL)) {
                 appInstanceListener.stopRecordingTimes();
                 return false;
@@ -401,12 +402,12 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
         }
         return true;
     }
-    
+
     /**
      * 
      * @return True if started successfully, false otherwise
      */
-    private boolean postStartupJob() {
+    private boolean postStartupJob(boolean readyAfterApplications) {
         LinkedList<Future<Result<Thread>>> futures = appInstanceListener.getFutures();
 
         env.setStatus(ServerEnvironment.Status.starting);
@@ -453,7 +454,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
         }
 
         env.setStatus(ServerEnvironment.Status.started);
-        if (Boolean.parseBoolean(System.getProperty(READY_AFTER_APPLICATIONS_PROPERTY))) {
+        if (readyAfterApplications) {
             events.send(new Event(EventTypes.SERVER_STARTED), false);
         } else {
             events.send(new Event(EventTypes.SERVER_READY), false);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -174,10 +174,10 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
      * When set, SERVER_READY will fire once all `DeployPreviousApplicationsRunLevel` services
      * have initialised, and SERVER_STARTED will be fired in place of where SERVER_READY would normally.
      *
-     * This will be enabled by default in Community (opt-out instead of opt-in).
+     * Enabled by default.
      *
      * This is to counter a side effect of us changing the run levels to apply a structured order to the post-boot and
-     * deployment services in FISH-6588 (introduced in version 5.47.0) to prevent a race between post-boot scripts
+     * deployment services in FISH-6588 (introduced in version 6.2022.2) to prevent a race between post-boot scripts
      * and previously deployed applications; all of these services used to run at the same `StartupRunLevel`
      * and so would've been initialised by the time the `SERVER_READY` event would've fired.
      */
@@ -368,7 +368,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
             return false;
         }
 
-        boolean readyAfterApplications = Boolean.parseBoolean(System.getProperty(READY_AFTER_APPLICATIONS_PROPERTY));
+        boolean readyAfterApplications = Boolean.parseBoolean(System.getProperty(READY_AFTER_APPLICATIONS_PROPERTY, "true"));
         if (!postStartupJob(readyAfterApplications)) {
             appInstanceListener.stopRecordingTimes();
             return false;


### PR DESCRIPTION
## Description
Provides two potential opt-out fixes for the resource adaptor deployment vs. transaction recovery race condition. This is a race condition that may occur if you have a resource that utilises a custom resource adaptor (as in, one that must be deployed to the server) - the resource adaptor may not be deployed by the time the transaction recovery thread attempts to utilise it.

Both fixes allow opting-out for now until we're sure everything is fine.

### Fix Number 1 - Delay `SERVER_READY` Event
The startup time of the above threads getting kicked off is defined by `TransactionLifecycleService`. This has a service run level of 10 (`StartupRunLevel`), but the actual timing of the threads being kicked off is the `SERVER_READY` event, which gets sent by `AppServerStartup`.

This `SERVER_READY` event is currently sent very shortly after the `SERVER_STARTUP` event in the `AppServerStartup#PostStartupJob` method. The current distinction between these two events is:
* `SERVER_STARTUP`: fired once all `StartupRunLevel` services have initialised.
* `SERVER_READY`: fired once all services that are listening to the `SERVER_STARTUP` event have processed the event, and once all `InstanceLifecycleListener` listeners have responded to it (or after three seconds if taking too long). By default, the only lifecycle listeners activated at this time appears to be the Grizzly HTTP listeners - one `future` for each listener.

Currently the `SERVER_READY` gets fired before applications are deployed.
Previously, applications were deployed before this event was fired - they would get deployed at run level 10 (`StartupRunLevel`) during the initialisation of the `ApplicationLoaderService`.
We changed this behaviour in https://github.com/payara/Payara/pull/5993, where we delayed application deployment until run-level 15, so as to define an order allowing post-boot scripts to be run before application deployment.

I have defined a new system property that when enabled (enabled / undefined by default) delays the firing of the `SERVER_READY` event until after this delayed application deployment time at `DeployPreviousApplicationsRunLevel` (15): `fish.payara.ready-after-applications`.

In addition to this delayed firing, a replacement `SERVER_STARTED` event is fired in the place where `SERVER_READY` would normally have been sent.
This is not currently used anywhere, I'm just introducing it for if we end up needing to adjust some of the services which are currently listening for the `SERVER_READY` event in the event that this delayed firing breaks them in some way. By my count there are 17 of these services - it would take a lot of investigating to properly map out and document which of these services should start at which time (though I imagine most if not all Should™ run at the later time - with the old boot order they would've been running post application deployment time too).

### Fix Number 2 - Delay `ResourceRecoveryManager` Service Lookup
The service lookup on the `RecoveryHelperThread` instances was happening immediately without any way to delay it. During the boot of the server, these transaction recovery threads will be kicked off on server startup to execute asynchronously to the rest of the deployment. 

I have defined a new property for the Transaction Service: `recover-txn-delay`.
When set to a positive value (-1 / disabled / undefined by default), the configured delay will happen before lookup of this service is attempted. This Should™ allow the deployment of the required resource adaptor RAR to be deployed and available for use.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
We don't have a reliable reproducer for this issue unfortunately, so my testing has largely been "poke in related areas with stick".

* Start a fresh domain
* For both `server-config` and `default-config` (configured via admin console)
  * JVM Settings: Set `suspend` to `y` within "Debug Options"
  * Transaction Service: 
    * Enable "On Restart"
      * For `default-config` this should already be enabled by default
  * Logger Settings > Log Levels:
    * Set `javax.enterprise.resource.jta` to `FINEST`
    * Set `javax.enterprise.system.core.transaction` to `FINEST`
* Create a new instance (I named mine "Alan")
* Compile the three JTA samples in [JavaEE7 Samples](https://github.com/payara/patched-src-javaee7-samples/tree/Payara6) and deploy them to both the DAS and the new instance
* Stop the DAS
* Start the DAS with debug enabled, with breakpoints configured at:
  * `TransactionServiceProperties` line 371 (at the start of the `run` method)
  * `AppServerStartup` line 371
* Step through with the debugger, ensuring that the new timing behaviour is activated
* Do the same for Alan
* Inspect the logs of both instances for explosions - should be none
  * The new FINER level log messages should be present:
    * `Initialising transaction recovery from JavaEETransactionManagerJTSDelegate`
    * `Initialising transaction recovery from TransactionManagerImpl`
* For both `server-config` and `Alan-config` (or the respective config of your created instance)
  * Transaction Service: 
    * Add a new property: `recover-txn-delay` with a value of `5`
  * System Properties
    * Add a new property: `fish.payara.ready-after-applications` with a value of `true`
* Stop the DAS and Alan
* Start the DAS with debug enabled
* Step through with the debugger, ensuring that the new timing behaviour is activated
* Do the same with Alan
* Inspect the logs of both instances for explosions - should be none
* For both `server-config` and `Alan-config` (or the respective config of your created instance)
  * Transaction Service: 
    * Set the value of `recover-txn-delay` to `-1`
  * System Properties
    * Set the value of `fish.payara.ready-after-applications` to `false`
* Stop the DAS and Alan
* Start the DAS with debug enabled
* Step through with the debugger, ensuring that the new timing behaviour is **not** activated
* Do the same with Alan
* For both `server-config` and `Alan-config` (or the respective config of your created instance)
  * Transaction Service: 
    * Set the value of `recover-txn-delay` to `wibbles`
  * System Properties
    * Set the value of `fish.payara.ready-after-applications` to `12345`
* Stop the DAS and Alan
* Start the DAS with debug enabled
* Step through with the debugger, ensuring that the invalid values are parsed and that the server falls back to the old timing behaviour
* Do the same with Alan

### Testing Environment
Windows 11, Maven 3.9.10, Zulu JDK 11.0.27

## Documentation
https://github.com/payara/Payara-Documentation/pull/632

## Notes for Reviewers
Old run levels (pre 6.2022.2):
* “Predefined” applications (those which are present in the domain.xml AKA the server has been started before and had these applications deployed) = Server Startup (run-level 10)
  * As an extra caveat, this can actually happen before server startup if a particularly eager service requests - the run-level is not mandatory
* Applications within the autodeploy directory = Post Server Startup (run-level 20)
  * This includes the admin console
* Applications and resource adaptors deployed via post-boot = Server Startup (run-level 10).

"New" run levels (6.2022.2 and later):
* Server Startup = Level 10
  * This is where the various services of Payara start, of note being the services required to allow variable substitution via `TranslatedConfigView`
* Post-Boot = Level 12
  * This is where the post-boot commands run.
    * This is where a user can configure the DAS and domain
    * This is also where a user can deploy applications and resource adaptors
    * This is also be where a user can configure their new or existing resource adaptors.
    * The ordering of all of this would be up to the user and their script - we will continue to run the commands in the order defined.
* Deploy Applications = Level 15
  * This is where predefined applications (those that have been deployed previously) would begin deployment
* Post-Startup = Level 20
  * This is where applications defined for auto-deployment run

[FISH-6588]: https://payara.atlassian.net/browse/FISH-6588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ