### PR TITLE
FISH-11924 Upgrade Docker JDK to 21.0.8

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2021-2024 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2021-2025 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -57,7 +57,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk21.tag>21.0.7-jdk</docker.jdk21.tag>
+        <docker.jdk21.tag>21.0.8-jdk</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.


### PR DESCRIPTION
## Description
Upgrades the Docker JDKs to 21.0.8

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran Docker unit tests - all passed.

### Testing Environment
Windows 11

## Documentation
N/A

## Notes for Reviewers
None
