### PR TITLE
FISH-12303 Add prefix to OpenAPI endpoints field

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OpenAPIImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,6 +39,7 @@
  */
 package fish.payara.microprofile.openapi.impl.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.impl.model.info.InfoImpl;
 import fish.payara.microprofile.openapi.impl.model.security.SecurityRequirementImpl;
@@ -351,6 +352,7 @@ public class OpenAPIImpl extends ExtensibleImpl<OpenAPI> implements OpenAPI, Clo
         return clonedObj;
     }
 
+    @JsonIgnore
     public Map<String, Set<String>> getEndpoints() {
         return endpoints;
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/service/OpenApiResource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -91,6 +91,10 @@ public class OpenApiResource {
             LOGGER.info("No OpenAPI document found.");
             OpenAPI result = new BaseProcessor(new ArrayList<>()).process(new OpenAPIImpl(), null);
             return Response.status(Status.NOT_FOUND).entity(result).build();
+        }
+
+        if (((OpenAPIImpl) document).getEndpoints() != null) {
+            document.addExtension("x-endpoints", ((OpenAPIImpl) document).getEndpoints());
         }
 
         // Return the document


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
The 'endpoints' field is not part of OpenAPI  and should be prefixed with 'x-' to differentiate. 
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Deployed two openapi applications, verified endpoints were updated and prefixed. 
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.9, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.9-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "15.6", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a