### PR TITLE
FISH-9896 Upgrade to Mojarra 4.1.4 and Reapply Patches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         <!-- BOM-referenced versions -->
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
         <snakeyaml.version>2.5</snakeyaml.version>
-        <mojarra.version>4.1.4</mojarra.version>
+        <mojarra.version>4.1.4.payara-p1</mojarra.version>
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
         <jakarta.mvc.version>3.0.0</jakarta.mvc.version>
         <krazo.version>4.0.0</krazo.version>


### PR DESCRIPTION
## Description
Updates Mojarra to 4.1.4 with patches reapplied.

Currently draft for testing the snapshot.

## Important Info
### Blockers
https://github.com/payara/patched-src-mojarra/pull/29

## Testing
### New tests
None

### Testing Performed
Ran Mojarra tests - all passed
Loaded the admin console - no explosions.
Ran the reproducers for FISH-11055 and FISH-8542 (after updating them to EE11) - bugs fixed.

### Testing Environment
Windows 11, Maven 3.9.11, Zulu JDK 21.0.8

## Documentation
N/A

## Notes for Reviewers
None
