### PR TITLE
FISH-12472 Replace jsf.js with faces.jsf in help admingui page

### DIFF
--- a/appserver/admingui/common/src/main/resources/help/help.jsf
+++ b/appserver/admingui/common/src/main/resources/help/help.jsf
@@ -56,7 +56,7 @@
     <sun:head title="$resource{i18n.helpWindowTitle}" debug="false" parseOnLoad="false">
 	<sun:link url="/resource/common/help/help.css" />
 	<sun:script url="/resource/common/js/adminjsf.js" />
-	<h:outputScript name="jsf.js" library="jakarta.faces" target="head" />
+	<h:outputScript name="faces.js" library="jakarta.faces" target="head" />
     </sun:head>
     <sun:body id="bodyTag" style="display:none;" onLoad="admingui.help.fixTreeOnclick(document.getElementById('tocTree')); admingui.help.fixTreeOnclick(document.getElementById('indexTree')); admingui.help.loadHelpPageFromContextRef('#{pageSession.contextRef}', 'helpContent'); document.getElementById('bodyTag').style.display='block';">
 	"<div id="menuContent" class="helpMenuBox">


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Payara7 admingui uses newer version of jsftemplating from glassfish where they replaced `jsf.js` with `faces.js`. This is one of several places that still reference the previous version

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Open admin UI and click on help in top masthead it should open a new window
Without this fix the Index tab does not work and an error is visible in developer tools console complaining about missing `faces.jsf`
The Index tab should switch the view from ToC to Index and each link on the Index page should be clickable

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu JDK 21.0.9 on Linux Mint 22.3 with Maven 3.9.11

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
