### PR TITLE
FISH-11959 FISH-12071 Revert "Bump jakarta.mail:jakarta.mail-api from 2.1.3 to 2.1.4"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
         <stax2-api.version>4.2.2</stax2-api.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jbi.version>1.0</jbi.version>
-        <mail.version>2.1.4</mail.version>
+        <mail.version>2.1.3</mail.version>
         <angus.mail.version>2.0.4</angus.mail.version>
         <opentelemetry.version>1.29.0</opentelemetry.version>
         <opentelemetry.alpha.version>1.29.0-alpha</opentelemetry.alpha.version>


### PR DESCRIPTION
## Description
This reverts commit e78690e7d2618f3efd03913d665edb74b8060c20 / https://github.com/payara/Payara/pull/7616

Breaks our run of the Jakarta TCK.
Investigation of whether it's our runner causing this pending.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran Jakarta EE TCK Signature test and Mail TCKs - green.

### Testing Environment
Jenkins

## Documentation
N/A

## Notes for Reviewers
None
