### PR TITLE
FISH-12093 FISH-12132 Allow `--warlibs` with the `deploy-remote-archive` Command

### DIFF
--- a/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
+++ b/nucleus/deployment/admin/src/main/java/fish/payara/deployment/admin/DeployRemoteArchiveCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2021 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2025 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -59,6 +59,7 @@ import org.glassfish.api.admin.RestEndpoints;
 import org.glassfish.api.admin.RestParam;
 import org.glassfish.api.admin.RuntimeType;
 import org.glassfish.api.deployment.DeployCommandParameters;
+import org.glassfish.common.util.admin.ParameterMapExtractor;
 import org.glassfish.config.support.CommandTarget;
 import org.glassfish.config.support.TargetType;
 import org.glassfish.hk2.api.PerLookup;
@@ -69,6 +70,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -172,7 +174,17 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
             ActionReport subReport = actionReport.addSubActionsReport();
             CommandRunner.CommandInvocation commandInvocation =
                     commandRunner.getCommandInvocation("deploy", subReport, context.getSubject());
-            ParameterMap parameters = createAndPopulateParameterMap(fileToDeploy);
+            ParameterMap parameters;
+            final ParameterMapExtractor extractor = new ParameterMapExtractor(this);
+            try {
+                List<String> excludedParameters = new ArrayList<>();
+                excludedParameters.add("path");
+                parameters = extractor.extract(excludedParameters);
+            } catch (IllegalArgumentException | IllegalAccessException ex) {
+                throw new RuntimeException(ex);
+            }
+            parameters.add("path", fileToDeploy.getAbsolutePath());
+
             commandInvocation.parameters(parameters);
             commandInvocation.execute();
         } else {
@@ -180,131 +192,5 @@ public class DeployRemoteArchiveCommand extends DeployCommandParameters implemen
                     + "\nSee the server log for more details");
             actionReport.setActionExitCode(ActionReport.ExitCode.FAILURE);
         }
-    }
-
-    private ParameterMap createAndPopulateParameterMap(File fileToDeploy) {
-        ParameterMap parameterMap = new ParameterMap();
-
-        parameterMap.add("name", name);
-        parameterMap.add("path", fileToDeploy.getAbsolutePath());
-        parameterMap.add("contextroot", contextroot);
-
-        if (virtualservers != null) {
-            parameterMap.add("virtualservers", virtualservers);
-        }
-
-        if (libraries != null) {
-            parameterMap.add("libraries", libraries);
-        }
-
-        if (force != null) {
-            parameterMap.add("force", force.toString());
-        }
-
-        if (precompilejsp != null) {
-            parameterMap.add("precompilejsp", precompilejsp.toString());
-        }
-
-        if (verify != null) {
-            parameterMap.add("verify", verify.toString());
-        }
-
-        if (retrieve != null) {
-            parameterMap.add("retrieve", retrieve);
-        }
-
-        if (dbvendorname != null) {
-            parameterMap.add("dbvendorname", dbvendorname);
-        }
-
-        if (createtables != null) {
-            parameterMap.add("createtables", createtables.toString());
-        }
-
-        if (dropandcreatetables != null) {
-            parameterMap.add("dropandcreatetables", dropandcreatetables.toString());
-        }
-
-        if (uniquetablenames != null) {
-            parameterMap.add("uniquetablenames", uniquetablenames.toString());
-        }
-
-        if (deploymentplan != null) {
-            parameterMap.add("deploymentplan", deploymentplan.getAbsolutePath());
-        }
-
-        if (altdd != null) {
-            parameterMap.add("altdd", altdd.getAbsolutePath());
-        }
-
-        if (runtimealtdd != null) {
-            parameterMap.add("runtimealtdd", runtimealtdd.getAbsolutePath());
-        }
-
-        if (enabled != null) {
-            parameterMap.add("enabled", enabled.toString());
-        }
-
-        if (generatermistubs != null) {
-            parameterMap.add("generatermistubs", generatermistubs.toString());
-        }
-
-        if (availabilityenabled != null) {
-            parameterMap.add("availabilityenabled", availabilityenabled.toString());
-        }
-
-        if (asyncreplication != null) {
-            parameterMap.add("asyncreplication", asyncreplication.toString());
-        }
-
-        if (target != null) {
-            parameterMap.add("target", target);
-        }
-
-        if (keepreposdir != null) {
-            parameterMap.add("keepreposdir", keepreposdir.toString());
-        }
-
-        if (keepfailedstubs != null) {
-            parameterMap.add("keepfailedstubs", keepfailedstubs.toString());
-        }
-
-        if (isredeploy != null) {
-            parameterMap.add("isredeploy", isredeploy.toString());
-        }
-
-        if (logReportedErrors != null) {
-            parameterMap.add("logReportedErrors", logReportedErrors.toString());
-        }
-
-        if (properties != null) {
-            String propertiesString = properties.toString();
-            propertiesString = propertiesString.replaceAll(", ", ":");
-            parameterMap.add("properties", propertiesString);
-        }
-
-        if (property != null) {
-            String propertyString = property.toString();
-            propertyString = propertyString.replaceAll(", ", ":");
-            parameterMap.add("property", propertyString);
-        }
-
-        if (type != null) {
-            parameterMap.add("type", type);
-        }
-
-        if (keepstate != null) {
-            parameterMap.add("keepstate", keepstate.toString());
-        }
-
-        if (lbenabled != null) {
-            parameterMap.add("lbenabled", lbenabled);
-        }
-
-        if (deploymentorder != null) {
-            parameterMap.add("deploymentorder", deploymentorder.toString());
-        }
-
-        return parameterMap;
     }
 }

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
@@ -25,6 +25,7 @@ SYNOPSIS
            [--asyncreplication={true|false}]
            [--lbenabled={true|false}]
            [--keepstate={false|true}]
+           [--warlibs={false|true}]
            [--libraries jar_file[,jar_file]*]
            [--target target]
            [--type pkg-type]
@@ -263,6 +264,12 @@ OPTIONS
            the newly redeployed application deserializes the data that was
            previously saved.
 
+       --warlibs
+           If set to true, enables an application to make use of shared
+           libraries installed to `domain_dir/lib/warlibs`.
+           Default is false.
+           This parameter takes precedence over enabling warlibs in --properties.
+
        --libraries
            A comma-separated list of library JAR files. Specify the library
            JAR files by their relative or absolute paths. Specify relative
@@ -394,6 +401,11 @@ OPTIONS
            preserveAppScopedResources
                If set to true, preserves any application-scoped resources and
                restores them during redeployment. Default is false.
+
+           warlibs={false|true}
+               If set to true, enables an application to make use of shared
+               libraries installed to `domain_dir/lib/warlibs`.
+               Default is false.
 
            Other available properties are determined by the implementation of
            the component that is being redeployed.


### PR DESCRIPTION
## Description
Allows using the new `--warlibs` parameter with the `deploy-remote-archive` command.

Also adds missing help docs for the redeploy command

## Important Info
### Blockers
N/A

## Testing
### New tests
None

### Testing Performed
```
git clone https://github.com/lprimak/apps/ Lenny-Apps
cd Lenny-Apps/starter-generator

mvn dependency:copy-dependencies
mvn package -Dskinny.war

asadmin start-domain
asadmin add-library --type war target\dependency\*
asadmin restart-domain

# Test failure
asadmin deploy-remote-archive --name sg https://github.com/Pandrex247/Payara/raw/refs/heads/TESTING/starter-generator-1.x-SNAPSHOT.war

# Test success
asadmin deploy-remote-archive --name sg --warlibs https://github.com/Pandrex247/Payara/raw/refs/heads/TESTING/starter-generator-1.x-SNAPSHOT.war

# Test success (alt)
asadmin undeploy sg
asadmin deploy-remote-archive --name sg --properties "warlibs=true"  https://github.com/Pandrex247/Payara/raw/refs/heads/TESTING/starter-generator-1.x-SNAPSHOT.war

# Test success (overrides)
asadmin undeploy sg
asadmin deploy-remote-archive --name sg --warlibs true --properties "warlibs=false"  https://github.com/Pandrex247/Payara/raw/refs/heads/TESTING/starter-generator-1.x-SNAPSHOT.war
```

### Testing Environment
Windows 11, Zulu JDK 21.0.8, Maven 3.9.11

## Documentation
https://github.com/payara/Payara-Documentation/pull/648

## Notes for Reviewers
None
