### PR TITLE
FISH-13385 Switch to getJvmRawOptions() to fix regression introduced …

### DIFF
--- a/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/compatibility/JaccProviderCompatibilityStartup.java
+++ b/appserver/security/jacc.provider.inmemory/src/main/java/fish/payara/security/jacc/provider/compatibility/JaccProviderCompatibilityStartup.java
@@ -165,7 +165,7 @@ public class JaccProviderCompatibilityStartup implements PostConstruct {
 
     private void ensureJaccPolicyFactoryJvmOption(Config config) {
         JavaConfig javaConfig = config.getJavaConfig();
-        List<String> jvmOptions = javaConfig.getJvmOptions();
+        List<String> jvmOptions = javaConfig.getJvmRawOptions();
 
         Optional<String> existing = jvmOptions.stream()
                 .filter(opt -> opt.startsWith(JACC_POLICY_FACTORY_JVM_OPTION_KEY))
@@ -183,12 +183,11 @@ public class JaccProviderCompatibilityStartup implements PostConstruct {
         }
 
         logger.log(Level.INFO, "Adding missing JACC PolicyFactory JVM option: {0}", JACC_POLICY_FACTORY_JVM_OPTION);
-        jvmOptions.add(JACC_POLICY_FACTORY_JVM_OPTION);
 
         try {
             ConfigSupport.apply(jconfig -> {
-                jconfig.setJvmOptions(jvmOptions);
-                return config;
+                jconfig.getJvmRawOptions().add(JACC_POLICY_FACTORY_JVM_OPTION);
+                return true;
             }, javaConfig);
 
             logger.log(Level.INFO, "Successfully added JACC PolicyFactory JVM option");


### PR DESCRIPTION
…in commit 4055c7759409acf9ce51d2abe357c7bdfb9a4329

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This PR resolves an issue where JVM options were updated, but lost extra data, potentially causing JVM options to be unrecognised, switching to getJvmRawOptions resolves this.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
