### PR TITLE
Fish 11806 fix illegalargumentexception from entity tests

### DIFF
--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
@@ -40,12 +40,14 @@
 package fish.payara.data.core.cdi.extension;
 
 import fish.payara.data.core.util.DataParameter;
+import fish.payara.data.core.util.DeleteOperationUtility;
 import fish.payara.data.core.util.EntityIntrospectionUtil;
 import fish.payara.data.core.util.FindOperationUtility;
 import fish.payara.data.core.util.QueryByNameOperationUtility;
 import fish.payara.data.core.util.QueryOperationUtility;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.exceptions.OptimisticLockingFailureException;
+import jakarta.data.repository.By;
 import jakarta.data.repository.OrderBy;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.OptimisticLockException;
@@ -160,7 +162,7 @@ public class RepositoryImpl<T> implements InvocationHandler {
         if (method.isDefault()) {
             return InvocationHandler.invokeDefault(proxy, method, args);
         }
-        
+
         QueryData dataForQuery = queries.get(method);
         Object objectToReturn;
         startTransactionComponents();
@@ -169,21 +171,21 @@ public class RepositoryImpl<T> implements InvocationHandler {
             switch (dataForQuery.getQueryType()) {
                 case SAVE -> objectToReturn = processSaveOperation(args, dataForQuery);
                 case INSERT -> objectToReturn = processInsertOperation(args, dataForQuery);
-                case DELETE ->
-                        objectToReturn = processDeleteOperation(args, dataForQuery.getDeclaredEntityClass(), 
-                                dataForQuery.getMethod(), dataForQuery);
+                case DELETE -> objectToReturn = processDeleteOperation(args, dataForQuery.getDeclaredEntityClass(),
+                        dataForQuery.getMethod(), dataForQuery);
                 case UPDATE -> objectToReturn = processUpdateOperation(args, dataForQuery);
                 case FIND -> objectToReturn = processFindOperation(proxy, args, dataForQuery);
                 case QUERY -> objectToReturn = processQueryOperation(args, dataForQuery);
-                case FIND_BY_NAME -> objectToReturn = QueryByNameOperationUtility.processFindByNameOperation(args, 
+                case FIND_BY_NAME -> objectToReturn = QueryByNameOperationUtility.processFindByNameOperation(args,
                         dataForQuery, getEntityManager(this.applicationName));
-                case DELETE_BY_NAME -> objectToReturn = QueryByNameOperationUtility.processDeleteByNameOperation(args, 
+                case DELETE_BY_NAME -> objectToReturn = QueryByNameOperationUtility.processDeleteByNameOperation(args,
                         dataForQuery, getEntityManager(this.applicationName), getTransactionManager());
-                case COUNT_BY_NAME -> objectToReturn = QueryByNameOperationUtility.processCountByNameOperation(args, 
+                case COUNT_BY_NAME -> objectToReturn = QueryByNameOperationUtility.processCountByNameOperation(args,
                         dataForQuery, getEntityManager(this.applicationName));
-                case EXISTS_BY_NAME -> objectToReturn = QueryByNameOperationUtility.processExistsByNameOperation(args, 
+                case EXISTS_BY_NAME -> objectToReturn = QueryByNameOperationUtility.processExistsByNameOperation(args,
                         dataForQuery, getEntityManager(this.applicationName));
-                default -> throw new UnsupportedOperationException("QueryType " + dataForQuery.getQueryType() + " not supported.");
+                default ->
+                        throw new UnsupportedOperationException("QueryType " + dataForQuery.getQueryType() + " not supported.");
             }
         } catch (jakarta.persistence.OptimisticLockException e) {
             // Expected in Data TCK
@@ -365,7 +367,8 @@ public class RepositoryImpl<T> implements InvocationHandler {
                         transactionManager.rollback();
                     }
                 }
-            } catch (Exception ex) {}
+            } catch (Exception ex) {
+            }
             if (entityExistsConstraintViolation(t)) {
                 throw new jakarta.data.exceptions.EntityExistsException("Entity already exists", t);
             }
@@ -383,17 +386,24 @@ public class RepositoryImpl<T> implements InvocationHandler {
      * Processes standard delete operations, such as delete(entity) or deleteById(id).
      * This version has been completely rewritten to be more robust and TCK-compliant.
      *
-     * @param args The arguments passed to the repository method.
+     * @param args                The arguments passed to the repository method.
      * @param declaredEntityClass The primary entity class for the repository.
-     * @param method The repository method that was invoked.
+     * @param method              The repository method that was invoked.
      * @return The number of deleted entities, converted to the method's return type.
      * @throws ... various transaction exceptions
      */
-    public Object processDeleteOperation(Object[] args, Class<?> declaredEntityClass, 
-                                         Method method, QueryData dataForQuery) 
-            throws SystemException, NotSupportedException {
+    public Object processDeleteOperation(Object[] args, Class<?> declaredEntityClass,
+                                         Method method, QueryData dataForQuery)
+            throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        Annotation[][] parameterAnnotations = dataForQuery.getMethod().getParameterAnnotations();
+        int resultDelete = 0;
+        boolean hasBy = Arrays.stream(parameterAnnotations).flatMap(Arrays::stream).anyMatch(a -> a instanceof By);
 
-        if (args == null) {
+        if (hasBy) {
+            resultDelete = DeleteOperationUtility.processDeleteByOperation(args, declaredEntityClass,
+                    transactionManager, em, dataForQuery, method);
+            return processReturnQueryUpdate(method, resultDelete);
+        } else if (args == null && !hasBy) {
             startTransactionAndJoin(transactionManager, em, dataForQuery);
             try {
                 String deleteAllQuery = "DELETE FROM " + declaredEntityClass.getSimpleName();
@@ -429,7 +439,7 @@ public class RepositoryImpl<T> implements InvocationHandler {
         if (entitiesToDelete.isEmpty()) {
             return processReturnQueryUpdate(method, 0);
         }
-        
+
         startTransactionAndJoin(transactionManager, em, dataForQuery);
         try {
             for (Object entity : entitiesToDelete) {
@@ -600,5 +610,5 @@ public class RepositoryImpl<T> implements InvocationHandler {
         transactionManager = getTransactionManager();
         em = getEntityManager(this.applicationName);
     }
-    
+
 }

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/util/DeleteOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/util/DeleteOperationUtility.java
@@ -1,0 +1,90 @@
+package fish.payara.data.core.util;
+
+import fish.payara.data.core.cdi.extension.EntityMetadata;
+import fish.payara.data.core.cdi.extension.QueryData;
+import jakarta.data.repository.By;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.RollbackException;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+
+import static fish.payara.data.core.util.DataCommonOperationUtility.endTransaction;
+import static fish.payara.data.core.util.DataCommonOperationUtility.startTransactionAndJoin;
+import static fish.payara.data.core.util.FindOperationUtility.getIDParameterName;
+
+/**
+ * Utility class used to process Jakarta Data delete operations
+ */
+public class DeleteOperationUtility {
+
+    public static final Logger logger = Logger.getLogger(DeleteOperationUtility.class.getName());
+
+    public static int processDeleteByOperation(Object[] args, Class<?> declaredEntityClass, TransactionManager tm,
+                                               EntityManager em, QueryData dataForQuery, Method method)
+            throws SystemException, NotSupportedException, HeuristicRollbackException,
+            HeuristicMixedException, RollbackException, jakarta.transaction.RollbackException {
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("DELETE FROM ").append(declaredEntityClass.getSimpleName())
+                .append(" o");
+
+        String attributeValue = null;
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        int queryPosition = 1;
+        boolean hasWhere = false;
+
+        for (Annotation[] annotations : parameterAnnotations) {
+            for (Annotation annotation : annotations) {
+                if (annotation instanceof By) {
+                    attributeValue = ((By) annotation).value();
+                }
+                if (!hasWhere) {
+                    builder.append(" WHERE (");
+                    hasWhere = true;
+                } else {
+                    builder.append(" AND ");
+                }
+
+                if (attributeValue != null) {
+                    attributeValue = preprocessAttributeName(dataForQuery.getEntityMetadata(), attributeValue);
+                }
+                builder.append("o.").append(attributeValue).append("=?").append(queryPosition);
+            }
+            queryPosition++;
+        }
+
+        if (hasWhere) {
+            builder.append(")");
+        }
+
+        startTransactionAndJoin(tm, em, dataForQuery);
+        Query q = em.createQuery(builder.toString());
+        for (int i = 0; i < args.length; i++) {
+            q.setParameter(i + 1, args[i]);
+        }
+        int rowsAffected = q.executeUpdate();
+        endTransaction(tm, em, dataForQuery);
+
+        logger.info("Rows affected from delete operation: " + rowsAffected);
+        return rowsAffected;
+    }
+
+    private static String preprocessAttributeName(EntityMetadata entityMetadata, String attributeName) {
+        if (attributeName.endsWith(")")) {
+            return getIDParameterName(entityMetadata, attributeName);
+        }
+        if (entityMetadata.getAttributeNames().containsKey(attributeName.toLowerCase())) {
+            return entityMetadata.getAttributeNames().get(attributeName.toLowerCase());
+        }
+        throw new IllegalArgumentException("The attribute " + attributeName +
+                " is not mapped on the entity " + entityMetadata.getEntityName());
+    }
+
+}

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
@@ -82,7 +82,7 @@ import static fish.payara.data.core.util.FindOperationUtility.processPagination;
  */
 public class QueryOperationUtility {
 
-    private static final List<String> selectQueryPatterns = List.of("SELECT", "FROM", "WHERE", "ORDER", "BY", "GROUP", "HAVING");
+    private static final List<String> selectQueryPatterns = List.of("SELECT", "FROM", "WHERE", "ORDER BY", "GROUP BY", "HAVING");
     private static final List<String> deleteQueryPatterns = List.of("DELETE", "FROM", "WHERE");
     private static final List<String> updateQueryPatterns = List.of("UPDATE", "SET", "WHERE");
 
@@ -169,7 +169,7 @@ public class QueryOperationUtility {
                 validateParameters(dataForQuery, entry.getValue(), queryAnnotation.value());
             }
             objectToReturn = processPagination(entityManager, dataForQuery, args,
-                    method, new StringBuilder(dataForQuery.getQueryString()), 
+                    method, new StringBuilder(dataForQuery.getQueryString()),
                     patternSelectPositions.containsValue("WHERE"), dataParameter);
         }
 
@@ -316,15 +316,28 @@ public class QueryOperationUtility {
                     queryBuilder.append(query.substring(whereIndex + 6));
                 }
             }
-            case "ORDER" -> {
+            case "ORDER BY" -> {
                 int whereIndex = getIndexFromMap("WHERE", patternPositions);
-                int orderIndex = getIndexFromMap("ORDER", patternPositions);
-                queryBuilder.append(query.substring(whereIndex + 6, orderIndex));
-                if (patternPositions.containsValue("BY")) {
+                int orderIndex = getIndexFromMap("ORDER BY", patternPositions);
+                int fromIndex = getIndexFromMap("FROM", patternPositions);
+                int selectIndex = getIndexFromMap("SELECT", patternPositions);
+                if (fromIndex != -1) {
+                    queryBuilder.append(query.substring(fromIndex + 5, orderIndex));
+                }
+                if (whereIndex != -1) {
+                    queryBuilder.append(query.substring(whereIndex + 6, orderIndex));
+                }
+
+                if (fromIndex == -1 && whereIndex == -1 && selectIndex != -1) {
+                    String entityName = getSingleEntityName(entityClass.getName());
+                    queryBuilder.append(query.substring(selectIndex + 6, orderIndex));
+                    queryBuilder.append(" FROM ").append(entityName);
+                }
+                if (patternPositions.containsValue("ORDER BY")) {
                     queryBuilder.append(" ORDER BY ").append(query.substring(orderIndex + 9));
                 }
             }
-            case "GROUP" -> {
+            case "GROUP BY" -> {
                 int whereIndex = getIndexFromMap("WHERE", patternPositions);
                 int groupIndex = getIndexFromMap("GROUP", patternPositions);
                 int havingIndex = getIndexFromMap("HAVING", patternPositions);

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
@@ -332,7 +332,11 @@ public class QueryOperationUtility {
                     String entityName = getSingleEntityName(entityClass.getName());
                     queryBuilder.append(query.substring(selectIndex + 6, orderIndex));
                     queryBuilder.append(" FROM ").append(entityName);
+                } else if(fromIndex == -1 && whereIndex == -1 && selectIndex == -1) {
+                    String entityName = getSingleEntityName(entityClass.getName());
+                    queryBuilder.append(" FROM ").append(entityName);
                 }
+                
                 if (patternPositions.containsValue("BY")) {
                     queryBuilder.append(" ORDER BY ").append(query.substring(orderIndex + 9));
                 }

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
@@ -82,7 +82,7 @@ import static fish.payara.data.core.util.FindOperationUtility.processPagination;
  */
 public class QueryOperationUtility {
 
-    private static final List<String> selectQueryPatterns = List.of("SELECT", "FROM", "WHERE", "ORDER BY", "GROUP BY", "HAVING");
+    private static final List<String> selectQueryPatterns = List.of("SELECT", "FROM", "WHERE", "ORDER", "GROUP", "BY", "HAVING");
     private static final List<String> deleteQueryPatterns = List.of("DELETE", "FROM", "WHERE");
     private static final List<String> updateQueryPatterns = List.of("UPDATE", "SET", "WHERE");
 
@@ -316,9 +316,9 @@ public class QueryOperationUtility {
                     queryBuilder.append(query.substring(whereIndex + 6));
                 }
             }
-            case "ORDER BY" -> {
+            case "ORDER" -> {
                 int whereIndex = getIndexFromMap("WHERE", patternPositions);
-                int orderIndex = getIndexFromMap("ORDER BY", patternPositions);
+                int orderIndex = getIndexFromMap("ORDER", patternPositions);
                 int fromIndex = getIndexFromMap("FROM", patternPositions);
                 int selectIndex = getIndexFromMap("SELECT", patternPositions);
                 if (fromIndex != -1) {
@@ -333,11 +333,11 @@ public class QueryOperationUtility {
                     queryBuilder.append(query.substring(selectIndex + 6, orderIndex));
                     queryBuilder.append(" FROM ").append(entityName);
                 }
-                if (patternPositions.containsValue("ORDER BY")) {
+                if (patternPositions.containsValue("BY")) {
                     queryBuilder.append(" ORDER BY ").append(query.substring(orderIndex + 9));
                 }
             }
-            case "GROUP BY" -> {
+            case "GROUP" -> {
                 int whereIndex = getIndexFromMap("WHERE", patternPositions);
                 int groupIndex = getIndexFromMap("GROUP", patternPositions);
                 int havingIndex = getIndexFromMap("HAVING", patternPositions);

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
@@ -321,10 +321,9 @@ public class QueryOperationUtility {
                 int orderIndex = getIndexFromMap("ORDER", patternPositions);
                 int fromIndex = getIndexFromMap("FROM", patternPositions);
                 int selectIndex = getIndexFromMap("SELECT", patternPositions);
-                if (fromIndex != -1) {
+                if (fromIndex != -1 && whereIndex == -1) {
                     queryBuilder.append(query.substring(fromIndex + 5, orderIndex));
-                }
-                if (whereIndex != -1) {
+                } else if (whereIndex != -1) {
                     queryBuilder.append(query.substring(whereIndex + 6, orderIndex));
                 }
 
@@ -332,11 +331,11 @@ public class QueryOperationUtility {
                     String entityName = getSingleEntityName(entityClass.getName());
                     queryBuilder.append(query.substring(selectIndex + 6, orderIndex));
                     queryBuilder.append(" FROM ").append(entityName);
-                } else if(fromIndex == -1 && whereIndex == -1 && selectIndex == -1) {
+                } else if (fromIndex == -1 && whereIndex == -1 && selectIndex == -1) {
                     String entityName = getSingleEntityName(entityClass.getName());
                     queryBuilder.append(" FROM ").append(entityName);
                 }
-                
+
                 if (patternPositions.containsValue("BY")) {
                     queryBuilder.append(" ORDER BY ").append(query.substring(orderIndex + 9));
                 }

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/util/QueryOperationUtility.java
@@ -231,6 +231,16 @@ public class QueryOperationUtility {
             parameters.add(paramName.toString());
         }
 
+        //for update operation
+        if (patternPositions.containsValue("UPDATE") && patternPositions.containsValue("SET") && !patternPositions.containsValue("WHERE")) {
+            for (Map.Entry<Integer, String> entry : patternPositions.entrySet()) {
+                if (entry.getValue().equals("SET")) {
+                    Integer startPositionSet = entry.getKey();
+                    queryBuilder.append(queryString.substring(startPositionSet + 4));
+                }
+            }
+        }
+
         Map<String, Set<String>> queryMapping = new LinkedHashMap<>();
         queryMapping.put(queryBuilder.toString(), parameters);
         dataForQuery.setQueryString(queryBuilder.toString());


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Fix IllegalArgumentExceptions from Jakarta Data TCK results
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix to resolve TCK errors reported from Jakarta Data TCK
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing executing the Jakarta Data TCK:

`
[ERROR] Errors:
[ERROR]   EntityTests.testLiteralTrue » Runtime jakarta.persistence.PersistenceException: Exception [EclipseLink-4002] (Eclipse Persistence Services - 5.0.0-B08.v202505280949-dfc411d38767f696ce9f2741de051aef050cbeba): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: org.h2.jdbc.JdbcSQLSyntaxErrorException: Column "ID" must be in the GROUP BY list; SQL statement:
SELECT COUNT(ID) FROM NATURALNUMBER WHERE ((ISODD = ?) AND (ID BETWEEN ? AND ?)) ORDER BY ID ASC [90016-224]
Error Code: 90016
Call: SELECT COUNT(ID) FROM NATURALNUMBER WHERE ((ISODD = ?) AND (ID BETWEEN ? AND ?)) ORDER BY ID ASC
        bind => [3 parameters bound]
Query: ReportQuery(referenceClass=NaturalNumber sql="SELECT COUNT(ID) FROM NATURALNUMBER WHERE ((ISODD = ?) AND (ID BETWEEN ? AND ?)) ORDER BY ID ASC")
[ERROR]   EntityTests.testUpdateQueryWithWhereClause » Runtime Exception [EclipseLink-6075] (Eclipse Persistence Services - 5.0.0-B08.v202505280949-dfc411d38767f696ce9f2741de051aef050cbeba): org.eclipse.persistence.exceptions.QueryException
Exception Description: Object comparisons can only use the equal() or notEqual() operators.  Other comparisons must be done through query keys or direct attribute level comparisons.
Expression: [
Relation operator [ > ]
   Base ee.jakarta.tck.data.standalone.entity.Box
   Constant 0.0]
Query: DeleteAllQuery(referenceClass=Box jpql="DELETE FROM Box WHERE x > 0.0d AND y > 0.0f")
[INFO]

[ERROR] Tests run: 99, Failures: 0, Errors: 2, Skipped: 0
[INFO]
`
Now we don't have any IllegalArgumentExceptions reported on any of the tests

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04, zulu jdk 21, maven 3.9.9
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
