### PR TITLE
FISH-7667 PartItem memory leak

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/fileupload/PartItem.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/fileupload/PartItem.java
@@ -812,6 +812,7 @@ class PartItem
     }
     
     private static class Cleaner implements Runnable {
+        private final static Logger logger = LogFacade.getLogger();
         private DeferredFileOutputStream fileStream;
 
         private void setFileStream(DeferredFileOutputStream fileStream) {
@@ -826,10 +827,11 @@ class PartItem
             
             File file = fileStream.getFile();
             if (file != null && file.exists()) {
-                if (!file.delete() && log.isLoggable(Level.FINE)) {
-                    log.log(Level.FINE, "Cannot delete file: " + fileStream);
+                if (!file.delete() && logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, "Cannot delete file: " + fileStream);
                 }
             }
+            fileStream = null;
         }
     }
 }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Fixes FISH-7667
  - Rewrites the `PartItem` garbage collection runnable to prevent it from maintaining a reference to the object.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Tested using the reproducer provided in the ticket. Allowed the test method to iterate 200 times and observed no notable increases in the number of `PartItem` objects held in memory, the value stayed at a consistent 4.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.6
Java version: 21.0.3, vendor: Eclipse Adoptium
Default locale: en_GB, platform encoding: UTF-8
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
