### PR TITLE
FISH-12442 : Add Java 25 Docker image build configuration for Payara Community 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ appserver/tests/quicklook/quicklook_summary.txt
 appserver/packager/legal/src/main/resources/glassfish/legal/3RD-PARTY-LICENSE.txt
 /appserver/tests/payara-samples/samples/data/.claude/settings.local.json
 /appserver/tests/payara-samples/samples/.claude/settings.local.json
+/.claude/settings.local.json

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2021-2025 Payara Foundation and/or its affiliates. All rights reserved.
+    Copyright (c) 2021-2026 Payara Foundation and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -58,6 +58,7 @@
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk21.tag>21.0.9-jdk</docker.jdk21.tag>
+        <docker.jdk25.tag>25.0.1-jdk</docker.jdk25.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.
@@ -218,6 +219,119 @@
                                                 <cleanup>none</cleanup>
                                                 <noCache>${docker.noCache}</noCache>
                                                 <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk21</dockerFile>
+                                                <assembly>
+                                                    <mode>tar</mode>
+                                                    <descriptor>assembly.xml</descriptor>
+                                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                                </assembly>
+                                                <buildx>
+                                                    <platforms>
+                                                        <platform>${docker.platforms}</platform>
+                                                    </platforms>
+                                                </buildx>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>generate-jdk25-docker-image</id>
+            <activation>
+                <file>
+                    <!-- Essentially - Skip this aggregator pom -->
+                    <exists>src/main/docker/Dockerfile</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Required until https://github.com/fabric8io/docker-maven-plugin/issues/859 and https://github.com/fabric8io/docker-maven-plugin/issues/1705 are resolved -->
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>filter-jdk25-dockerfile</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <copy file="src/main/docker/Dockerfile" toFile="target/antrun/Dockerfile.jdk25">
+                                            <filterset>
+                                                <filter token="docker.java.image" value="${docker.java.repository}:${docker.jdk25.tag}"/>
+                                                <filter token="docker.payara.domainName" value="${docker.payara.domainName}"/>
+                                                <filter token="docker.payara.rootDirectoryName" value="${docker.payara.rootDirectoryName}"/>
+                                            </filterset>
+                                        </copy>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-jdk25-docker-image</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${docker.payara.repository}</name>
+                                            <build>
+                                                <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                                <filter>@</filter>
+                                                <tags>
+                                                    <tag>${docker.payara.tag}-jdk25</tag>
+                                                </tags>
+                                                <cleanup>none</cleanup>
+                                                <noCache>${docker.noCache}</noCache>
+                                                <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk25</dockerFile>
+                                                <assembly>
+                                                    <mode>tar</mode>
+                                                    <descriptor>assembly.xml</descriptor>
+                                                    <tarLongFileMode>gnu</tarLongFileMode>
+                                                </assembly>
+                                                <buildx>
+                                                    <platforms>
+                                                        <platform>${docker.platforms}</platform>
+                                                    </platforms>
+                                                </buildx>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
+                            </execution>
+
+                            <execution>
+                                <id>deploy-jdk25-docker-image</id>
+                                <goals>
+                                    <goal>push</goal>
+                                </goals>
+                                <phase>deploy</phase>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${docker.payara.repository}</name>
+                                            <build>
+                                                <!-- On Windows with default setting ${*}, $PATH would get filtered as well -->
+                                                <filter>@</filter>
+                                                <tags>
+                                                    <tag>${docker.payara.tag}-jdk25</tag>
+                                                </tags>
+                                                <cleanup>none</cleanup>
+                                                <noCache>${docker.noCache}</noCache>
+                                                <dockerFile>${project.build.directory}/antrun/Dockerfile.jdk25</dockerFile>
                                                 <assembly>
                                                     <mode>tar</mode>
                                                     <descriptor>assembly.xml</descriptor>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
Add Java 25 Docker image build configuration for Payara Community 7. This adds a new Maven profile generate-jdk25-docker-image that builds Docker images using Azul Zulu OpenJDK 25, following the same pattern used for JDK 21.

## Important Info
### Blockers
None

## Testing
### New tests
No new tests required - uses existing Docker image build infrastructure.

### Testing Performed
Build and run Docker images for server-full and micro using JDK 25:

#### Payara Server (JDK 25)                                                                                                                                                                                                          
1. Use in WSL                                                                                                                                                                                                                   
2. mvn clean install -DskipTests at root directory                                                                                                                                                                              
3. cd appserver/extras/docker-images/server-full                                                                                                                                                                                
4. mvn clean package                                                                                                                                                                                                            
5. cd target/docker                                                                                                                                                                                                             
6. docker build -t payara/server-full:local-jdk25 -f ./payara/server-full/build/Dockerfile.jdk25 ./payara/server-full/tmp/docker-build/                                                                                         
7. docker run -it -e ENABLE_FILE_LOGS=true -p 8080:8080 -p 4848:4848 --name payara_docker_jdk25 payara/server-full:local-jdk25

#### Payara Micro (JDK 25)                                                                                                                                                                                                           
1. Use in WSL                                                                                                                                                                                                                   
2. mvn clean install -DskipTests at root directory                                                                                                                                                                              
3. cd appserver/extras/docker-images/micro                                                                                                                                                                                      
4. mvn clean package                                                                                                                                                                                                            
5. cd target/docker                                                                                                                                                                                                             
6. docker build -t payara/micro:local-jdk25 -f ./payara/micro/build/Dockerfile.jdk25 ./payara/micro/tmp/docker-build/                                                                                                           
7. docker run -it payara/micro:local-jdk25

### Testing Environment
Azul Zulu JDK 25.0.1 on Ubuntu 24.04 with Maven 3.9.9

## Documentation
N/A

## Notes for Reviewers
- The new profile follows the same structure as generate-jdk21-docker-image                                                                                                                                                     
- Docker images will be tagged with -jdk25 suffix (e.g., 7.2026.2-jdk25)                                                                                                                                                        
- Base image: azul/zulu-openjdk:25.0.1-jdk (verified available on Docker Hub)     
