### PR TITLE
FISH-12951 Remove leading slash from MP JWT properties

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/eesecurity/SignedJWTIdentityStore.java
+++ b/appserver/payara-appserver-modules/microprofile/jwt-auth/src/main/java/fish/payara/microprofile/jwtauth/eesecurity/SignedJWTIdentityStore.java
@@ -48,6 +48,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.jwt.config.Names;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Arrays;
@@ -152,9 +153,9 @@ public class SignedJWTIdentityStore implements IdentityStore {
         URL mpJwtResource = currentThread().getContextClassLoader().getResource("payara-mp-jwt.properties");
         Properties properties = null;
         if (mpJwtResource != null) {
-            try {
-                properties = new Properties();
-                properties.load(mpJwtResource.openStream());
+            properties = new Properties();
+            try (InputStream is = mpJwtResource.openStream()) {
+                properties.load(is);
             } catch (IOException e) {
                 throw new IllegalStateException("Failed to load Vendor properties from resource file", e);
             }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Removing the leading slash allows for the resolution of the properties file in external libraries - previously a zip entry with the exact name was required if a user wanted to load these properties.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Manual testing of external libraries (domain/lib)
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a