### PR TITLE
FISH-12205 Add Cache TTL to Application Deployment Properties

### DIFF
--- a/appserver/web/admin/src/main/manpages/org/glassfish/web/admin/cli/create-virtual-server.1
+++ b/appserver/web/admin/src/main/manpages/org/glassfish/web/admin/cli/create-virtual-server.1
@@ -329,6 +329,12 @@ OPTIONS
                server. Specify an empty string to disable the default error
                page mechanism for this virtual server.
 
+           cacheTTL
+               Specifies the time to live (TTL) in milliseconds of the
+               virtual server cache for serving files.
+
+               Defaults to 5000
+
        --target
            Creates the virtual server only on the specified target. Valid
            values are as follows:

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -200,6 +200,7 @@ public class WebModule extends PwcWebModule implements Context {
 
     private static final String WS_SERVLET_CONTEXT_LISTENER =
         "com.sun.xml.ws.transport.http.servlet.WSServletContextListener";
+    public static final String CACHE_TTL_APP_PROPERTY = "cacheTTL";
 
     // ----------------------------------------------------- Instance Variables
 
@@ -1466,6 +1467,14 @@ public class WebModule extends PwcWebModule implements Context {
             configureProperty(vs, contextPath, name, value);
         }
 
+        if (getWebModuleConfig() != null && getWebModuleConfig().getDeploymentContext() != null) {
+            var appProperties = getWebModuleConfig().getDeploymentContext().getAppProps();
+            String cacheTTL = appProperties.getProperty(CACHE_TTL_APP_PROPERTY);
+            if (cacheTTL != null) {
+                configureProperty(vs, contextPath, CACHE_TTL_APP_PROPERTY, cacheTTL);
+            }
+        }
+
         // sen-web.xml preserved for backward compatibility
         final SunWebAppImpl configBean = getIasWebAppConfigBean();
         if (configBean != null && configBean.sizeWebProperty() > 0) {
@@ -1552,6 +1561,8 @@ public class WebModule extends PwcWebModule implements Context {
             vs.setDefaultWebXmlLocation(value);
         } else if(name.startsWith("alternatedocroot_")) {
             parseAlternateDocBase(name, value);
+        } else if(CACHE_TTL_APP_PROPERTY.equalsIgnoreCase(name)) {
+            setCacheTTL(Integer.parseInt(value));
         } else if(name.startsWith("valve_") ||
             name.startsWith("listener_") ||
             name.startsWith("send-error_")) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Currently, there is no way to set cache TTL for serving files. This prevents dev mode to function properly

Fixes #7663

## Documentation
add `--properties cacheTTL=0` to deployment
