### PR TITLE
FISH-12538 bugfix [Payara 6]: clean up better after failed EAR deployment

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.ejb.startup;
 
@@ -294,6 +294,11 @@ public class EjbDeployer extends JavaEEDeployer<EjbContainerStarter, EjbApplicat
 
         try {
             compEnvManager.unbindFromComponentNamespace(ejbBundle);
+            Object rootDesc = ejbBundle.getModuleDescriptor().getDescriptor();
+            if ((rootDesc != ejbBundle) && (rootDesc instanceof WebBundleDescriptor)) {
+                WebBundleDescriptor webBundle = (WebBundleDescriptor) rootDesc;
+                compEnvManager.unbindFromComponentNamespace(webBundle);
+            }
         } catch (Exception e) {
             _logger.log(Level.WARNING, "Error unbinding ejb bundle " + ejbBundle.getModuleName() + " dependency namespace", e);
         }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Failed EAR deployments are not cleaned up completely from internal state

## Applicability
This PR patches Payara 6
NOTE: Needs ported to Payara 7