### PR TITLE
FISH-12252: replace inline EE7 samples test execution with a call to Run-EE7-Samples

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,8 @@ pipeline {
             steps {
                 script {
                     pom = readMavenPom file: 'pom.xml'
-
+                    payaraBuildNumber = "PR${env.ghprbPullId}#${currentBuild.number}"
+                    DOMAIN_NAME = "test-domain"
                     echo "Payara pom version is ${pom.version}"
                     echo "Build number is ${payaraBuildNumber}"
                     echo "Domain name is ${DOMAIN_NAME}"


### PR DESCRIPTION
This PR replaces the maven commands for the EE7 with a direct call to the Run-EE7-Samples Jenkins job.