### PR TITLE
FISH-12191 Admin Console: Advanced Tab in Connection Pools Not Working Correctly

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -37,10 +37,20 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-/*Portions Copyright 2016-2023 Payara Foundation and/or its affiliates
+/*Portions Copyright 2016-2026 Payara Foundation and/or its affiliates
 /*
  * Common utility
  */
+
+/* Load dependencies eagerly to prevent issues with loading them asynchrnously later.
+ */
+require(['webui/suntheme/field']);
+require(['webui/suntheme/dropDown']);
+require(['webui/suntheme/upload']);
+require(['webui/suntheme/jumpDropDown']);
+require(['webui/suntheme/hyperlink']);
+require(['webui/suntheme/props']);
+
 
 /* To work around a timing issue where for Firefox 2.0.0.3 on Mac OS X
  * We need to put in a little delay before returning the var
@@ -115,24 +125,23 @@ function getField(theForm, fieldName) {
     return null;
 }
 
-// in case modules are not loaded, return temporary object with empty, but existing data
-function createFakeText(id) {
-    return {
-        id,
-        value: "FAKE"
-    };
-}
-
 // FIXME: suntheme should not be used -- prevents theme from changing
 function getTextElement(componentName) {
+
+    var el;
+
     require(['webui/suntheme/field'], function (field) {
-        var el = field.getInputElement(componentName);
-        if (el === null) {
-            el = document.getElementById(componentName); // This may get too deep inside WS, but it should work as a fall back
+        if(field === "undefined"){
+            return  document.getElementById(componentName);
         }
-        return el;
+
+        var el = field.getInputElement(componentName);
     });
-    return createFakeText(componentName);
+
+    if (el == null) {
+        el = document.getElementById(componentName); // This may get too deep inside WS, but it should work as a fall back
+    }
+    return el;
 }
 
 function getSelectElement(componentName) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->

Made same change as glassfish implementation. I also removed the `CreateFakeText` since it was not used anywhere else. Was thinking of keeping it but theres no need.

## Important Info
## Testing
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Build Payara -> JDBC -> Connection Pool -> H2 -> Advanced -> Change field value and save, error should not appear and values are correct in domain

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
