### PR TITLE
FISH-13327 Replace `snakeyaml` with `snakeyaml-engine` for YAML 1.2

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -943,8 +943,8 @@
             </dependency>
 
             <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
+                <groupId>org.snakeyaml</groupId>
+                <artifactId>snakeyaml-engine</artifactId>
                 <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>

--- a/nucleus/packager/external/opentelemetry-repackaged/pom.xml
+++ b/nucleus/packager/external/opentelemetry-repackaged/pom.xml
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.snakeyaml</groupId>
             <artifactId>snakeyaml-engine</artifactId>
-            <version>${snakeyaml-version}</version>
+            <version>${snakeyaml.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/nucleus/packager/nucleus-jersey/pom.xml
+++ b/nucleus/packager/nucleus-jersey/pom.xml
@@ -40,7 +40,7 @@
     holder.
 
 -->
-<!-- Portions Copyright 2017-2024 Payara Foundation and/or its affiliates -->
+<!-- Portions Copyright 2017-2026 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -143,8 +143,8 @@
             <artifactId>stax2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.parsson</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -151,7 +151,6 @@
 
         <okhttp3-version>4.12.0</okhttp3-version>
         <kotlin-version>2.3.0</kotlin-version>
-        <snakeyaml-version>2.9</snakeyaml-version>
 
         <payara.deployment.transformer.version>2.0.0-SNAPSHOT</payara.deployment.transformer.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
 
         <!-- BOM-referenced versions -->
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
-        <snakeyaml.version>2.5</snakeyaml.version>
+        <snakeyaml.version>2.9</snakeyaml.version>
         <mojarra.version>4.1.6.payara-p1</mojarra.version>
         <jaxb-extra-osgi.version>2.3.0</jaxb-extra-osgi.version>
         <jakarta.mvc.version>3.0.0</jakarta.mvc.version>


### PR DESCRIPTION
## Description
Noticed during https://github.com/payara/Payara/pull/8053 that we've now got two separate snakeyaml versions and dependencies. This is a test/upgrade to only use the "new"(?) `snakeyaml-engine` dependency (YAML 1.2 instead of 1.1)

## Important Info
### Blockers
May end up colliding https://github.com/payara/Payara/pull/8053

## Testing
### New tests
None

### Testing Performed
Built the server and started the DAS - Explodes Jackson

```
missing requirement [com.fasterxml.jackson.dataformat.jackson-dataformat-yaml [156](R 156.0)] osgi.wiring.package; (&(osgi.wiring.package=org.yaml.snakeyaml)(version>=2.4.0)(!(version>=3.0.0)
```

### Testing Environment
Jenkins

## Documentation
None...?

## Notes for Reviewers
None
