### PR TITLE
FISH-10834 Indicate server restart required for Virtual Threads config change

### DIFF
--- a/appserver/concurrent/concurrent-impl/pom.xml
+++ b/appserver/concurrent/concurrent-impl/pom.xml
@@ -86,6 +86,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>fish.payara.server.internal.test-utils</groupId>
+            <artifactId>utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>fish.payara.server.internal.admin</groupId>
             <artifactId>admin-util</artifactId>
             <version>${project.version}</version>

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
@@ -40,7 +40,6 @@
 package org.glassfish.concurrent.admin.listener;
 
 import com.sun.enterprise.config.serverbeans.Domain;
-import com.sun.enterprise.config.serverbeans.Resources;
 import com.sun.enterprise.util.i18n.StringManager;
 import fish.payara.internal.api.PostBootRunLevel;
 import jakarta.annotation.PostConstruct;
@@ -52,8 +51,7 @@ import org.glassfish.concurrent.config.ManagedThreadFactory;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigListener;
-import org.jvnet.hk2.config.ConfigSupport;
-import org.jvnet.hk2.config.ObservableBean;
+import org.jvnet.hk2.config.Transactions;
 import org.jvnet.hk2.config.UnprocessedChangeEvent;
 import org.jvnet.hk2.config.UnprocessedChangeEvents;
 
@@ -70,6 +68,9 @@ public class ResourcesConfigListener implements ConfigListener {
 
     @Inject
     private Domain domain;
+
+    @Inject
+    private Transactions transactions;
 
     @Override
     public UnprocessedChangeEvents changed(PropertyChangeEvent[] events) {
@@ -94,8 +95,6 @@ public class ResourcesConfigListener implements ConfigListener {
 
     @PostConstruct
     public void postConstruct() {
-        Resources resources = domain.getResources();
-        ObservableBean bean = (ObservableBean) ConfigSupport.getImpl(resources);
-        bean.addListener(this);
+        transactions.addListenerForType(ResourcesConfigListener.class, this);
     }
 }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
@@ -51,7 +51,11 @@ import org.glassfish.concurrent.config.ManagedThreadFactory;
 import org.glassfish.hk2.api.PostConstruct;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
-import org.jvnet.hk2.config.*;
+import org.jvnet.hk2.config.ConfigListener;
+import org.jvnet.hk2.config.ConfigSupport;
+import org.jvnet.hk2.config.ObservableBean;
+import org.jvnet.hk2.config.UnprocessedChangeEvent;
+import org.jvnet.hk2.config.UnprocessedChangeEvents;
 
 import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
@@ -57,7 +57,6 @@ import org.jvnet.hk2.config.UnprocessedChangeEvents;
 import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 
 @Service
 @RunLevel(PostBootRunLevel.VAL)
@@ -74,14 +73,7 @@ public class ResourcesConfigListener implements ConfigListener {
         List<UnprocessedChangeEvent> unprocessedChangeEvents = new ArrayList<>(1);
 
         for (PropertyChangeEvent propertyChangeEvent : events) {
-            Object source = propertyChangeEvent.getSource();
-
-            if (evaluateInterfaces(
-                    source.getClass(), clazz ->
-                            clazz == ManagedExecutorService.class
-                                    || clazz == ManagedScheduledExecutorService.class
-                                    || clazz == ManagedThreadFactory.class)
-                    && "use-virtual-threads".equals(propertyChangeEvent.getPropertyName())
+            if ("use-virtual-threads".equals(propertyChangeEvent.getPropertyName())
                     && !propertyChangeEvent.getOldValue().equals(propertyChangeEvent.getNewValue())) {
 
                 unprocessedChangeEvents.add(
@@ -94,16 +86,8 @@ public class ResourcesConfigListener implements ConfigListener {
 
     @PostConstruct
     public void postConstruct() {
-        transactions.addListenerForType(ResourcesConfigListener.class, this);
-    }
-
-    private boolean evaluateInterfaces(Class<?> clazz, Predicate<Class<?>> function) {
-        for (Class<?> interfaceClazz : clazz.getInterfaces()) {
-            if (function.test(interfaceClazz)) {
-                return true;
-            }
-            return evaluateInterfaces(interfaceClazz, function);
-        }
-        return false;
+        transactions.addListenerForType(ManagedExecutorService.class, this);
+        transactions.addListenerForType(ManagedScheduledExecutorService.class, this);
+        transactions.addListenerForType(ManagedThreadFactory.class, this);
     }
 }

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
@@ -43,12 +43,12 @@ import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Resources;
 import com.sun.enterprise.util.i18n.StringManager;
 import fish.payara.internal.api.PostBootRunLevel;
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import org.glassfish.concurrent.admin.ManagedExecutorServiceBaseManager;
 import org.glassfish.concurrent.config.ManagedExecutorService;
 import org.glassfish.concurrent.config.ManagedScheduledExecutorService;
 import org.glassfish.concurrent.config.ManagedThreadFactory;
-import org.glassfish.hk2.api.PostConstruct;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigListener;
@@ -63,7 +63,7 @@ import java.util.List;
 
 @Service
 @RunLevel(PostBootRunLevel.VAL)
-public class ResourcesConfigListener implements ConfigListener, PostConstruct {
+public class ResourcesConfigListener implements ConfigListener {
 
     private static StringManager sm
             = StringManager.getManager(ManagedExecutorServiceBaseManager.class);
@@ -92,7 +92,7 @@ public class ResourcesConfigListener implements ConfigListener, PostConstruct {
         return new UnprocessedChangeEvents(unprocessedChangeEvents);
     }
 
-    @Override
+    @PostConstruct
     public void postConstruct() {
         Resources resources = domain.getResources();
         ObservableBean bean = (ObservableBean) ConfigSupport.getImpl(resources);

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
@@ -67,9 +67,6 @@ public class ResourcesConfigListener implements ConfigListener {
             = StringManager.getManager(ManagedExecutorServiceBaseManager.class);
 
     @Inject
-    private Domain domain;
-
-    @Inject
     private Transactions transactions;
 
     @Override

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/main/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
 package org.glassfish.concurrent.admin.listener;
 
 import com.sun.enterprise.config.serverbeans.Domain;

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/listener/ResourcesConfigListener.java
@@ -1,0 +1,58 @@
+package org.glassfish.concurrent.admin.listener;
+
+import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.config.serverbeans.Resources;
+import com.sun.enterprise.util.i18n.StringManager;
+import fish.payara.internal.api.PostBootRunLevel;
+import jakarta.inject.Inject;
+import org.glassfish.concurrent.admin.ManagedExecutorServiceBaseManager;
+import org.glassfish.concurrent.config.ManagedExecutorService;
+import org.glassfish.concurrent.config.ManagedScheduledExecutorService;
+import org.glassfish.concurrent.config.ManagedThreadFactory;
+import org.glassfish.hk2.api.PostConstruct;
+import org.glassfish.hk2.runlevel.RunLevel;
+import org.jvnet.hk2.annotations.Service;
+import org.jvnet.hk2.config.*;
+
+import java.beans.PropertyChangeEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RunLevel(PostBootRunLevel.VAL)
+public class ResourcesConfigListener implements ConfigListener, PostConstruct {
+
+    private static StringManager sm
+            = StringManager.getManager(ManagedExecutorServiceBaseManager.class);
+
+    @Inject
+    private Domain domain;
+
+    @Override
+    public UnprocessedChangeEvents changed(PropertyChangeEvent[] events) {
+        List<UnprocessedChangeEvent> unprocessedChangeEvents = new ArrayList<>(1);
+
+        for (PropertyChangeEvent propertyChangeEvent : events) {
+            Object source = propertyChangeEvent.getSource();
+
+            if (!(source instanceof ManagedExecutorService
+                    || source instanceof ManagedScheduledExecutorService)
+                    || source instanceof ManagedThreadFactory) {
+                continue;
+            }
+
+            if ("use-virtual-threads".equals(propertyChangeEvent.getPropertyName())
+                    && (!propertyChangeEvent.getOldValue().equals(propertyChangeEvent.getNewValue()))) {
+                unprocessedChangeEvents.add(new UnprocessedChangeEvent(propertyChangeEvent, sm.getString("virtual.threads.change.requires.restart")));
+            }
+        }
+        return new UnprocessedChangeEvents(unprocessedChangeEvents);
+    }
+
+    @Override
+    public void postConstruct() {
+        Resources resources = domain.getResources();
+        ObservableBean bean = (ObservableBean) ConfigSupport.getImpl(resources);
+        bean.addListener(this);
+    }
+}

--- a/appserver/concurrent/concurrent-impl/src/main/resources/org/glassfish/concurrent/admin/LocalStrings.properties
+++ b/appserver/concurrent/concurrent-impl/src/main/resources/org/glassfish/concurrent/admin/LocalStrings.properties
@@ -92,3 +92,4 @@ maxsize.must.be.number=Option maximumpoolsize must be a number.
 coresize.maxsize.both.zero=Options corepoolsize and maximumpoolsize cannot both have value 0.
 coresize.biggerthan.maxsize=Option corepoolsize cannot have a bigger value than option maximumpoolsize.
 delete.concurrent.resource.notAllowed=The {0} resource cannot be deleted as it is required to be configured in the system.
+virtual.threads.change.requires.restart=Virtual Threads change requires restart.

--- a/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
+++ b/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
@@ -1,0 +1,152 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2009-2012 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
+
+package org.glassfish.concurrent.admin;
+
+import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.config.serverbeans.Resources;
+import org.glassfish.concurrent.admin.listener.ResourcesConfigListener;
+import org.glassfish.concurrent.config.ManagedExecutorService;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.resources.admin.cli.ResourceConstants;
+import org.glassfish.tests.utils.ConfigApiTest;
+import org.glassfish.tests.utils.Utils;
+import org.junit.Test;
+import org.jvnet.hk2.config.*;
+
+import java.beans.PropertyChangeEvent;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Jerome Dochez
+ */
+public class VirtualThreadsUnprocessedEventsTest extends ConfigApiTest implements TransactionListener {
+
+    private ServiceLocator habitat = Utils.instance.getHabitat(this);
+
+    private PropertyChangeEvent propertyChangeEvent = null;
+    private Resources resources = habitat.<Domain>getService(Domain.class).getResources();
+    private long timeBeforeChange;
+
+    /**
+     * Returns the DomainTest file name without the .xml extension to load the test configuration
+     * from.
+     *
+     * @return the configuration file name
+     */
+    public String getFileName() {
+        return "VirtualThreadsUnprocessedEventsTest";
+    }
+
+    @Test
+    public void restartRequiredTest() throws TransactionFailure {
+        Map<String, String> attributes = new HashMap<>();
+
+        attributes.put(ResourceConstants.USE_VIRTUAL_THREADS, "true");
+        attributes.put(ResourceConstants.JNDI_NAME, "concurrent/TestManagedExecutorService");
+
+        ConfigBean managedExecutorServiceConfigBean =
+                ConfigSupport.createAndSet(
+                        (ConfigBean) ConfigBean.unwrap(resources),
+                        ManagedExecutorService.class, attributes);
+
+        Transactions transactions = getHabitat().getService(Transactions.class);
+
+        transactions.waitForDrain();
+
+        ManagedExecutorService managedExecutorService =
+                managedExecutorServiceConfigBean.getProxy(ManagedExecutorService.class);
+
+        ResourcesConfigListener resourcesConfigListener = new ResourcesConfigListener();
+        ObservableBean bean = (ObservableBean) ConfigSupport.getImpl(resources);
+
+        bean.addListener(resourcesConfigListener);
+
+        try {
+            transactions.addTransactionsListener(this);
+            timeBeforeChange = System.currentTimeMillis();
+
+            try {
+                ConfigSupport.apply(
+                        param -> {param.setUseVirtualThreads("false"); return null;},
+                        managedExecutorService);
+            }
+            finally {
+                ConfigSupport.apply(
+                        param -> {param.setUseVirtualThreads("true"); return null;},
+                        managedExecutorService);
+            }
+
+            transactions.waitForDrain();
+            assertNotNull(propertyChangeEvent);
+
+            bean.removeListener(resourcesConfigListener);
+        }
+        finally {
+            transactions.removeTransactionsListener(this);
+            ConfigSupport.deleteChild((ConfigBean) ConfigBean.unwrap(resources), managedExecutorServiceConfigBean);
+        }
+    }
+
+
+    public void transactionCommited(List<PropertyChangeEvent> changes) {
+    }
+
+    public void unprocessedTransactedEvents(List<UnprocessedChangeEvents> changes) {
+        changes.stream().map(
+                UnprocessedChangeEvents::getUnprocessed
+        ).flatMap(
+                List::stream
+        ).filter(
+                unprocessedChangeEvent -> unprocessedChangeEvent.getWhen() >= timeBeforeChange
+        ).map(
+                UnprocessedChangeEvent::getEvent
+        ).filter(
+                event -> event.getSource() instanceof ManagedExecutorService
+        ).forEach(
+                param -> propertyChangeEvent = param
+        );
+    }
+}

--- a/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
+++ b/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
@@ -48,7 +48,14 @@ import org.glassfish.resources.admin.cli.ResourceConstants;
 import org.glassfish.tests.utils.ConfigApiTest;
 import org.glassfish.tests.utils.Utils;
 import org.junit.Test;
-import org.jvnet.hk2.config.*;
+import org.jvnet.hk2.config.ConfigBean;
+import org.jvnet.hk2.config.ConfigSupport;
+import org.jvnet.hk2.config.ObservableBean;
+import org.jvnet.hk2.config.TransactionFailure;
+import org.jvnet.hk2.config.TransactionListener;
+import org.jvnet.hk2.config.Transactions;
+import org.jvnet.hk2.config.UnprocessedChangeEvent;
+import org.jvnet.hk2.config.UnprocessedChangeEvents;
 
 import java.beans.PropertyChangeEvent;
 import java.util.HashMap;

--- a/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
+++ b/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
@@ -1,44 +1,42 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2009-2012 Oracle and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common Development
- * and Distribution License("CDDL") (collectively, the "License").  You
- * may not use this file except in compliance with the License.  You can
- * obtain a copy of the License at
- * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
- * or packager/legal/LICENSE.txt.  See the License for the specific
- * language governing permissions and limitations under the License.
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/main/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
  *
- * When distributing the software, include this License Header Notice in each
- * file and include the License file at packager/legal/LICENSE.txt.
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at glassfish/legal/LICENSE.txt.
  *
- * GPL Classpath Exception:
- * Oracle designates this particular file as subject to the "Classpath"
- * exception as provided by Oracle in the GPL Version 2 section of the License
- * file that accompanied this code.
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
  *
- * Modifications:
- * If applicable, add the following below the License Header, with the fields
- * enclosed by brackets [] replaced by your own identifying information:
- * "Portions Copyright [year] [name of copyright owner]"
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
  *
- * Contributor(s):
- * If you wish your version of this file to be governed by only the CDDL or
- * only the GPL Version 2, indicate your decision by adding "[Contributor]
- * elects to include this software in this distribution under the [CDDL or GPL
- * Version 2] license."  If you don't indicate a single choice of license, a
- * recipient has the option to distribute your version of this file under
- * either the CDDL, the GPL Version 2 or to extend the choice of license to
- * its licensees as provided above.  However, if you add GPL Version 2 code
- * and therefore, elected the GPL Version 2 license, then the option applies
- * only if the new code is made subject to such option by the copyright
- * holder.
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
  */
-// Portions Copyright [2017] [Payara Foundation and/or its affiliates]
-
 package org.glassfish.concurrent.admin;
 
 import com.sun.enterprise.config.serverbeans.Domain;
@@ -59,9 +57,6 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 
-/**
- * @author Jerome Dochez
- */
 public class VirtualThreadsUnprocessedEventsTest extends ConfigApiTest implements TransactionListener {
 
     private ServiceLocator habitat = Utils.instance.getHabitat(this);

--- a/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
+++ b/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
@@ -123,6 +123,7 @@ public class VirtualThreadsUnprocessedEventsTest extends ConfigApiTest implement
 
             transactions.waitForDrain();
             assertNotNull(propertyChangeEvent);
+            assertEquals("use-virtual-threads", propertyChangeEvent.getPropertyName());
 
             bean.removeListener(resourcesConfigListener);
         }

--- a/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
+++ b/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/admin/VirtualThreadsUnprocessedEventsTest.java
@@ -133,9 +133,11 @@ public class VirtualThreadsUnprocessedEventsTest extends ConfigApiTest implement
     }
 
 
+    @Override
     public void transactionCommited(List<PropertyChangeEvent> changes) {
     }
 
+    @Override
     public void unprocessedTransactedEvents(List<UnprocessedChangeEvents> changes) {
         changes.stream().map(
                 UnprocessedChangeEvents::getUnprocessed

--- a/appserver/concurrent/concurrent-impl/src/test/resources/VirtualThreadsUnprocessedEventsTest.xml
+++ b/appserver/concurrent/concurrent-impl/src/test/resources/VirtualThreadsUnprocessedEventsTest.xml
@@ -4,41 +4,41 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2012-2014 Oracle and/or its affiliates. All rights reserved.
+     Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
 
-    The contents of this file are subject to the terms of either the GNU
-    General Public License Version 2 only ("GPL") or the Common Development
-    and Distribution License("CDDL") (collectively, the "License").  You
-    may not use this file except in compliance with the License.  You can
-    obtain a copy of the License at
-    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
-    or packager/legal/LICENSE.txt.  See the License for the specific
-    language governing permissions and limitations under the License.
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
 
-    When distributing the software, include this License Header Notice in each
-    file and include the License file at packager/legal/LICENSE.txt.
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at glassfish/legal/LICENSE.txt.
 
-    GPL Classpath Exception:
-    Oracle designates this particular file as subject to the "Classpath"
-    exception as provided by Oracle in the GPL Version 2 section of the License
-    file that accompanied this code.
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
 
-    Modifications:
-    If applicable, add the following below the License Header, with the fields
-    enclosed by brackets [] replaced by your own identifying information:
-    "Portions Copyright [year] [name of copyright owner]"
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
 
-    Contributor(s):
-    If you wish your version of this file to be governed by only the CDDL or
-    only the GPL Version 2, indicate your decision by adding "[Contributor]
-    elects to include this software in this distribution under the [CDDL or GPL
-    Version 2] license."  If you don't indicate a single choice of license, a
-    recipient has the option to distribute your version of this file under
-    either the CDDL, the GPL Version 2 or to extend the choice of license to
-    its licensees as provided above.  However, if you add GPL Version 2 code
-    and therefore, elected the GPL Version 2 license, then the option applies
-    only if the new code is made subject to such option by the copyright
-    holder.
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
 
 -->
 

--- a/appserver/concurrent/concurrent-impl/src/test/resources/VirtualThreadsUnprocessedEventsTest.xml
+++ b/appserver/concurrent/concurrent-impl/src/test/resources/VirtualThreadsUnprocessedEventsTest.xml
@@ -1,0 +1,601 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2012-2014 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at packager/legal/LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+
+<!-- Portions Copyright [2017-2024] [Payara Foundation and/or its affiliates] -->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+    <hazelcast-runtime-configuration start-port="5900" das-port="53460" auto-increment-port="true"></hazelcast-runtime-configuration>
+    <security-configurations>
+        <authentication-service default="true" name="adminAuth" use-password-credential="true">
+            <security-provider name="spcrealm" type="LoginModule" provider-name="adminSpc">
+                <login-module-config name="adminSpecialLM" control-flag="sufficient" module-class="com.sun.enterprise.admin.util.AdminLoginModule">
+                    <property name="config" value="server-config"></property>
+                    <property name="auth-realm" value="admin-realm"></property>
+                </login-module-config>
+            </security-provider>
+            <security-provider name="filerealm" type="LoginModule" provider-name="adminFile">
+                <login-module-config name="adminFileLM" control-flag="sufficient" module-class="com.sun.enterprise.security.auth.login.FileLoginModule">
+                    <property name="config" value="server-config"></property>
+                    <property name="auth-realm" value="admin-realm"></property>
+                </login-module-config>
+            </security-provider>
+        </authentication-service>
+        <authorization-service default="true" name="authorizationService">
+            <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+                <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+            </security-provider>
+        </authorization-service>
+    </security-configurations>
+    <system-applications />
+    <resources>
+        <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-all" />
+        <jdbc-resource pool-name="H2Pool" jndi-name="jdbc/__default" object-type="system-all" />
+        <jdbc-connection-pool name="__TimerPool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.XADataSource">
+            <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/ejbtimer;AUTO_SERVER=TRUE" />
+        </jdbc-connection-pool>
+        <jdbc-connection-pool is-isolation-level-guaranteed="false" name="H2Pool" datasource-classname="org.h2.jdbcx.JdbcDataSource" res-type="javax.sql.DataSource">
+            <property name="URL" value="jdbc:h2:${com.sun.aas.instanceRoot}/lib/databases/embedded_default;AUTO_SERVER=TRUE" />
+        </jdbc-connection-pool>
+    </resources>
+    <servers>
+        <server name="server" config-ref="server-config">
+            <resource-ref ref="jdbc/__TimerPool" />
+            <resource-ref ref="jdbc/__default" />
+        </server>
+    </servers>
+    <nodes>
+        <node name="localhost-test_domain" type="CONFIG" node-host="localhost" install-dir="${com.sun.aas.productRoot}" />
+    </nodes>
+    <configs>
+        <config name="server-config">
+            <system-property name="JMS_PROVIDER_PORT" value="53455" description="Port Number that JMS Service will listen for remote clients connection." />
+
+            <payara-executor-service-configuration />
+            <http-service>
+                <access-log />
+                <virtual-server id="server" network-listeners="http-listener-1,http-listener-2" />
+                <virtual-server id="__asadmin" network-listeners="admin-listener" />
+            </http-service>
+            <iiop-service>
+                <orb use-thread-pool-ids="thread-pool-1" />
+                <iiop-listener address="0.0.0.0" port="53456" id="orb-listener-1" lazy-init="true" />
+                <ssl />
+                <iiop-listener security-enabled="true" address="0.0.0.0" port="3820" id="SSL">
+                    <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+                </iiop-listener>
+                <iiop-listener security-enabled="true" address="0.0.0.0" port="3920" id="SSL_MUTUALAUTH">
+                    <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+                </iiop-listener>
+            </iiop-service>
+            <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
+                <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="53458" name="system" />
+                <property value="/admin" name="adminConsoleContextRoot" />
+                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+                <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+            </admin-service>
+            <connector-service shutdown-timeout-in-seconds="30"></connector-service>
+            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" />
+            <asadmin-recorder-configuration></asadmin-recorder-configuration>
+            <request-tracing-service-configuration>
+                <notifier>log-notifier</notifier>
+            </request-tracing-service-configuration>
+            <notification-service-configuration enabled="true">
+                <log-notifier-configuration enabled="true"></log-notifier-configuration>
+            </notification-service-configuration>
+            <hazelcast-config-specific-configuration></hazelcast-config-specific-configuration>
+            <monitoring-service-configuration>
+                <notifier>log-notifier</notifier>
+            </monitoring-service-configuration>
+            <microprofile-metrics-configuration></microprofile-metrics-configuration>
+            <health-check-service-configuration>
+                <notifier>log-notifier</notifier>
+            </health-check-service-configuration>
+            <admin-audit-configuration>
+                <notifier>log-notifier</notifier>
+            </admin-audit-configuration>
+            <diagnostic-service />
+            <security-service>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                    <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+                    <property value="fileRealm" name="jaas-context" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                    <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+                    <property value="fileRealm" name="jaas-context" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate">
+                    <property value="true" name="certificate-validation"/>
+                </auth-realm>
+                <jacc-provider policy-provider="org.glassfish.exousia.modules.def.DefaultPolicy" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.def.DefaultPolicyConfigurationFactory"></jacc-provider>
+                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                    <property value="false" name="auditOn" />
+                </audit-module>
+                <message-security-config auth-layer="SOAP">
+                    <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="dynamic.username.password" />
+                        <property value="false" name="debug" />
+                    </provider-config>
+                    <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="dynamic.username.password" />
+                        <property value="false" name="debug" />
+                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+                    </provider-config>
+                    <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="debug" />
+                    </provider-config>
+                    <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property value="s1as" name="encryption.key.alias" />
+                        <property value="s1as" name="signature.key.alias" />
+                        <property value="false" name="debug" />
+                        <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+                    </provider-config>
+                </message-security-config>
+                <message-security-config auth-layer="HttpServlet">
+                    <provider-config provider-type="server" provider-id="GFConsoleAuthModule" class-name="org.glassfish.admingui.common.security.AdminConsoleAuthModule">
+                        <request-policy auth-source="sender"></request-policy>
+                        <response-policy></response-policy>
+                        <property name="loginPage" value="/login.jsf"></property>
+                        <property name="loginErrorPage" value="/loginError.jsf"></property>
+                    </provider-config>
+                </message-security-config>
+                <property value="SHA-256" name="default-digest-algorithm" />
+            </security-service>
+            <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=53459">
+                <jvm-options>-server</jvm-options>
+                <jvm-options>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+                <!-- Hazelcast internal package access requirement to get the best performance results. -->
+                <jvm-options>--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.net=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
+                <jvm-options>[24|]--sun-misc-unsafe-memory-access=allow</jvm-options>
+                <jvm-options>[24|]--enable-native-access=ALL-UNNAMED</jvm-options>
+                <jvm-options>-Xmx512m</jvm-options>
+                <jvm-options>-XX:NewRatio=2</jvm-options>
+                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+                <jvm-options>-Djava.awt.headless=true</jvm-options>
+                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+                <jvm-options>-Djakarta.security.jacc.PolicyFactory.provider=org.glassfish.exousia.modules.def.DefaultPolicyFactory</jvm-options>
+                <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
+                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.p12</jvm-options>
+                <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
+                <jvm-options>-Djdbc.drivers=org.h2.Driver</jvm-options>
+                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+                <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names. -->
+                <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.shell.remote,org.apache.felix.fileinstall</jvm-options>
+                <!-- Configuration of various third-party OSGi bundles like
+                Felix Remote Shell, FileInstall, etc. -->
+                <!-- Port on which remote shell listens for connections.-->
+                <jvm-options>-Dosgi.shell.telnet.port=6666</jvm-options>
+                <!-- How many concurrent users can connect to this remote shell -->
+                <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
+                <!-- From which hosts users can connect -->
+                <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
+                <!-- Gogo shell configuration -->
+                <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
+                <!-- Directory being watched by fileinstall. -->
+                <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
+                <!-- Time period fileinstaller thread in ms. -->
+                <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
+                <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
+                <jvm-options>-Dfelix.fileinstall.log.level=2</jvm-options>
+                <!-- should new bundles be started or installed only?
+                     true => start, false => only install
+                -->
+                <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
+                <!-- should watched bundles be started transiently or persistently -->
+                <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
+                <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes -->
+                <!-- If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten. -->
+                <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
+                <!-- End of OSGi bundle configurations -->
+                <!-- Woodstox property needed to pass StAX TCK -->
+                <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+                <!-- Grizzly NPN Bootstrap compatible with used JDK version -->
+                <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+                <!-- allow asadmin command enable-monitoring -->
+                <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
+                <!-- Hotswap Agent -->
+                <jvm-options>[Dynamic Code Evolution-11.0.10|]-XX:HotswapAgent=core</jvm-options>
+                <jvm-options>[Dynamic Code Evolution-11.0.10|]-Xlog:redefine+class*=info</jvm-options>
+                <jvm-options>-Djakarta.security.jacc.policy.provider=org.glassfish.exousia.modules.def.DefaultPolicy</jvm-options>
+            </java-config>
+            <availability-service>
+                <web-container-availability />
+                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore" />
+            </availability-service>
+            <network-config>
+                <protocols>
+                    <protocol name="http-listener-1">
+                        <http default-virtual-server="server" max-connections="250">
+                            <file-cache enabled="false"></file-cache>
+                        </http>
+                        <ssl />
+                    </protocol>
+                    <protocol security-enabled="true" name="http-listener-2">
+                        <http default-virtual-server="server" max-connections="250">
+                            <file-cache enabled="false"></file-cache>
+                        </http>
+                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as"></ssl>
+                    </protocol>
+                    <protocol name="admin-listener">
+                        <http default-virtual-server="__asadmin" max-connections="250" encoded-slash-enabled="true">
+                            <file-cache enabled="false"></file-cache>
+                        </http>
+                    </protocol>
+                </protocols>
+                <network-listeners>
+                    <network-listener port="53454" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool"></network-listener>
+                    <network-listener port="53457" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool"></network-listener>
+                    <network-listener port="53453" protocol="admin-listener" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool"></network-listener>
+                </network-listeners>
+                <transports>
+                    <transport name="tcp"></transport>
+                </transports>
+            </network-config>
+            <thread-pools>
+                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+                <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
+                <thread-pool name="thread-pool-1" max-thread-pool-size="200" />
+            </thread-pools>
+            <system-property name="org.glassfish.gmbal.no.multipleUpperBoundsException" value="true"/>
+        </config>
+        <config name="default-config" dynamic-reconfiguration-enabled="true">
+            <payara-executor-service-configuration />
+            <http-service>
+                <access-log />
+                <virtual-server id="server" network-listeners="http-listener-1, http-listener-2">
+                    <property name="default-web-xml" value="${com.sun.aas.instanceRoot}/config/default-web.xml" />
+                </virtual-server>
+                <virtual-server id="__asadmin" network-listeners="admin-listener" />
+            </http-service>
+            <iiop-service>
+                <orb use-thread-pool-ids="thread-pool-1" />
+                <iiop-listener port="${IIOP_LISTENER_PORT}" id="orb-listener-1" lazy-init="true" address="0.0.0.0" />
+                <ssl />
+                <iiop-listener port="${IIOP_SSL_LISTENER_PORT}" id="SSL" address="0.0.0.0" security-enabled="true">
+                    <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+                </iiop-listener>
+                <iiop-listener port="${IIOP_SSL_MUTUALAUTH_PORT}" id="SSL_MUTUALAUTH" address="0.0.0.0" security-enabled="true">
+                    <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+                </iiop-listener>
+            </iiop-service>
+            <admin-service system-jmx-connector-name="system" type="server">
+                <!-- JSR 160  "system-jmx-connector" -->
+                <jmx-connector address="0.0.0.0" auth-realm-name="admin-realm" name="system" port="${JMX_SYSTEM_CONNECTOR_PORT}" protocol="rmi_jrmp" security-enabled="false" />
+                <!-- JSR 160  "system-jmx-connector" -->
+                <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+            </admin-service>
+            <web-container>
+                <session-config>
+                    <session-manager>
+                        <manager-properties />
+                        <store-properties />
+                    </session-manager>
+                    <session-properties />
+                </session-config>
+            </web-container>
+            <ejb-container session-store="${com.sun.aas.instanceRoot}/session-store">
+                <ejb-timer-service />
+            </ejb-container>
+            <mdb-container />
+            <jms-service type="EMBEDDED" default-jms-host="default_JMS_host" addresslist-behavior="priority">
+                <jms-host name="default_JMS_host" host="localhost" port="${JMS_PROVIDER_PORT}" admin-user-name="admin" admin-password="admin" lazy-init="true" />
+            </jms-service>
+            <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+                <module-log-levels />
+            </log-service>
+            <security-service>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+                    <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile" />
+                    <property name="jaas-context" value="fileRealm" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+                    <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile" />
+                    <property name="jaas-context" value="fileRealm" />
+                </auth-realm>
+                <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate">
+                    <property name="certificate-validation" value="true" />
+                </auth-realm>
+                <jacc-provider policy-provider="org.glassfish.exousia.modules.def.DefaultPolicy" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.def.DefaultPolicyConfigurationFactory"></jacc-provider>
+                <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+                    <property value="false" name="auditOn" />
+                </audit-module>
+                <message-security-config auth-layer="SOAP">
+                    <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="dynamic.username.password" value="false" />
+                        <property name="debug" value="false" />
+                    </provider-config>
+                    <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="dynamic.username.password" value="false" />
+                        <property name="debug" value="false" />
+                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                    </provider-config>
+                    <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="debug" value="false" />
+                    </provider-config>
+                    <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+                        <request-policy auth-source="content" />
+                        <response-policy auth-source="content" />
+                        <property name="encryption.key.alias" value="s1as" />
+                        <property name="signature.key.alias" value="s1as" />
+                        <property name="debug" value="false" />
+                        <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" />
+                    </provider-config>
+                </message-security-config>
+            </security-service>
+            <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" />
+            <request-tracing-service-configuration>
+                <notifier>log-notifier</notifier>
+            </request-tracing-service-configuration>
+            <notification-service-configuration enabled="true">
+                <log-notifier-configuration enabled="true"></log-notifier-configuration>
+            </notification-service-configuration>
+            <hazelcast-config-specific-configuration config-specific-data-grid-start-port="${HZ_LISTENER_PORT}"></hazelcast-config-specific-configuration>
+            <monitoring-service-configuration>
+                <notifier>log-notifier</notifier>
+            </monitoring-service-configuration>
+            <microprofile-metrics-configuration></microprofile-metrics-configuration>
+            <health-check-service-configuration>
+                <notifier>log-notifier</notifier>
+            </health-check-service-configuration>
+            <admin-audit-configuration>
+                <notifier>log-notifier</notifier>
+            </admin-audit-configuration>
+            <diagnostic-service />
+            <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
+                <jvm-options>-server</jvm-options>
+                <jvm-options>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+                <!-- Hazelcast internal package access requirement to get the best performance results. -->
+                <jvm-options>--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.net=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.nio=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/sun.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.logging/java.util.logging=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/javax.management=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.management/javax.management.openmbean=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-exports=java.base/sun.net.www=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.lang.invoke=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.desktop/java.beans=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
+                <jvm-options>--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED</jvm-options>
+                <jvm-options>[24|]--sun-misc-unsafe-memory-access=allow</jvm-options>
+                <jvm-options>[24|]--enable-native-access=ALL-UNNAMED</jvm-options>
+                <jvm-options>-Xmx512m</jvm-options>
+                <jvm-options>-XX:NewRatio=2</jvm-options>
+                <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+                <jvm-options>-Djava.awt.headless=true</jvm-options>
+                <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+                <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
+                <jvm-options>-Djakarta.security.jacc.PolicyFactory.provider=org.glassfish.exousia.modules.def.DefaultPolicyFactory</jvm-options>
+                <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
+                <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
+                <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.p12</jvm-options>
+                <jvm-options>-Djdbc.drivers=org.h2.Driver</jvm-options>
+                <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
+                <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
+                <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
+                <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names.
+                The remote shell bundle has been disabled for cluster and remote instances. -->
+                <jvm-options>-Dorg.glassfish.additionalOSGiBundlesToStart=org.apache.felix.shell,org.apache.felix.gogo.runtime,org.apache.felix.gogo.shell,org.apache.felix.gogo.command,org.apache.felix.fileinstall</jvm-options>
+                <!-- Port on which remote shell listens for connections.-->
+                <jvm-options>-Dosgi.shell.telnet.port=${OSGI_SHELL_TELNET_PORT}</jvm-options>
+                <!-- How many concurrent users can connect to this remote shell -->
+                <jvm-options>-Dosgi.shell.telnet.maxconn=1</jvm-options>
+                <!-- From which hosts users can connect -->
+                <jvm-options>-Dosgi.shell.telnet.ip=127.0.0.1</jvm-options>
+                <!-- Gogo shell configuration -->
+                <!--PAYARA-495-->
+                <!--<jvm-options>-Dgosh.args=nointeractive</jvm-options>-->
+                <jvm-options>-Dgosh.args=--nointeractive</jvm-options>
+                <!-- Directory being watched by fileinstall. -->
+                <jvm-options>-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/</jvm-options>
+                <!-- Time period fileinstaller thread in ms. -->
+                <jvm-options>-Dfelix.fileinstall.poll=5000</jvm-options>
+                <!-- log level: 1 for error, 2 for warning, 3 for info and 4 for debug. -->
+                <jvm-options>-Dfelix.fileinstall.log.level=3</jvm-options>
+                <!-- should new bundles be started or installed only?
+                    true => start, false => only install
+                -->
+                <jvm-options>-Dfelix.fileinstall.bundles.new.start=true</jvm-options>
+                <!-- should watched bundles be started transiently or persistently -->
+                <jvm-options>-Dfelix.fileinstall.bundles.startTransient=true</jvm-options>
+                <!-- Should changes to configuration be saved in corresponding cfg file? false: no, true: yes
+                     If we don't set false, everytime server starts from clean osgi cache, the file gets rewritten.
+                -->
+                <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
+                <!-- End of OSGi bundle configurations -->
+                <!-- PAYARA-1033 Maintain backwards compatibility to old Grizzly Memeory Manager -->
+                <jvm-options>-Dorg.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMemoryManager</jvm-options>
+                <jvm-options>-Dorg.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true</jvm-options>
+                <jvm-options>-Dorg.jboss.weld.serialization.beanIdentifierIndexOptimization=false</jvm-options>
+                <!-- Grizzly NPN Bootstrap compatible with used JDK version -->
+                <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
+                <!-- Hotswap Agent -->
+                <jvm-options>[Dynamic Code Evolution-11.0.10|]-XX:HotswapAgent=core</jvm-options>
+                <jvm-options>[Dynamic Code Evolution-11.0.10|]-Xlog:redefine+class*=info</jvm-options>
+                <jvm-options>-Djakarta.security.jacc.policy.provider=org.glassfish.exousia.modules.def.DefaultPolicy</jvm-options>
+            </java-config>
+            <availability-service>
+                <web-container-availability />
+                <ejb-container-availability sfsb-store-pool-name="jdbc/hastore" />
+                <jms-availability />
+            </availability-service>
+            <network-config>
+                <protocols>
+                    <protocol name="http-listener-1">
+                        <http default-virtual-server="server">
+                            <file-cache />
+                        </http>
+                        <ssl />
+                    </protocol>
+                    <protocol security-enabled="true" name="http-listener-2">
+                        <http default-virtual-server="server">
+                            <file-cache />
+                        </http>
+                        <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+                    </protocol>
+                    <protocol name="admin-listener">
+                        <http default-virtual-server="__asadmin" max-connections="250">
+                            <file-cache enabled="false" />
+                        </http>
+                    </protocol>
+                    <protocol security-enabled="true" name="sec-admin-listener">
+                        <http default-virtual-server="__asadmin" encoded-slash-enabled="true">
+                            <file-cache></file-cache>
+                        </http>
+                        <ssl client-auth="want" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="glassfish-instance" renegotiate-on-client-auth-want="false"></ssl>
+                    </protocol>
+                    <protocol name="admin-http-redirect">
+                        <http-redirect secure="true"></http-redirect>
+                    </protocol>
+                    <protocol name="pu-protocol">
+                        <port-unification>
+                            <protocol-finder protocol="sec-admin-listener" name="http-finder" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                            <protocol-finder protocol="admin-http-redirect" name="admin-http-redirect" classname="org.glassfish.grizzly.config.portunif.HttpProtocolFinder"></protocol-finder>
+                        </port-unification>
+                    </protocol>
+
+                </protocols>
+                <network-listeners>
+                    <network-listener address="0.0.0.0" port="${HTTP_LISTENER_PORT}" protocol="http-listener-1" transport="tcp" name="http-listener-1" thread-pool="http-thread-pool" />
+                    <network-listener address="0.0.0.0" port="${HTTP_SSL_LISTENER_PORT}" protocol="http-listener-2" transport="tcp" name="http-listener-2" thread-pool="http-thread-pool" />
+                    <network-listener port="${ASADMIN_LISTENER_PORT}" protocol="pu-protocol" transport="tcp" name="admin-listener" thread-pool="admin-thread-pool" />
+                </network-listeners>
+                <transports>
+                    <transport name="tcp" />
+                </transports>
+            </network-config>
+            <thread-pools>
+                <thread-pool name="http-thread-pool" />
+                <thread-pool min-thread-pool-size="2" max-thread-pool-size="200" idle-thread-timeout-in-seconds="120" name="thread-pool-1" />
+                <thread-pool name="admin-thread-pool" max-thread-pool-size="15" min-thread-pool-size="1" max-queue-size="256"></thread-pool>
+            </thread-pools>
+            <group-management-service />
+            <system-property name="JMS_PROVIDER_PORT" value="27676" description="Port Number that JMS Service will listen for remote clients connection." />
+            <system-property name="ASADMIN_LISTENER_PORT" value="24848" />
+            <system-property name="HTTP_LISTENER_PORT" value="28080" />
+            <system-property name="HTTP_SSL_LISTENER_PORT" value="28181" />
+            <system-property name="IIOP_LISTENER_PORT" value="23700" />
+            <system-property name="IIOP_SSL_LISTENER_PORT" value="23820" />
+            <system-property name="IIOP_SSL_MUTUALAUTH_PORT" value="23920" />
+            <system-property name="JMX_SYSTEM_CONNECTOR_PORT" value="28686" />
+            <system-property name="OSGI_SHELL_TELNET_PORT" value="26666" />
+            <system-property name="JAVA_DEBUGGER_PORT" value="29009" />
+            <system-property name="HZ_LISTENER_PORT" value="5900" />
+            <system-property name="org.glassfish.gmbal.no.multipleUpperBoundsException" value="true"/>
+        </config>
+    </configs>
+    <property name="administrative.domain.name" value="test_domain" />
+    <secure-admin special-admin-indicator="5455096d-1dd7-4f69-9f2c-4672a2ab9d6f">
+        <secure-admin-principal dn="CN=Stians-MacBook-Pro.local,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK"></secure-admin-principal>
+        <secure-admin-principal dn="CN=Stians-MacBook-Pro.local-instance,OU=Payara,O=Payara Foundation,L=Great Malvern,ST=Worcestershire,C=UK"></secure-admin-principal>
+    </secure-admin>
+</domain>


### PR DESCRIPTION
https://payara.atlassian.net/browse/FISH-10834

## Description
Adds a `ConfigListener` which creates `UnprocessedChangeEvents` when the `use-virtual-threads` setting is changed for `ManagedExecutorService`, `ManagedScheduledExecutorService`, and `ManagedThreadFactory` which are server resources.

## Important Info
### Blockers
N/A

## Testing
### New tests
New unit test added in PR. It tests creating a new ManagedExecutorService and asserts if changing the the use-virtual-threads property on it causes the `UnprocessedChangeEvent` to be created.

### Testing Performed
Manual testing via Admin console and asadmin commands carried out.
After researching the topic I believe the only indicator of when a server restart is required is under: Common Tasks > Server . There you will see "Status: Restart Required".

Similarly when using the asadmin comment, you need to execute the following command: `asadmin _get-restart-required
`
### Testing Environment
OSX 15.1, Zulu 21.0.8, Maven 3.9.9

## Documentation
No new documentation.

## Notes for Reviewers

