### PR TITLE
FISH-12469 Bump io.fabric8:docker-maven-plugin from 0.46.0 to 0.47.0

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -87,7 +87,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.46.0</version>
+                    <version>0.47.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <verbose>true</verbose>


### PR DESCRIPTION
Ports https://github.com/payara/Payara/pull/7747