### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/generate-metrics-report.yml
+++ b/.github/workflows/generate-metrics-report.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run issue-metrics action, raised issues
         id: issue-metrics-raised
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABELS_TO_MEASURE: 'Status: Open,Status: Accepted,Status: Pending'
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run issue-metrics action, closed issues
         id: issue-metrics-closed
-        uses: github/issue-metrics@v3
+        uses: github-community-projects/issue-metrics@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABELS_TO_MEASURE: 'Status: Open,Status: Accepted,Status: Pending'


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/issue-metrics` | `github-community-projects/issue-metrics` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
