### PR TITLE
FISH-12436 FISH-12437 FISH-12438 Upgrade Docker JDKs

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -59,7 +59,7 @@
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk11.tag>11.0.29-jdk</docker.jdk11.tag>
         <docker.jdk17.tag>17.0.17-jdk</docker.jdk17.tag>
-        <docker.jdk21.tag>21.0.8-jdk</docker.jdk21.tag>
+        <docker.jdk21.tag>21.0.9-jdk</docker.jdk21.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.


### PR DESCRIPTION
## Description
Upgrades the Docker image JDKs to 11.0.29, 17.0.17, and 21.0.9

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran unit tests, all passed

### Testing Environment
Docker

## Documentation
N/A

## Notes for Reviewers
None
