### PR TITLE
FISH-11779 Jakarta Data - Add checks for user transactions

### DIFF
--- a/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/RepositoryImpl.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/jakarta/data/core/cdi/extension/RepositoryImpl.java
@@ -54,6 +54,7 @@ import jakarta.transaction.HeuristicMixedException;
 import jakarta.transaction.HeuristicRollbackException;
 import jakarta.transaction.NotSupportedException;
 import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.TransactionManager;
 import jakarta.validation.ConstraintViolation;
@@ -258,18 +259,28 @@ public class RepositoryImpl<T> implements InvocationHandler {
             return processInsertAndSaveOperationForArray(args, getTransactionManager(), getEntityManager(this.applicationName), dataForQuery);
         } else if (arg instanceof Iterable toIterate) {
             results = new ArrayList<>();
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             for (Object e : toIterate) {
                 results.add(em.merge(e));
             }
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
             if (!results.isEmpty()) {
                 return processReturnType(dataForQuery, results);
             }
         } else if (args[0] != null) {
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             entity = em.merge(args[0]);
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
         }
 
         if (evaluateReturnTypeVoidPredicate.test(dataForQuery.getMethod().getReturnType())) {
@@ -290,21 +301,31 @@ public class RepositoryImpl<T> implements InvocationHandler {
             return processInsertAndSaveOperationForArray(args, getTransactionManager(), getEntityManager(this.applicationName), dataForQuery);
         } else if (arg instanceof Iterable toIterate) {  //insert multiple entities from list reference
             results = new ArrayList<>();
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             for (Object e : ((Iterable<?>) toIterate)) {
                 em.persist(e);
                 results.add(e);
             }
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
 
             if (!results.isEmpty()) {
                 return processReturnType(dataForQuery, results);
             }
         } else if (arg != null) { //insert a single entity
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             entity = args[0];
             em.persist(args[0]);
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
         }
 
         if (evaluateReturnTypeVoidPredicate.test(dataForQuery.getMethod().getReturnType())) {
@@ -322,14 +343,22 @@ public class RepositoryImpl<T> implements InvocationHandler {
 
         if (args == null) { // delete all records
             startTransactionComponents();
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             String deleteAllQuery = "DELETE FROM " + declaredEntityClass.getSimpleName();
             returnValue = em.createQuery(deleteAllQuery).executeUpdate();
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
         } else if (args[0] instanceof List arr) {
             // existing list handling code
             startTransactionComponents();
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             List<Object> ids = getIds((List<?>) arr);
             if (!ids.isEmpty()) {
                 String deleteQuery = "DELETE FROM " + declaredEntityClass.getSimpleName() + " e WHERE e.id IN :ids";
@@ -337,7 +366,9 @@ public class RepositoryImpl<T> implements InvocationHandler {
                         .setParameter("ids", ids)
                         .executeUpdate();
             }
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
         } else {
             // Handle @By annotation cases
             Optional<Annotation> byFound = Arrays.stream(parameterAnnotations)
@@ -359,7 +390,10 @@ public class RepositoryImpl<T> implements InvocationHandler {
                 );
             } else if (args[0] != null) { // delete single entity
                 startTransactionComponents();
+                boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
                 startTransactionAndJoin();
+            }
                 try {
                     Method getId = args[0].getClass().getMethod("getId");
                     Object id = getId.invoke(args[0]);
@@ -370,7 +404,9 @@ public class RepositoryImpl<T> implements InvocationHandler {
                 } catch (Exception e) {
                     throw new RuntimeException("Error to get entity ID", e);
                 }
+                if (!userTransaction) {
                 endTransaction();
+            }
             }
         }
 
@@ -402,32 +438,47 @@ public class RepositoryImpl<T> implements InvocationHandler {
         if (dataForQuery.getEntityParamType().isArray()) { //update multiple entities from array reference
             int length = Array.getLength(args[0]);
             results = new ArrayList<>(length);
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             for (int i = 0; i < length; i++) {
                 em.merge(Array.get(args[0], i));
                 results.add(Array.get(args[0], i));
             }
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
 
             if (!results.isEmpty()) {
                 return processReturnType(dataForQuery, results);
             }
         } else if (arg instanceof List toIterate) { //update multiple entities
             results = new ArrayList<>();
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             for (Object e : ((Iterable<?>) toIterate)) {
                 entity = em.merge(e);
                 results.add(entity);
             }
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
 
             if (!results.isEmpty()) {
                 return processReturnType(dataForQuery, results);
             }
         } else if (arg != null) { //update single entity
-            startTransactionAndJoin();
+            boolean userTransaction = transactionManager.getStatus() == Status.STATUS_ACTIVE;
+            if (!userTransaction) {
+                startTransactionAndJoin();
+            }
             entity = em.merge(args[0]);
-            endTransaction();
+            if (!userTransaction) {
+                endTransaction();
+            }
         }
 
         if (evaluateReturnTypeVoidPredicate.test(dataForQuery.getMethod().getReturnType())) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Checks if a transaction is already started, if so, don't start and end a new transaction
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Ran the jakarta data tck:
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.821 s -- in ee.jakarta.tck.data.web.transaction.PersistenceTests
Stopping container using command: [/Users/kalinchan/.sdkman/candidates/java/21.0.5-zulu/bin/java, -jar, /Users/kalinchan/workspace/jakartaee-10-tck-runners/target/payara7/glassfish/modules/admin-cli.jar, stop-domain, -t]
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- failsafe:3.5.3:verify (run-data-tck) @ data-tck-runner ---
```
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.5, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.5-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "15.5", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a