### PR TITLE
FISH-13090 Reduce Data Logging Levels

### DIFF
--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/DynamicInterfaceDataProducer.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/DynamicInterfaceDataProducer.java
@@ -181,17 +181,17 @@ public class DynamicInterfaceDataProducer<T> implements Producer<T>, ProducerFac
     }
 
     private void processQueriesForEntity() {
-        logger.fine("Processing query for entity class: " + repository);
+        logger.finer("Processing query for entity class: " + repository);
         //get entity type
         Class<?> declaredEntityClass = getEntityTypeFromGenerics(this.repository);
         // If entity type is not declared via generics, infer it from lifecycle method parameters
         if (declaredEntityClass == null) {
             declaredEntityClass = inferEntityTypeFromLifecycleMethods(this.repository);
         }
-        logger.fine("Processing entity class " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null"));
+        logger.finer("Processing entity class " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null"));
         try (EntityManager entityManager = getEntityManagerSupplier(this.jakartaDataExtension.getApplicationName(), this.dataStore).get()) {
             for (Method method : this.repository.getMethods()) {
-                logger.fine("Processing query for " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null") + "." + method.getName());
+                logger.finer("Processing query for " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null") + "." + method.getName());
                 //skip if method is default
                 if (method.isDefault()) {
                     continue;

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/DynamicInterfaceDataProducer.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/DynamicInterfaceDataProducer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) 2025 Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2025-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -181,17 +181,17 @@ public class DynamicInterfaceDataProducer<T> implements Producer<T>, ProducerFac
     }
 
     private void processQueriesForEntity() {
-        logger.info("Processing query for entity class: " + repository);
+        logger.fine("Processing query for entity class: " + repository);
         //get entity type
         Class<?> declaredEntityClass = getEntityTypeFromGenerics(this.repository);
         // If entity type is not declared via generics, infer it from lifecycle method parameters
         if (declaredEntityClass == null) {
             declaredEntityClass = inferEntityTypeFromLifecycleMethods(this.repository);
         }
-        logger.info("Processing entity class " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null"));
+        logger.fine("Processing entity class " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null"));
         try (EntityManager entityManager = getEntityManagerSupplier(this.jakartaDataExtension.getApplicationName(), this.dataStore).get()) {
             for (Method method : this.repository.getMethods()) {
-                logger.info("Processing query for " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null") + "." + method.getName());
+                logger.fine("Processing query for " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null") + "." + method.getName());
                 //skip if method is default
                 if (method.isDefault()) {
                     continue;

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2025] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2025-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -161,7 +161,7 @@ public class RepositoryImpl<T> implements InvocationHandler {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         //In this method we can add implementation to execute dynamic queries
-        logger.info("executing method:" + method.getName());
+        logger.fine("executing method:" + method.getName());
         if (method.isDefault()) {
             return InvocationHandler.invokeDefault(proxy, method, args);
         }

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/util/DeleteOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/util/DeleteOperationUtility.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2025-2026] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2025-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *     The contents of this file are subject to the terms of either the GNU
  *     General Public License Version 2 only ("GPL") or the Common Development
@@ -116,7 +116,7 @@ public class DeleteOperationUtility {
         // Clear cache for the affected entity after DELETE
         clearCache(em, declaredEntityClass);
 
-        logger.info("Rows affected from delete operation: " + rowsAffected);
+        logger.fine("Rows affected from delete operation: " + rowsAffected);
         return rowsAffected;
     }
 

--- a/appserver/tests/payara-samples/samples/data/pom.xml
+++ b/appserver/tests/payara-samples/samples/data/pom.xml
@@ -51,7 +51,7 @@
 
   <artifactId>data</artifactId>
   <name>Payara Samples - Data (Arquillian/H2)</name>
-  <packaging>jar</packaging>
+  <packaging>war</packaging>
 
   <properties>
     <junit.jupiter.version>6.0.3</junit.jupiter.version>


### PR DESCRIPTION
## Description
Reduces the most verbose aspects of the Data implementation logging: where it processes all of the methods and classes.

Also fixes the Data sample: it should be a WAR, not a JAR

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Deployed the Data application from Payara Samples and inspected the logs - much less noise from Payara (albeit EclipseLink spews out a load of noise).

### Testing Environment
Windows 11, Maven 3.9.14, Zulu JDK 21.0.10

## Documentation
N/A

## Notes for Reviewers
None
