### PR TITLE
FISH-12539 bugfix [Payara 6]: DataSourceDefinition properties trimmed so whitespace is allo…

### DIFF
--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
@@ -455,7 +455,7 @@ public class DataSourceDefinitionHandler extends AbstractResourceHandler {
                     if (index > -1 && index != 0 && index < property.length() - 1) {
                         String name = property.substring(0, index);
                         String value = property.substring(index + 1);
-                        properties.put(name, TranslatedConfigView.expandValue(value));
+                        properties.put(name.trim(), TranslatedConfigView.expandValue(value.trim()));
                     }
                 }
             }


### PR DESCRIPTION
…wed around the equal sign, allowing for prettier definitions

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

`@DataSourceDefinition` properties now allow whitespace instead of silently ignoring the property instead.
Fixes #7767 