### PR TITLE
FISH-11174 Get instance info in parallel & display timeouts as Unknown

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/dg/dgGeneral.jsf
+++ b/appserver/admingui/cluster/src/main/resources/dg/dgGeneral.jsf
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2018] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2018-2025] [Payara Foundation and/or its affiliates]
 
 -->
 
@@ -185,7 +185,6 @@
             <event>
             <!beforeEncode
                 setAttribute(key="tmp" value="#{instance}");
-                gf.listInstances(optionKeys={"id"} optionValues={"$attribute{tmp}"}, statusMap="#{requestScope.statusMap}");
                 setAttribute(key="status" value="#{requestScope.statusMap['$attribute{tmp}']}");
                 setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp;  $resource{i18nc.status.$attribute{status}}");
             />

--- a/appserver/admingui/cluster/src/main/resources/dg/dgs.jsf
+++ b/appserver/admingui/cluster/src/main/resources/dg/dgs.jsf
@@ -38,7 +38,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright [2018-2022] [Payara Foundation and/or its affiliates]
+    Portions Copyright [2018-2025] [Payara Foundation and/or its affiliates]
 
 -->
 <!initPage
@@ -193,6 +193,7 @@
                 gf.getChildrenNamesList(endpoint="#{sessionScope.REST_URL}/deployment-groups/deployment-group/#{pageSession.dgName}/dg-server-ref",
                     id="Ref" result="#{requestScope.listOfInstances}");
                 mapPut(map="#{pageSession.dgInstanceMap}" key="#{pageSession.dgName}" value="#{requestScope.listOfInstances}");
+                gf.listInstances(optionKeys={"id"} optionValues={"$pageSession{dgName}"}, statusMap="#{requestScope.statusMap}");
             />
         </event>
         "<table border="1">
@@ -200,7 +201,6 @@
             <event>
             <!beforeEncode
                 setAttribute(key="tmp" value="#{instance}");
-                gf.listInstances(optionKeys={"id"} optionValues={"$attribute{tmp}"}, statusMap="#{requestScope.statusMap}");
                 setAttribute(key="status" value="#{requestScope.statusMap['$attribute{tmp}']}");
                 setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp;  $resource{i18nc.status.$attribute{status}}");
             />

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -800,7 +800,7 @@ PropertiesTab=Properties
 status.image.RUNNING=<img src="/theme/com/sun/webui/jsf/suntheme/images/alerts/ok_small.gif" alt="Running" title="Running"/>
 status.image.NOT_RUNNING=<img src="/theme/com/sun/webui/jsf/suntheme/images/alerts/failed_small.gif" alt="Stopped" title="Stopped"/>
 status.image.REQUIRES_RESTART=<img src="/theme/com/sun/webui/jsf/suntheme/images/alerts/degraded_small.gif" alt="Restart Required" title="Restart Required"/>
-status.image.UNKNOWN=
+status.image.UNKNOWN=<img src="/theme/com/sun/webui/jsf/suntheme/images/alerts/unknown_small.gif" alt="Unknown" title="Unknown"/>
 
 status.RUNNING=Running
 status.REQUIRES_RESTART=Restart Required

--- a/nucleus/cluster/admin/src/main/java/fish/payara/admin/cluster/ExecutorServiceFactory.java
+++ b/nucleus/cluster/admin/src/main/java/fish/payara/admin/cluster/ExecutorServiceFactory.java
@@ -1,0 +1,114 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.admin.cluster;
+
+import com.sun.enterprise.config.serverbeans.Config;
+import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.v3.admin.adapter.AdminEndpointDecider;
+import com.sun.enterprise.v3.admin.cluster.ClusterCommandHelper;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.lang.Math.min;
+
+/**
+ * ExecutorServiceFactory refactored from {@link ClusterCommandHelper}
+ * to provide access to ExecutorService and its calculated fixed thread pool size
+ *
+ * @author Jason Tarry
+ */
+public class ExecutorServiceFactory {
+    private static final int ADMIN_DEFAULT_POOL_SIZE = 5;
+    private static final String SERVER_CONFIG = "server-config";
+
+    private ExecutorServiceFactory() {
+        // private constructor
+    }
+
+    // Holder for both executor and size
+    public static class ExecutorServiceHolder {
+        private final ExecutorService executorService;
+        private final int poolSize;
+
+        public ExecutorServiceHolder(ExecutorService executorService, int poolSize) {
+            this.executorService = executorService;
+            this.poolSize = poolSize;
+        }
+
+        public ExecutorService getExecutorService() {
+            return executorService;
+        }
+
+        public int getThreadPoolSize() {
+            return poolSize;
+        }
+    }
+
+    private static int getAdminThreadPoolSize(final Domain domain) {
+        // Get the DAS configuration
+        Config config = domain.getConfigNamed(SERVER_CONFIG);
+        if (config == null) {
+            return ADMIN_DEFAULT_POOL_SIZE;
+        }
+
+        return new AdminEndpointDecider(config).getMaxThreadPoolSize();
+    }
+
+    private static int getThreadPoolSize(final Domain domain, int nInstances, boolean rolling) {
+        int threadPoolSize = 1;
+        if (!rolling) {
+            // Make the thread pool use the smaller of the number of instances
+            // or half the admin thread pool size
+            threadPoolSize = min(nInstances, getAdminThreadPoolSize(domain) / 2);
+
+            if (threadPoolSize < 1) {
+                threadPoolSize = 1;
+            }
+        }
+        return threadPoolSize;
+    }
+
+    public static ExecutorServiceHolder newFixedThreadPool(final Domain domain, int nInstances, boolean rolling) {
+        int poolSize = getThreadPoolSize(domain, nInstances, rolling);
+        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+        return new ExecutorServiceHolder(executor, poolSize);
+    }
+}

--- a/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/InstanceInfo.java
+++ b/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/InstanceInfo.java
@@ -203,11 +203,20 @@ public final class InstanceInfo {
 
             if ((!instanceLocation.endsWith(res.getServer().getName()))
                     || (res.getReport().getActionExitCode() != ActionReport.ExitCode.SUCCESS)) {
-                uptime = -1;
-                state = NOT_RUNNING;
-                running = false;
-                pid = -1;
-                ssState = stateService.setState(name, InstanceState.StateType.NOT_RUNNING, false);
+                // this can be a timeout
+                if (res.getReport().getMessage().contains("No response")) {
+                    running = null;
+                    state = UNKNOWN;
+                    uptime = -1;
+                    pid = -1;
+                    ssState = stateService.setState(name, InstanceState.StateType.UNKNOWN, false);
+                } else {
+                    uptime = -1;
+                    running = false;
+                    state = NOT_RUNNING;
+                    pid = -1;
+                    ssState = stateService.setState(name, InstanceState.StateType.NOT_RUNNING, false);
+                }
             }
             else {
                 Properties props = res.getReport().getTopMessagePart().getProps();

--- a/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/LocalStrings.properties
+++ b/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/LocalStrings.properties
@@ -47,6 +47,7 @@ ListInstances.state=State
 ListInstances.cluster=Cluster
 ListInstances.NotRunning=Not Running
 ListInstances.Running=Running
+ListInstances.Unknown=Unknown
 instanceinfo.uptime=Uptime: {0}
 
 ListNode.name=Node Name

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/admin/InstanceState.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/admin/InstanceState.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2025 [Payara Foundation and/or its affiliates]
 
 package org.glassfish.api.admin;
 
@@ -106,6 +107,14 @@ public class InstanceState {
 
             public String getDisplayString() {
                 return " never started";
+            }
+        },
+        UNKNOWN {
+            public String getDescription() {
+                return "UNKNOWN";
+            }
+            public String getDisplayString() {
+                return " unknown";
             }
         };
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

- Modified `ClusterCommandHelper.java` to use `ExecutorServiceFactory` for thread pool management when executing commands on cluster instances, factoring out thread pool creation
- Introduced `ExecutorServiceFactory.java` to encapsulate the creation of `ExecutorService` instances
- Modified `ListInstancesCommand.java` to retrieve instance information in parallel using an `ExecutorService`
- Modified `InstanceInfo.java` to handle `TimeoutException`, setting the state to `UNKNOWN` 
- Updated `Strings.properties` and `LocalStrings.properties` to add support for new `Unknown` state with corresponding image and text.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
See https://payara.atlassian.net/browse/FISH-12070

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

- Created deployment group with remote instances
- Slowdown network on remote instances so they don't respond within timeout period (default 10 secs)
- Observe timeout is only ever 10 secs and never 10 secs per slow/unreachable instance
- Observe instances that do timeout become Unknown state

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 24.04 openjdk 21.0.8 2025-07-15

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
