### PR TITLE
Reduced logging level for "Clustered CDI Event bus initialized"

### DIFF
--- a/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java
+++ b/appserver/payara-appserver-modules/payara-micro-cdi/src/main/java/fish/payara/micro/cdi/extension/ClusteredCDIEventBusImpl.java
@@ -100,7 +100,7 @@ public class ClusteredCDIEventBusImpl implements CDIEventListener, ClusteredCDIE
         }
         runtime.addCDIListener(this);
         if (runtime.isClustered()) {
-            Logger.getLogger(ClusteredCDIEventBusImpl.class.getName()).log(Level.INFO, "Clustered CDI Event bus initialized");
+            Logger.getLogger(ClusteredCDIEventBusImpl.class.getName()).log(Level.FINE, "Clustered CDI Event bus initialized");
         }
     }
 


### PR DESCRIPTION
Reducing from INFO to FINE as no administrator actually wants to see literally hundreds to thousands of time this message in real-word production scenarios. Developers can easily configure their log to see that message, if they really want to. The defaults should be for production use, not for developers.