### PR TITLE
Fish-11777: fixing CDI Test for Jakarta Data TCK

### DIFF
--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/JakartaDataExtension.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/JakartaDataExtension.java
@@ -66,6 +66,11 @@ public class JakartaDataExtension implements Extension {
 
     private static final Logger logger = Logger.getLogger(JakartaDataExtension.class.getName());
 
+    /**
+     * This is the built-in provider name
+     */
+    private static final String PROVIDER_NAME = "Payara";
+
     private String applicationName;
 
     public JakartaDataExtension() {
@@ -101,6 +106,14 @@ public class JakartaDataExtension implements Extension {
         List<Class<?>> classListResult = new ArrayList<>();
         root:
         for (Class<?> clazz : classList) {
+            Repository repository = clazz.getAnnotation(Repository.class);
+            if (repository != null) {
+                String dataProvider = repository.provider();
+                boolean provide = Repository.ANY_PROVIDER.equals(dataProvider) || PROVIDER_NAME.equalsIgnoreCase(dataProvider);
+                if (!provide) {
+                    continue root;
+                }
+            }
             Type[] types = clazz.getGenericInterfaces();
             for (Type type : types) {
                 if (type instanceof ParameterizedType parameterizedType) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

Changes to pass CDI TCK tests preventing the usage of different providers and custom entity annotations

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

This is a fix to pass Jakarta Data TCK with test related to validate CDI test cases

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

Running the Jakarta Data TCK and passing the failures from the CDITests configuration:

<img width="1185" height="110" alt="image" src="https://github.com/user-attachments/assets/b9dd122f-bd5c-45f9-bc57-1f6b05781833" />


### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04, Maven 3.9.9, zulu JDK 21
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
