### PR TITLE
FISH-8914 Reapply EclipseLink Patches (5.0.0-B08)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <jakarta.mvc.version>3.0.0</jakarta.mvc.version>
         <krazo.version>4.0.0</krazo.version>
         <yasson.version>3.0.4</yasson.version>
-        <eclipselink.version>5.0.0-B08</eclipselink.version>
+        <eclipselink.version>5.0.0-B08.payara-p1</eclipselink.version>
         <eclipselink.asm.version>9.9.0</eclipselink.asm.version>
         <openmq.version>6.7.0.payara-p1</openmq.version>
         <com.ibm.jbatch.container.version>2.1.1</com.ibm.jbatch.container.version>


### PR DESCRIPTION
## Description
Follow-up to https://github.com/payara/Payara/pull/7728 / https://github.com/payara/Payara/pull/7743

Reapplies our patches to EclipseLink 5.0.0-B08, since newer versions of EclipseLink cause issues with the Data TCK

## Important Info
### Blockers
https://github.com/payara/patched-src-eclipselink/pull/45

## Testing
### New tests
None

### Testing Performed
Jenkins test please
Ran against the Data TCK and passed: https://jenkins.payara.fish/view/TCKs/job/JakartaEE-11-TCK/353/

### Testing Environment
Jenkins

## Documentation
N/A

## Notes for Reviewers
None
