### PR TITLE
FISH-8914 Upgrade EclipseLink to 5.0.0-B11 and Reapply Patches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <jakarta.mvc.version>3.0.0</jakarta.mvc.version>
         <krazo.version>4.0.0</krazo.version>
         <yasson.version>3.0.4</yasson.version>
-        <eclipselink.version>5.0.0-B08</eclipselink.version>
+        <eclipselink.version>5.0.0-B11.payara-p1</eclipselink.version>
         <eclipselink.asm.version>9.9.0</eclipselink.asm.version>
         <!-- Needs FISH-28, FISH-642, and FISH-7273 reapplying? -->
         <openmq.version>6.6.0</openmq.version>


### PR DESCRIPTION
## Description
Upgrades EclipseLink to 5.0.0-B11 with our outstanding patches applied.

## Important Info
### Blockers
Patched EclipseLink PR: https://github.com/payara/patched-src-eclipselink/pull/44

## Testing
### New tests
None

### Testing Performed
I have run the EclipseLink unit tests (`mvn clean install`) and all passed.
Tested the reproducer for FISH-9551 - still applicable

### Testing Environment
Windows 11, Maven 3.9.11, Zulu JDK 21.0.8

## Documentation
N/A

## Notes for Reviewers
None
