### PR TITLE
FISH-11545 Fix Patched Grizzly Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <soteria.version>4.0.1.payara-p1</soteria.version>
         <cdi-api.version>4.1.0</cdi-api.version>
         <!-- Needs FISH-9690 reapplying -->
-        <grizzly.version>4.1.0.payara-p1</grizzly.version>
+        <grizzly.version>4.1.0-M1.payara-p1</grizzly.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <expressly.version>6.0.0</expressly.version>


### PR DESCRIPTION
## Description
Fixes the Grizzly version - we patched 4.1.0-M1, not 4.1.0.

Outstanding patches will be applied in a follow-up PR.

## Important Info
### Blockers
Release of patched Grizzly - _Done_

## Testing
### New tests
None

### Testing Performed
Ran Grizzly unit tests, all passed.
Jenkins test please

### Testing Environment
WSL OpenSUSE Tumbleweed, Maven 3.9.11, Zulu JDK 17.0.16

## Documentation
N/A

## Notes for Reviewers
None
