### PR TITLE
FISH-13937 fixes #8001 Fix RandomAccessFile leak in FilePool.close()

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/data/RandomAccessDataFile.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/data/RandomAccessDataFile.java
@@ -278,10 +278,22 @@ public class RandomAccessDataFile implements RandomAccessData {
 		public void close() throws IOException {
 			this.available.acquireUninterruptibly(this.size);
 			try {
+				IOException first = null;
 				RandomAccessFile pooledFile = this.files.poll();
 				while (pooledFile != null) {
-					pooledFile.close();
+					try {
+						pooledFile.close();
+					} catch (IOException e) {
+						if (first == null) {
+							first = e;
+						} else {
+							first.addSuppressed(e);
+						}
+					}
 					pooledFile = this.files.poll();
+				}
+				if (first != null) {
+					throw first;
 				}
 			}
 			finally {


### PR DESCRIPTION
## Description
Fix resource cleanup in RandomAccessDataFile.FilePool#close().
If closing one pooled RandomAccessFile throws an IOException, the current loop exits early and remaining pooled files may remain unclosed. This change continues closing the rest and then rethrows the first exception (with subsequent ones suppressed).

Addresses: #8001

## Important Info
## Blockers
None.

## Testing
New tests
None.

Built the affected module locally.


### Notes for Reviewers
Change is limited to FilePool#close() and only affects the failure path when RandomAccessFile.close() throws.