### PR TITLE
Read in `payara.version` to Docker Jcache Test

### DIFF
--- a/appserver/extras/docker-images/tests/src/test/java/fish/payara/jcache/JCacheRestTest.java
+++ b/appserver/extras/docker-images/tests/src/test/java/fish/payara/jcache/JCacheRestTest.java
@@ -73,7 +73,7 @@ public class JCacheRestTest {
                 .build();
 
         network = Network.newNetwork();
-        DockerImageName payaraImg = DockerImageName.parse("payara/micro");
+        DockerImageName payaraImg = DockerImageName.parse("payara/micro:" + System.getProperty("payara.version", "latest"));
 
         for (int instanceIndex = 0; instanceIndex < 3; instanceIndex++) {
             GenericContainer<?> container = new GenericContainer<>(payaraImg)


### PR DESCRIPTION
## Description
Adjusts the Docker Jcache test so that it reads in the payara.version property, rather than always relying on "latest"

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built Docker image and ran test - all passed
Ran tests with "-Dpayara.version=6.2025.8" - logs indicated 6.2025.8 was being used and tests passed.

### Testing Environment
Windows 11, Maven 3.9.11, Zulu JDK 11.0.28

## Documentation
N/A

## Notes for Reviewers
None
