### PR TITLE
FISH-10915 Remove ClassGraph

### DIFF
--- a/appserver/data/data-core/pom.xml
+++ b/appserver/data/data-core/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) 2025-2026 Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
@@ -69,10 +69,6 @@
             <groupId>fish.payara.server.internal.web</groupId>
             <artifactId>weld-integration</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.classgraph</groupId>
-            <artifactId>classgraph</artifactId>
         </dependency>
     </dependencies>
     

--- a/appserver/packager/data/pom.xml
+++ b/appserver/packager/data/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) 2025-2026 Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
@@ -93,10 +93,6 @@
             <groupId>fish.payara.server.internal.data</groupId>
             <artifactId>data-core</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.classgraph</groupId>
-            <artifactId>classgraph</artifactId>
         </dependency>
     </dependencies>
 

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright 2016-2025 Payara Foundation and/or its affiliates -->
+<!-- Portions Copyright 2016-2026 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -91,9 +91,6 @@
         <!-- Yubico client validation version property -->
         <yubico-validation-client2.version>3.0.2.payara-p1</yubico-validation-client2.version>
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
-
-        <!-- classgraph dependency used to solve issue when creating proxy implementations for jakarta data-->
-        <classgraph.version>4.8.184</classgraph.version>
     </properties>
 
 
@@ -592,12 +589,6 @@
                 <groupId>fish.payara.security.connectors</groupId>
                 <artifactId>security-connector-oauth2-client</artifactId>
                 <version>${payara.security-connectors.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.github.classgraph</groupId>
-                <artifactId>classgraph</artifactId>
-                <version>${classgraph.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description
ClassGraph was introduced to aid with our Jakarta Data implementation, but given that we already do class scanning via HK2 it always felt somewhat redundant. To not halt development to conduct an investigation we pulled it in.

This PR iterates on this original implementation and removes the ClassGraph dependency to tidy things up, as after some experimentation: no we don't need it.
This is achieved by using the HK2 class canning which will already have been conducted and stored as deployment metadata to store the names of the annotated classes in the CDI extension, in a similar way as to how we store the application name.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Ran against Data sample in Payara Samples
Ran against Data TCK

Would like to do some leak testing before I make this PR "final" - local poking seemed fine

### Testing Environment
Windows 11, Maven 3.9.11, Zulu JDK 21.0.9

## Documentation
N/A

## Notes for Reviewers
None
