### PR TITLE
FISH-13058 Session bugs in availability mode: Missing `JSESSIONIDVERSION` and parallel requests Lead To Session Not Being Correctly Retrieved In Relaxed Mode

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/session/ManagerBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/session/ManagerBase.java
@@ -55,7 +55,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Portions Copyright [2016-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2026] [Payara Foundation and/or its affiliates]
 
 package org.apache.catalina.session;
 
@@ -708,7 +708,14 @@ public abstract class ManagerBase implements Manager {
      */
     @Override
     public void add(Session session) {
-        sessions.put(session.getIdInternal(), session);
+        sessions.compute(session.getIdInternal(), (id, existingSession) -> {
+            if (isSessionVersioningSupported()
+                    && existingSession != null
+                    && existingSession.getVersion() > session.getVersion()) {
+                    return existingSession;
+                }
+            return session;
+        });
         int size = sessions.size();
         if (size > maxActive) {
             synchronized(maxActiveUpdateLock) {

--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ReplicationManagerBase.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/session/management/ReplicationManagerBase.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+// Portions Copyright [2016-2026] [Payara Foundation and/or its affiliates]
 
 package org.glassfish.web.ha.session.management;
 
@@ -108,6 +108,12 @@ public abstract class ReplicationManagerBase<T extends Storeable> extends Persis
         if(_logger.isLoggable(Level.FINE)) {
             _logger.fine("in findSession: version=" + version);
         }
+
+        if (isRelaxCacheVersionSemantics() && version == null) {
+            _logger.fine("Relaxed cache version semantics enabled and version is null, treating as version -1");
+            version = "-1";
+        }
+
         if(!this.isSessionIdValid(id) || version == null) {
             return null;
         }


### PR DESCRIPTION
…y retrieved in relaxed mode

This only happens on a first request that happens in parallel with session creation, so very sporadic.

Another issue in the same realm. During parallel requests, older version of the session can overwrite a newer version. This fixes that by preventing older version from ever overriding a newer one.

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
This is a bug fix. When a new session is being accessed in parallel with another thread creating it,
no version exists and thus session is not being found, or newer sessions being overwritten with older versions