### PR TITLE
FISH-13427 HK2 4.0.1

### DIFF
--- a/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/CliCommands.java
+++ b/appserver/tests/payara-samples/test-utils/src/main/java/fish/payara/samples/CliCommands.java
@@ -1,3 +1,43 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2019-2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
 package fish.payara.samples;
 
 import static java.lang.Runtime.getRuntime;
@@ -11,8 +51,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 import java.util.logging.Logger;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Methods to execute "cli commands" against various servers.
@@ -57,7 +95,7 @@ public class CliCommands {
 
         cmd.add(asadminPath.toAbsolutePath().toString());
         cmd.addAll(cliCommands);
-        logger.info("Executing command: \n" + StringUtils.join(cmd, " "));
+        logger.info("Executing command: \n" + String.join(" ", cmd));
 
         ProcessBuilder processBuilder = new ProcessBuilder(cmd);
         processBuilder.redirectErrorStream(true);

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
         <payara.security-connectors.version>4.0.0</payara.security-connectors.version>
-        <hk2.version>4.0.0</hk2.version>
+        <hk2.version>4.0.1</hk2.version>
         <osgi.version>8.0.0</osgi.version>
         <osgi.annotation.version>8.1.0</osgi.annotation.version>
         <osgi.enterprise.version>7.0.0</osgi.enterprise.version>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version>
         <validation.xml.root>${project.build.outputDirectory}</validation.xml.root>
         <payara.security-connectors.version>4.0.0</payara.security-connectors.version>
-        <hk2.version>4.0.0-M3.payara-p2</hk2.version>
+        <hk2.version>4.0.0</hk2.version>
         <osgi.version>8.0.0</osgi.version>
         <osgi.annotation.version>8.1.0</osgi.annotation.version>
         <osgi.enterprise.version>7.0.0</osgi.enterprise.version>


### PR DESCRIPTION
## Description
Upgrades HK2 to 4.0.0 (final).
All of our patches have been synced to upstream, so no need to create a patched release.

## Important Info
### Blockers
None - HK2 4.0.1 resolves most of the previous issues
~~CargoTracker update: https://github.com/payara/cargotracker/pull/49~~

## Testing
### New tests
None

### Testing Performed
Built the server and started the admin console.

### Testing Environment
Windows 11, Maven 3.9.14, Zulu JDK 21.0.10

## Documentation
N/A

## Notes for Reviewers
None
