### PR TITLE
FISH-11614 Cannot Switch Views in JVM Report in Payara7

### DIFF
--- a/appserver/admingui/faces-compat/pom.xml
+++ b/appserver/admingui/faces-compat/pom.xml
@@ -62,10 +62,11 @@
             <scope>provided</scope>
         </dependency>
 
+
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.faces</artifactId>
-            <version>3.0.2</version>
+            <version>4.1.3</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/appserver/admingui/faces-compat/src/main/java/fish/payara/server/internal/admingui/GlassFishInjectionProvider.java
+++ b/appserver/admingui/faces-compat/src/main/java/fish/payara/server/internal/admingui/GlassFishInjectionProvider.java
@@ -59,7 +59,7 @@ import com.sun.enterprise.container.common.spi.util.InjectionManager;
 import com.sun.enterprise.deployment.BundleDescriptor;
 import com.sun.enterprise.deployment.InjectionInfo;
 import com.sun.enterprise.deployment.JndiNameEnvironment;
-import com.sun.faces.config.WebConfiguration;
+//import com.sun.faces.config.WebConfiguration;
 import com.sun.faces.spi.AnnotationScanner;
 import com.sun.faces.spi.DiscoverableInjectionProvider;
 import com.sun.faces.spi.HighAvailabilityEnabler;
@@ -76,9 +76,9 @@ import org.glassfish.hk2.classmodel.reflect.Type;
 import org.glassfish.hk2.classmodel.reflect.Types;
 
 import static com.sun.enterprise.web.Constants.DEPLOYMENT_CONTEXT_ATTRIBUTE;
-import static com.sun.enterprise.web.Constants.ENABLE_HA_ATTRIBUTE;
-import static com.sun.enterprise.web.Constants.IS_DISTRIBUTABLE_ATTRIBUTE;
-import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.EnableAgressiveSessionDirtying;
+//import static com.sun.enterprise.web.Constants.ENABLE_HA_ATTRIBUTE;
+//import static com.sun.enterprise.web.Constants.IS_DISTRIBUTABLE_ATTRIBUTE;
+//import static com.sun.faces.config.WebConfiguration.BooleanWebContextInitParameter.EnableAgressiveSessionDirtying;
 import static java.lang.Boolean.TRUE;
 import static java.security.AccessController.doPrivileged;
 import static java.util.logging.Level.FINE;
@@ -89,7 +89,7 @@ import static org.glassfish.api.invocation.ComponentInvocation.ComponentInvocati
  * This <code>InjectionProvider</code> is specific to the Payara/GlassFish/SJSAS 9.x PE/EE application servers.
  * </p>
  */
-public class GlassFishInjectionProvider extends DiscoverableInjectionProvider implements AnnotationScanner, HighAvailabilityEnabler, ThreadContext {
+public class GlassFishInjectionProvider extends DiscoverableInjectionProvider implements AnnotationScanner, ThreadContext {
 
     private static final Logger LOGGER = FacesLogger.APPLICATION.getLogger();
     private static final String HABITAT_ATTRIBUTE = "org.glassfish.servlet.habitat";
@@ -451,30 +451,30 @@ public class GlassFishInjectionProvider extends DiscoverableInjectionProvider im
      * 
      * @param ctx
      */
-    public void enableHighAvailability(ServletContext ctx) {
-        
-        // look at the following values for the web app
-        // 1> has <distributable /> in the web.xml
-        // 2> Was deployed with --availabilityenabled --target <clustername>
-        
-        WebConfiguration config = WebConfiguration.getInstance(ctx);
-        if (!config.isSet(EnableAgressiveSessionDirtying)) {
-            Object isDistributableObj = ctx.getAttribute(IS_DISTRIBUTABLE_ATTRIBUTE);
-            Object enableHAObj = ctx.getAttribute(ENABLE_HA_ATTRIBUTE);
-            
-            if (isDistributableObj instanceof Boolean && enableHAObj instanceof Boolean) {
-                boolean isDistributable = (Boolean) isDistributableObj;
-                boolean enableHA = (Boolean) enableHAObj;
-
-                if (LOGGER.isLoggable(FINE)) {
-                    LOGGER.log(FINE, "isDistributable = {0} enableHA = {1}", new Object[] { isDistributable, enableHA });
-                }
-                
-                if (isDistributable && enableHA) {
-                    LOGGER.fine("setting the EnableAgressiveSessionDirtying to true");
-                    config.overrideContextInitParameter(EnableAgressiveSessionDirtying, TRUE);
-                }
-            }
-        }
-    }
+//    public void enableHighAvailability(ServletContext ctx) {
+//
+//        // look at the following values for the web app
+//        // 1> has <distributable /> in the web.xml
+//        // 2> Was deployed with --availabilityenabled --target <clustername>
+//
+//        WebConfiguration config = WebConfiguration.getInstance(ctx);
+//        if (!config.isSet(EnableAgressiveSessionDirtying)) {
+//            Object isDistributableObj = ctx.getAttribute(IS_DISTRIBUTABLE_ATTRIBUTE);
+//            Object enableHAObj = ctx.getAttribute(ENABLE_HA_ATTRIBUTE);
+//
+//            if (isDistributableObj instanceof Boolean && enableHAObj instanceof Boolean) {
+//                boolean isDistributable = (Boolean) isDistributableObj;
+//                boolean enableHA = (Boolean) enableHAObj;
+//
+//                if (LOGGER.isLoggable(FINE)) {
+//                    LOGGER.log(FINE, "isDistributable = {0} enableHA = {1}", new Object[] { isDistributable, enableHA });
+//                }
+//
+//                if (isDistributable && enableHA) {
+//                    LOGGER.fine("setting the EnableAgressiveSessionDirtying to true");
+//                    config.overrideContextInitParameter(EnableAgressiveSessionDirtying, TRUE);
+//                }
+//            }
+//        }
+//    }
 }

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -59,7 +59,7 @@
     <name>Payara Appserver Parent Project</name>
 
     <properties>
-        <jsftemplating.version>3.0.0</jsftemplating.version>
+        <jsftemplating.version>4.0.4</jsftemplating.version>
         <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
         <apache.bcel.version>6.10.0</apache.bcel.version>
         <jna.version>5.17.0</jna.version>


### PR DESCRIPTION
FISH-11614 Cannot Switch Views in JVM Report in Payara7


## Description

So for this issue to be fixed a few upgrades and revamps will need to be done. With these changes Payara compiles, however, admingui is broken as the CDI is missing.

According to a call I had with Petr this means we will need to upgrade woodstock, jsftemplating and mojarra (jakarta.faces)... Advised to create a PR as a draft 