### PR TITLE
FISH-12471 removed JS_Prefix

### DIFF
--- a/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvanceJS.inc
+++ b/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvanceJS.inc
@@ -188,21 +188,21 @@
                 disableComponent(textId, 'text');
                 document.getElementById(textId).value=textVal;
                 enableComponent(dropdownId, 'select');
-                #{themeJavascript.JS_PREFIX}.radiobutton.setChecked(propId+':optB', false);
-                #{themeJavascript.JS_PREFIX}.radiobutton.setChecked(propId+':optA', true);
+                require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked(propId+':optB', false); });
+                require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked(propId+':optA', true); });
                 document.getElementById(optionId).value='dropdown';
             }else{
                 enableComponent(textId, 'text');
                 disableComponent(dropdownId, 'select');
                 getTextElement(textId).focus();
-                #{themeJavascript.JS_PREFIX}.radiobutton.setChecked(propId+':optB', true);
-                #{themeJavascript.JS_PREFIX}.radiobutton.setChecked(propId+':optA', false);
+                require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked(propId+':optB', true); });
+                require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked(propId+':optA', false); });
                 document.getElementById(optionId).value='text';
             }         
       }
       function disableTwoRadioButtons(opt, propId, optionId){
-          #{themeJavascript.JS_PREFIX}.radiobutton.setDisabled(propId+':optA', opt);
-          #{themeJavascript.JS_PREFIX}.radiobutton.setDisabled(propId+':optB', opt);
+          require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setDisabled(propId+':optA', opt); });
+          require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setDisabled(propId+':optB', opt); });
           document.getElementById(optionId).value='';
       }
     </script>


### PR DESCRIPTION
FISH-12471 Infinite Loading Throbber on JDBC Connection Pools, Advanced Tab

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

When going to JDBC -> Select Pool -> Advanced -> infinite loading icon. Comparing to glassfish, they have fixed this issue previously  https://github.com/eclipse-ee4j/glassfish/commit/cc1dbb1bd5d3f3a789d5d6bb99ee44ffc09bd52a 

I have since applied their fix and tested it works.