### PR TITLE
FISH-10141 Update Parsson to 1.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright 2017-2025 Payara Foundation and/or affiliates
+    Portions Copyright 2017-2026 Payara Foundation and/or affiliates
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -304,7 +304,7 @@
         <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <expressly.version>6.0.0</expressly.version>
         <microprofile-config.version>3.1</microprofile-config.version>
-        <parsson.version>1.1.5.payara-p1</parsson.version>
+        <parsson.version>1.1.7.payara-p1</parsson.version>
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jaxb-api.version>4.0.4</jaxb-api.version>
         <jackson.version>2.20.1</jackson.version>


### PR DESCRIPTION
## Description
Updates Parsson to 1.1.7 with our patch reapplied.

We still maintain our patch to deprecate the JSON-P API used within Parsson due to changes made to `JsonProvider.provider()` breaking our TCK executions.

From previous investigation which has yet to be followed up on:

>Before this change, the TCK runner would fail to load the system property, meaning we would then attempt to load a factory class using the service loader mechanism, and ended up getting the correct dummy factory class that the TCK expects. With the changes, we now don’t fail to load the system property, but this causes us to encounter a `ClassNotFoundException` and fail the TCK as the provider method does not have any fallback mechanism once it commits to loading via system property or service loader. This exception is coming from the fact that at this point, we’re using the OSGi bundle class loader for the `jakarta.json.jar` module, which does not import the package of the dummy factory class (and so it doesn’t get wired) and the class is not otherwise available to it via other means. We need to look into why this is, and possible look into somehow forcing it to use the `WebappClassLoader` which Should™ have access to the dummy class (since it’s included in the deployed application that the TCK is using).

## Important Info
### Blockers
Approval and release of patched Parsson: https://github.com/payara/patched-src-parsson/pull/3

## Testing
### New tests
None

### Testing Performed
Started the admin console - no explosions
Passed a run of the JSON-P TCKs: https://jenkins.payara.fish/view/TCKs/job/TCKs/job/JakartaEE-11-TCK/50/

### Testing Environment
Jenkins

## Documentation
N/A

## Notes for Reviewers
None
