### PR TITLE
FISH-8652 Upgrade Hazelcast to a Patched 5.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
         <opentracing.version>0.33.0</opentracing.version>
         <jsp-api.version>4.0.0</jsp-api.version>
         <javax.cache-api.version>1.1.1.payara-p1</javax.cache-api.version>
-        <hazelcast.version>5.3.8-payara-1</hazelcast.version>
+        <hazelcast.version>5.5.0-payara-1-SNAPSHOT</hazelcast.version>
         <jakartaee.api.version>11.0.0</jakartaee.api.version>
         <weld-api.version>6.0.Final</weld-api.version>
         <weld.version>6.0.3.Final</weld.version>


### PR DESCRIPTION
## Description
Patched to avoid/fix OSGi resolution issue: Hazelcast expects a mandatory import of `javax.annotation` 3.0 from FindBugs (rather than the "proper" `jakarta.annotation` package).

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Loaded admin console - no OSGi explosions
Started 3 Payara Micro instances - all clustered as expected
Built the Docker images and ran the Docker JCache Test (from the `main` branch, specifying `payara.version` as 7.2025.1.Beta2-SNAPSHOT) - passed

Ran the Hazelcast unit and integration tests (against the snapshot version): https://jenkins.payara.fish/job/Patched-Project-Hazelcast/36/ (still running)

### Testing Environment
Windows 11, Maven 3.9.11, Zulu JDK 21.0.8

## Documentation
N/A

## Notes for Reviewers
None
