### PR TITLE
FISH-11546 Update Hibernate Valdiator to 9.0.1 with Patches Reapplied

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,8 +312,7 @@
         <jakarta.validation.version>3.1.1</jakarta.validation.version>
         <jakarta.validation.osgi.version>3.1</jakarta.validation.osgi.version>
         <jakarta.validation.osgi.version.upperbound>4</jakarta.validation.osgi.version.upperbound>
-        <!-- Needs FISH-10036 reapplying? -->
-        <hibernate.validator.version>9.0.0.Final</hibernate.validator.version>
+        <hibernate.validator.version>9.0.1.Final.payara-p1</hibernate.validator.version>
         <hibernate.validator.osgi.version>9.0</hibernate.validator.osgi.version>
         <hibernate.validator.osgi.version.upperbound>10.0</hibernate.validator.osgi.version.upperbound>
         <jaxb-impl.version>4.0.6</jaxb-impl.version>


### PR DESCRIPTION
## Description
Update Hibernate Validator to 9.0.1.Final with patches reapplied

## Important Info
### Blockers
https://github.com/payara/patched-src-hibernate-validator/pull/10

## Testing
### New tests
None

### Testing Performed
Ran the reproducer for FISH-10036 (after updating for EE11) - passed.
Ran the reproducer for FISH-10036 without the patch - error.

### Testing Environment
Windows 11, Maven 3.9.11, Zulu 21.0.8

## Documentation
N/A

## Notes for Reviewers
None
