### PR TITLE
FISH-10833 : Fix virtual server breaking on redeploy to deployment gr…

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/VirtualServer.java
@@ -580,10 +580,27 @@ public class VirtualServer extends StandardHost implements org.glassfish.embedda
                 String contextRoot = null;
                 String location = null;
 
-                ConfigBeansUtilities configBeansUtilities = getConfigBeansUtilities();
-                if (configBeansUtilities != null) {
-                    contextRoot = configBeansUtilities.getContextRoot(defaultWebModuleId);
-                    location = configBeansUtilities.getLocation(defaultWebModuleId);
+                // First try to get the location from ApplicationRegistry (works for all scenarios including deployment groups)
+                ApplicationInfo appInfo = appRegistry.get(defaultWebModuleId);
+                if (appInfo != null && appInfo.getSource() != null) {
+                    location = appInfo.getSource().getURI().getPath();
+                    // Get context root from the application metadata
+                    Application app = appInfo.getMetaData(Application.class);
+                    if (app != null && app.isVirtual()) {
+                        com.sun.enterprise.deployment.BundleDescriptor bd = app.getStandaloneBundleDescriptor();
+                        if (bd instanceof com.sun.enterprise.deployment.WebBundleDescriptor) {
+                            contextRoot = ((com.sun.enterprise.deployment.WebBundleDescriptor) bd).getContextRoot();
+                        }
+                    }
+                }
+
+                // Fallback to ConfigBeansUtilities if ApplicationRegistry doesn't have the info
+                if (location == null) {
+                    ConfigBeansUtilities configBeansUtilities = getConfigBeansUtilities();
+                    if (configBeansUtilities != null) {
+                        contextRoot = configBeansUtilities.getContextRoot(defaultWebModuleId);
+                        location = configBeansUtilities.getLocation(defaultWebModuleId);
+                    }
                 }
 
                 if (contextRoot != null && location != null) {

--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/FileDirContext.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/FileDirContext.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2017-2024] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2017-2025] [Payara Foundation and/or its affiliates]
 
 package org.apache.naming.resources;
 
@@ -931,7 +931,7 @@ public class FileDirContext extends BaseDirContext {
                 canPath = normalize(file.toPath().toRealPath(LinkOption.NOFOLLOW_LINKS).toString());
             } catch (IOException e) {
             }
-            if (canPath == null || (!canPath.startsWith(canonicalBase) && !allowLinking)) {
+            if (canPath == null || canonicalBase == null || (!canPath.startsWith(canonicalBase) && !allowLinking)) {
                 if (logger.isLoggable(Level.FINE)) {
                     logger.log(Level.FINE, LogFacade.FILE_RESOURCES_NULL_CANONICAL_PATH);
                 }
@@ -939,7 +939,7 @@ public class FileDirContext extends BaseDirContext {
             }
 
             // Check to see if going outside of the web application root
-            if ((!allowLinking) && (!canPath.startsWith(absoluteBase))) {
+            if ((!allowLinking) && (absoluteBase == null || !canPath.startsWith(absoluteBase))) {
                 if (logger.isLoggable(Level.FINE)) {
                     logger.log(Level.FINE, LogFacade.FILE_RESOURCES_NOT_ALLOWED, new Object[]{allowLinking,canPath,absoluteBase});
                 }


### PR DESCRIPTION
…oup when used as default module

## Description
This PR fixes an issue where redeploying an application to a deployment group causes the virtual server to break when the application is configured as the default-web-module. After redeploy, the application would fail to load and the page would not be accessible.

The root cause was that the code attempted to retrieve the application location from `ConfigBeansUtilities`, which returns the path configured in `domain.xml`. For deployment groups, this path may not exist on the current instance, causing the web module configuration to fail with `null` values.

This fix adapts the solution from **FISH-5939 (PR #5621)** to work with deployment groups by prioritizing `ApplicationRegistry` to obtain the actual runtime application location instead of relying solely on `domain.xml` configuration.

## Important Info
### Blockers
none

## Testing
### New tests
none

### Testing Performed
1. Create an instance (e.g., `i1`)
2. Create a deployment group (e.g., `dp1`)
3. Add `i1` to `dp1` and Start `dp1`
4. Deploy a web application (e.g., `javaeesimple10-1.0-SNAPSHOT.war`) to the deployment group with `--target=dp1`
5. Configure the application as the default-web-module for a virtual server
6. Perform a redeploy using `asadmin deploy --target=dp1 --force=true javaeesimple10-1.0-SNAPSHOT.war`
7. Verify the application is accessible after redeploy (poke e.g.: http://localhost:28080/)
 
### Testing Environment
Zulu JDK 11 on Windows 11 with Maven 3.9

## Documentation
none

## Notes for Reviewers
The fix consists of two main changes:
1. **VirtualServer.java (lines 571-592)**: Modified `getDefaultWebModule()` method to:
     - First attempt to retrieve application location from `ApplicationRegistry` (which has the actual runtime location)
     - Fall back to `ConfigBeansUtilities` only if `ApplicationRegistry` doesn't have the info
     - Extract context root from application metadata when available in `ApplicationRegistry`
2. **FileDirContext.java (lines 928, 936)**: Added null safety checks for `canonicalBase` and `absoluteBase` to prevent NPE during path validation when these values haven't been initialized yet.

The approach mirrors the pattern already used in `findWebModuleInJ2eeApp()` method (line 700 in VirtualServer.java), which successfully uses `ApplicationRegistry` for similar purposes.
