### PR TITLE
FISH-12972 Replace jsf.js with faces.jsf in shutdown/restart admingui pages

### DIFF
--- a/appserver/admingui/common/src/main/resources/appServer/restart-2.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/restart-2.jsf
@@ -52,7 +52,7 @@
 <sun:html id="html1">
 <sun:head title="$resource{i18n.restart.pageTitle}" parseOnLoad="false">
     <sun:link url="/resource/css/css_ns6up.css" />
-    <h:outputScript name="jsf.js" library="jakarta.faces" target="body" />
+    <h:outputScript name="faces.js" library="jakarta.faces" target="body" />
     <sun:script>
 	<f:verbatim>
 	    function triggerRestart() {
@@ -62,7 +62,7 @@
 		    render: '@none'
 		};
 		options[button.id] = button.id;
-		jsf.ajax.request(button, null, options);
+		faces.ajax.request(button, null, options);
 	    }
 	</f:verbatim>
     </sun:script>

--- a/appserver/admingui/common/src/main/resources/appServer/shutdown.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/shutdown.jsf
@@ -50,7 +50,7 @@
 <sun:html id="html1">
 <sun:head title="$resource{i18n.shutdown.pageTitle}" parseOnLoad="false">
     <sun:link url="/resource/css/css_ns6up.css" />
-    <h:outputScript name="jsf.js" library="jakarta.faces" target="body" />
+    <h:outputScript name="faces.js" library="jakarta.faces" target="body" />
     <sun:script>
 	<f:verbatim>
 	    function triggerShutdown() {
@@ -61,7 +61,7 @@
 		};
                 
 		options[button.id] = button.id;
-		jsf.ajax.request(button, null, options);
+		faces.ajax.request(button, null, options);
 
 	    }
 	</f:verbatim>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Payara7 admingui uses newer version of jsftemplating from glassfish where they replaced `jsf.js` with `faces.js`. This is one of several places that still reference the previous version

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Open admin UI and click on both Domain -> Server (Admin Server) -> Stop & Restart buttons
After Stop the process should not be running without having to click on Submit Query
After Restart there server should restart itself (can verify from server.log or new pid)
**note** that the Submit Query button is still visible only with this fix you don't need to click it to action the command

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu JDK 21.0.9 on Linux Mint 22.3 with Maven 3.9.11

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
