### PR TITLE
FISH-13167 FISH-13169 FISH-13156 FISH-13157 OpenAPI TCK: BeanValidation and OAS Config

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -255,16 +255,27 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
         if (multipleOf != null) {
             from.setMultipleOf(BigDecimal.valueOf(multipleOf));
         }
+
         String maximum = annotation.getValue("maximum", String.class);
         if (maximum != null && !maximum.isEmpty()) {
-            from.setMaximum(new BigDecimal(maximum));
+            Boolean isExclusiveMaximum = annotation.getValue("exclusiveMaximum", Boolean.class);
+            BigDecimal max = new BigDecimal(maximum);
+            from.setMaximum(max);
+            if (Boolean.TRUE.equals(isExclusiveMaximum)) {
+                from.setExclusiveMaximum(max);
+            }
         }
-        from.setExclusiveMaximum(annotation.getValue("exclusiveMaximum", BigDecimal.class));
+
         String minimum = annotation.getValue("minimum", String.class);
         if (minimum != null && !minimum.isEmpty()) {
-            from.setMinimum(new BigDecimal(minimum));
+            Boolean isExclusiveMinimum = annotation.getValue("exclusiveMinimum", Boolean.class);
+            BigDecimal min = new BigDecimal(minimum);
+            from.setMinimum(min);
+            if (Boolean.TRUE.equals(isExclusiveMinimum)) {
+                from.setExclusiveMinimum(min);
+            }
         }
-        from.setExclusiveMinimum(annotation.getValue("exclusiveMinimum", BigDecimal.class));
+
         from.setMaxLength(annotation.getValue("maxLength", Integer.class));
         from.setMinLength(annotation.getValue("minLength", Integer.class));
         from.setPattern(annotation.getValue("pattern", String.class));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 import fish.payara.microprofile.openapi.impl.model.ExtensibleImpl;
@@ -213,6 +214,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
     public static SchemaImpl valueOf(String content) throws JsonMappingException, JsonProcessingException {
         return ObjectMapperFactory
                 .createJson()
+                .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
                 .readValue(content, SchemaImpl.class);
     }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves the following TCK tests.
  - FISH-13156 BeanValidationTest
  - FISH-13157 BeanValidationDisabledTest
  - FISH-13167 OASConfigSchemaTest
  - FISH-13169 OASConfigWebInfTest
- Sets the `exclusiveMinimum` and `exclusiveMaximum` fields in `SchemaImpl` back to reading booleans from the schema, but copying the standard `minimum` and `maximum` fields for the internal values.
- Enables reading single values as arrays inside the `SchemaImpl` object mapper.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Passing TCKs on Jenkins
- [Both Bean Validation Tests](https://jenkins.payara.fish/view/TCKs/job/TCKs/job/MP-TCKs/2696/testReport/org.eclipse.microprofile.openapi.tck.beanvalidation/)
- [OASConfigSchemaTest](https://jenkins.payara.fish/view/TCKs/job/TCKs/job/MP-TCKs/2696/testReport/org.eclipse.microprofile.openapi.tck/OASConfigSchemaTest/)
- [OASConfigWebInfTest](https://jenkins.payara.fish/view/TCKs/job/TCKs/job/MP-TCKs/2696/testReport/org.eclipse.microprofile.openapi.tck/OASConfigWebInfTest/)

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
