### PR TITLE
FISH-12712 Revert "FISH-12696 Bump soteria.version from 4.0.1.payara-p1 to 4.0.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <osgi.enterprise.version>7.0.0</osgi.enterprise.version>
         <osgi.cmpn.version>7.0.0</osgi.cmpn.version>
         <osgi.dto.version>1.1.1</osgi.dto.version>
-        <soteria.version>4.0.2</soteria.version>
+        <soteria.version>4.0.1.payara-p1</soteria.version>
         <cdi-api.version>4.1.0</cdi-api.version>
         <grizzly.version>4.1.0-M1.payara-p2</grizzly.version>
         <servlet-api.version>6.1.0</servlet-api.version>


### PR DESCRIPTION
Reverts payara/Payara#7833

Soteria 4.0.2 breaks the custom caller principal tests in the Security TCK
We likely need to update our integration code somewhere, but we have a code freeze looming so just revert for now