### PR TITLE
FISH-11698 collect-log-files does not collect from custom location

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/CollectLogFiles.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/CollectLogFiles.java
@@ -146,11 +146,13 @@ public class CollectLogFiles implements AdminCommand {
             try {
 
                 String sourceDir = "";
-                if (logFileDetails.contains("${com.sun.aas.instanceRoot}/logs")) {
-                    sourceDir = env.getInstanceRoot() + File.separator + "logs";
-                } else {
-                    sourceDir = logFileDetails.substring(0, logFileDetails.lastIndexOf(File.separator));
+
+                String instanceRoot = env.getInstanceRoot().toString();
+                if (logFileDetails.contains("${com.sun.aas.instanceRoot}")) {
+                    logFileDetails = logFileDetails.replace("${com.sun.aas.instanceRoot}", instanceRoot);
                 }
+
+                sourceDir = logFileDetails.substring(0, logFileDetails.lastIndexOf(File.separator));
 
                 copyLogFilesForLocalhost(sourceDir, targetDir.getAbsolutePath(), report, targetServer.getName());
             } catch (Exception ex) {
@@ -292,11 +294,12 @@ public class CollectLogFiles implements AdminCommand {
 
             try {
                 String sourceDir = "";
-                if (logFileDetails.contains("${com.sun.aas.instanceRoot}/logs")) {
-                    sourceDir = env.getInstanceRoot() + File.separator + "logs";
-                } else {
-                    sourceDir = logFileDetails.substring(0, logFileDetails.lastIndexOf(File.separator));
+                String instanceRoot = env.getInstanceRoot().toString();
+                if (logFileDetails.contains("${com.sun.aas.instanceRoot}")) {
+                    logFileDetails = logFileDetails.replace("${com.sun.aas.instanceRoot}", instanceRoot);
                 }
+
+                sourceDir = logFileDetails.substring(0, logFileDetails.lastIndexOf(File.separator));
 
                 copyLogFilesForLocalhost(sourceDir, targetDir.getAbsolutePath(), report,
                         SystemPropertyConstants.DEFAULT_SERVER_INSTANCE_NAME);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
FISH-11698 collect-log-files does not collect from custom location

## Description

Previously, if ${com.sun.aas.instanceRoot} was in the path, it would change it to `env.getInstanceRoot`/logs. This means if the user had a custom path as `${com.sun.aas.instanceRoot}/logs/newlogs/server.log` It would overwrite that path and not use the newlogs directory.


### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

Tested the command with and without ${com.sun.aas.instanceRoot}.