### PR TITLE
FISH-10151 Fix Test for Windows

### DIFF
--- a/appserver/jdbc/jdbc-config/src/test/java/org/glassfish/main/jdbc/config/validators/JdbcConnectionPoolValidatorTest.java
+++ b/appserver/jdbc/jdbc-config/src/test/java/org/glassfish/main/jdbc/config/validators/JdbcConnectionPoolValidatorTest.java
@@ -49,6 +49,8 @@ import java.util.function.Consumer;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
 import javax.sql.XADataSource;
+
+import com.sun.enterprise.util.OS;
 import jakarta.validation.Payload;
 
 import org.glassfish.api.jdbc.SQLTraceListener;
@@ -130,8 +132,13 @@ public class JdbcConnectionPoolValidatorTest {
         updateMock(pool, p -> expect(p.getSteadyPoolSize()).andStubReturn("${ENV=steadypoolsizeproperty}"));
         assertTrue("undefined variable in steady pool size", this.validator.isValid(pool, null));
 
-        updateMock(pool, p -> expect(p.getSteadyPoolSize()).andStubReturn("${ENV=USER}"));
-        assertFalse("env.USER variable in steady pool size is not a number", this.validator.isValid(pool, null));
+        if (OS.isWindows()) {
+            updateMock(pool, p -> expect(p.getSteadyPoolSize()).andStubReturn("${ENV=USERNAME}"));
+            assertFalse("env.USERNAME variable in steady pool size is not a number", this.validator.isValid(pool, null));
+        } else {
+            updateMock(pool, p -> expect(p.getSteadyPoolSize()).andStubReturn("${ENV=USER}"));
+            assertFalse("env.USER variable in steady pool size is not a number", this.validator.isValid(pool, null));
+        }
 
         updateMock(pool, p -> expect(p.getSteadyPoolSize()).andStubReturn("${MPCONFIG=USER}"));
         try {


### PR DESCRIPTION
## Description
As of https://github.com/payara/Payara/pull/7718 this property now resolves, but on Windows the expected environment variable is `USERNAME` rather than `USER`. If the env variable isn't found the validation is delegated to later and `null` is returned which evaluates as valid here. This change makes it so if on Windows we check for the correct env variable, and then fail the assertion (as on Linux) as in all likelihood your username isn't just numbers

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran `jdbc-config` module unit tests on Windows and on Linux (WSL)

### Testing Environment
Windows 11, Zulu JDK 21.0.9, Maven 3.9.11
WSL OpenSUSE Tumbleweed, Zulu JDK 21.0.9, Maven 3.9.11

## Documentation
N/A

## Notes for Reviewers
None
