### PR TITLE
FISH-12561: fixing issue when redeploy ejb

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2026 Payara Foundation and/or its affiliates
 
 package com.sun.ejb;
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Fix to prevent declaration of EJB stubs on the CurrentBeforeParentClassLoader and use application assigned classloader, for rest client localization
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix of a reported bug when deploying and consuming EJB from remote clients
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing with reproducer indicated on the ticket [FISH-12561](https://payara.atlassian.net/browse/FISH-12561)
NOTE: you need to rebuild the reproducer using JDK 21 and Jakarta 11
Before change:
<img width="1152" height="336" alt="image" src="https://github.com/user-attachments/assets/ac3a5a42-3f78-4e1c-9a67-bc466f6a5497" />

error on logs:
``
Exception while invoking class org.glassfish.ejb.startup.EjbDeployer load method
java.lang.RuntimeException: EJB Container initialization error
        at org.glassfish.ejb.startup.EjbApplication.loadContainers(EjbApplication.java:237)
        at org.glassfish.ejb.startup.EjbDeployer.load(EjbDeployer.java:286)
        at org.glassfish.ejb.startup.EjbDeployer.load(EjbDeployer.java:104)
        at org.glassfish.internal.data.ModuleInfo.load(ModuleInfo.java:218)
        at org.glassfish.internal.data.ApplicationInfo.load(ApplicationInfo.java:334)
        at com.sun.enterprise.v3.server.ApplicationLifecycle.prepare(ApplicationLifecycle.java:580)
        at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:566)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:556)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:552)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/javax.security.auth.Subject.doAs(Subject.java:361)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:551)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:582)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:574)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.base/javax.security.auth.Subject.doAs(Subject.java:361)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:573)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1497)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1879)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1755)
        at org.glassfish.admin.rest.utils.ResourceUtil.runCommand(ResourceUtil.java:272)
        at org.glassfish.admin.rest.utils.ResourceUtil.runCommand(ResourceUtil.java:240)
        at org.glassfish.admin.rest.utils.ResourceUtil.runCommand(ResourceUtil.java:294)
        at org.glassfish.admin.rest.resources.TemplateListOfResource.createResource(TemplateListOfResource.java:136)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:189)
        at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
        at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:93)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:478)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:400)
        at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81)
        at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:274)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
        at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:266)
        at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:253)
        at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:696)
        at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:367)
        at org.glassfish.admin.rest.adapter.RestAdapter$2.service(RestAdapter.java:335)
        at org.glassfish.admin.rest.adapter.RestAdapter.service(RestAdapter.java:189)
        at org.glassfish.admin.rest.adapter.RestManagementAdapter.service(RestManagementAdapter.java:66)
        at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:520)
        at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:217)
        at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:174)
        at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:153)
        at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:196)
        at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:88)
        at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:246)
        at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:178)
        at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:118)
        at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:96)
        at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:51)
        at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:510)
        at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:82)
        at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:83)
        at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:101)
        at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:535)
        at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:515)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.RuntimeException: Unable to create reference
        at org.glassfish.enterprise.iiop.impl.POARemoteReferenceFactory.createRef(POARemoteReferenceFactory.java:425)
        at org.glassfish.enterprise.iiop.impl.POARemoteReferenceFactory.createRemoteReference(POARemoteReferenceFactory.java:370)
        at com.sun.ejb.containers.StatelessSessionContainer.initializeHome(StatelessSessionContainer.java:201)
        at com.sun.ejb.containers.StatelessContainerFactory.createContainer(StatelessContainerFactory.java:63)
        at org.glassfish.ejb.startup.EjbApplication.loadContainers(EjbApplication.java:225)
        ... 66 more
Caused by: java.lang.RuntimeException: Could not invoke defineClass method
        at org.glassfish.pfl.basic.reflection.BridgeBase.defineClass(BridgeBase.java:264)
        at org.glassfish.pfl.basic.reflection.BridgeBase.defineClass(BridgeBase.java:279)
        at org.glassfish.pfl.dynamic.codegen.impl.CodeGeneratorUtil.makeClass(CodeGeneratorUtil.java:57)
        at org.glassfish.pfl.dynamic.codegen.spi.Wrapper._generate(Wrapper.java:1069)
        at org.glassfish.pfl.dynamic.codegen.spi.Wrapper._generate(Wrapper.java:1040)
        at com.sun.corba.ee.impl.presentation.rmi.codegen.CodegenProxyCreator.create(CodegenProxyCreator.java:226)
        at com.sun.corba.ee.impl.presentation.rmi.codegen.StubFactoryCodegenImpl.createStubClass(StubFactoryCodegenImpl.java:80)
        at com.sun.corba.ee.impl.presentation.rmi.codegen.StubFactoryCodegenImpl.createStubClass(StubFactoryCodegenImpl.java:74)
        at com.sun.corba.ee.impl.presentation.rmi.codegen.StubFactoryCodegenImpl.lambda$getStubClass$0(StubFactoryCodegenImpl.java:57)
        at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1134)
        at com.sun.corba.ee.impl.presentation.rmi.codegen.StubFactoryCodegenImpl.getStubClass(StubFactoryCodegenImpl.java:57)
        at com.sun.corba.ee.impl.presentation.rmi.codegen.StubFactoryCodegenImpl.makeStub(StubFactoryCodegenImpl.java:84)
        at org.glassfish.enterprise.iiop.impl.POARemoteReferenceFactory.createRef(POARemoteReferenceFactory.java:415)
        ... 70 more
Caused by: java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.GeneratedMethodAccessor127.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.glassfish.pfl.basic.reflection.BridgeBase.defineClass(BridgeBase.java:261)
        ... 82 more
Caused by: java.lang.LinkageError: loader com.sun.enterprise.loader.CurrentBeforeParentClassLoader @5489b1f7 attempted duplicate class definition for com.test.payara.ejb.__TestService_Remote_DynamicStub. (com.test.payara.ejb.__TestService_Remote_DynamicStub is in unnamed module of loader com.sun.enterprise.loader.CurrentBeforeParentClassLoader @5489b1f7, parent loader com.sun.enterprise.v3.server.APIClassLoaderServiceImpl$APIClassLoader @63f9b562)
``
after adding the fix:
Now on logs you won't see any error when redeploying the ejb multiple times:

<img width="1896" height="677" alt="image" src="https://github.com/user-attachments/assets/1fd88f0c-235d-4332-a8fa-6cc5eae2ab77" />


``
[#|2026-01-11T16:43:39.253-0600|INFORMACIËN|Payara 7.2026.1|org.glassfish.admingui|_ThreadID=218;_ThreadName=admin-thread-pool::admin-listener(2);_TimeMillis=1768171419253;_LevelValue=800;|
  uploadFileName=TestEJBImpl.war|#]

[#|2026-01-11T16:43:39.285-0600|INFORMACIËN|Payara 7.2026.1||_ThreadID=218;_ThreadName=admin-thread-pool::admin-listener(2);_TimeMillis=1768171419285;_LevelValue=800;|
  ================== availabilityEnabled  skipped |#]

[#|2026-01-11T16:43:39.591-0600|INFORMACIËN|Payara 7.2026.1|javax.enterprise.system.core|_ThreadID=153;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1768171419591;_LevelValue=800;|
  No deployment transformer implementation found.|#]

[#|2026-01-11T16:43:39.740-0600|INFORMACIËN|Payara 7.2026.1|jakarta.enterprise.ejb.container|_ThreadID=153;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1768171419740;_LevelValue=800;_MessageID=AS-EJB-00054;|
  Portable JNDI names for EJB TestServiceBean: [java:global/TestEJBImpl/TestServiceBean!com.test.payara.ejb.TestService, java:global/TestEJBImpl/TestServiceBean!com.test.payara.ejb.impl.TestServiceBean]|#]

[#|2026-01-11T16:43:39.740-0600|INFORMACIËN|Payara 7.2026.1|jakarta.enterprise.ejb.container|_ThreadID=153;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1768171419740;_LevelValue=800;_MessageID=AS-EJB-00055;|
  Glassfish-specific (Non-portable) JNDI names for EJB TestServiceBean: [com.test.payara.ejb.TestService#com.test.payara.ejb.TestService, com.test.payara.ejb.TestService]|#]

[#|2026-01-11T16:43:40.078-0600|INFORMACIËN|Payara 7.2026.1|org.glassfish.soteria.servlet.SamRegistrationInstaller|_ThreadID=153;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1768171420078;_LevelValue=800;|
  Initializing Soteria 4.0.1.payara-p1 for context '/TestEJBImpl'|#]

[#|2026-01-11T16:43:40.112-0600|INFORMACIËN|Payara 7.2026.1|jakarta.enterprise.web|_ThreadID=153;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1768171420112;_LevelValue=800;_MessageID=AS-WEB-GLUE-00172;|
  Loading application [TestEJBImpl] at [/TestEJBImpl]|#]

[#|2026-01-11T16:43:40.143-0600|INFORMACIËN|Payara 7.2026.1|javax.enterprise.system.core|_ThreadID=153;_ThreadName=admin-thread-pool::admin-listener(1);_TimeMillis=1768171420143;_LevelValue=800;|
  TestEJBImpl was successfully deployed in 826 milliseconds.|#]
``

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, Azul JDK 21, maven 3.9.11
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->


[FISH-12561]: https://payara.atlassian.net/browse/FISH-12561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ