### PR TITLE
FISH-11726: reactivate client certificate test

### DIFF
--- a/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/samples/security/validation/ClientValidationTest.java
+++ b/appserver/tests/payara-samples/samples/client-certificate-validator/src/test/java/fish/payara/samples/security/validation/ClientValidationTest.java
@@ -329,14 +329,6 @@ public class ClientValidationTest {
                 }
             }
 
-            // Make sure we always return a response code
-            if (responseCode == 500 && connection != null) {
-                try {
-                    return connection.getResponseCode();
-                } catch (IOException e) {
-                    return 500;
-                }
-            }
             return responseCode;
         }
     }
@@ -362,6 +354,4 @@ public class ClientValidationTest {
         Path serverLog = ServerOperations.getDomainPath("logs/server.log");
         return Files.readAllLines(serverLog);
     }
-
-
 }


### PR DESCRIPTION
## Description
This PR reactivates and fixes the ClientValidationTest, as it has been disabled and broken for quite some time.

## Important Info
### Blockers
None

## Testing
### How to run only that test:
```
cd appserver/tests/payara-samples/samples
mvn test -pl client-certificate-validator -Dtest=ClientValidationTest
```

### Testing Performed
The test was executed against the latest Payara Community tree.
