### PR TITLE
FISH-12807 FISH-12812 Upgrade Docker JDKs

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -58,7 +58,7 @@
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk21.tag>21.0.10-jdk</docker.jdk21.tag>
-        <docker.jdk25.tag>25.0.1-jdk</docker.jdk25.tag>
+        <docker.jdk25.tag>25.0.2-jdk</docker.jdk25.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.


### PR DESCRIPTION
## Description
Upgrades the Docker JDKs to 21.0.10 and 25.0.2

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built and ran unit tests (pending) - fails, images aren't pushed yet

### Testing Environment
N/A

## Documentation
N/A

## Notes for Reviewers
None
