### PR TITLE
FISH-12539 bugfix [Payara 7]: DataSourceDefinition properties trimmed so whitespace is allo…

### DIFF
--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/deployment/annotation/handlers/DataSourceDefinitionHandler.java
@@ -455,7 +455,7 @@ public class DataSourceDefinitionHandler extends AbstractResourceHandler {
                     if (index > -1 && index != 0 && index < property.length() - 1) {
                         String name = property.substring(0, index);
                         String value = property.substring(index + 1);
-                        properties.put(name, TranslatedConfigView.expandValue(value));
+                        properties.put(name.trim(), TranslatedConfigView.expandValue(value.trim()));
                     }
                 }
             }


### PR DESCRIPTION
…wed around the equal sign, allowing for prettier definitions

Payara 7 version of #7768 