### PR TITLE
FISH-9455 Fix #7729: Updated maven-plugin-plugin to version 3.15.2 …

### DIFF
--- a/nucleus/hk2/config-generator/pom.xml
+++ b/nucleus/hk2/config-generator/pom.xml
@@ -66,7 +66,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>2.9</version>
+                <version>3.15.2</version>
+                <configuration>
+                    <!-- https://issues.apache.org/jira/browse/MPLUGIN-504 -->
+                    <goalPrefix>config-generator</goalPrefix>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -88,13 +92,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>3.0-alpha-2</version>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.plugin.api.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.codemodel</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>codemodel</artifactId>
-            <version>2.6</version>
+            <version>4.0.6</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>


### PR DESCRIPTION
…and fixed broken config. Updated dependencies to the latest maven-core and glassfish jaxb codemodel version

Fixes broken PR #7729 

## Description
Updated maven-plugin-plugin to version 3.15.2 and fixed broken config. Updated dependencies to the latest maven-core and glassfish jaxb codemodel version

## Important Info
### Blockers

unknown

## Testing
### New tests

none

### Testing Performed
 built mvn clean install

## Notes for Reviewers

please see description