### PR TITLE
FISH-13193 : throwing UnsupportedOperationException when the method is not supported by the Jakarta Data provider

### DIFF
--- a/appserver/data/data-core/pom.xml
+++ b/appserver/data/data-core/pom.xml
@@ -70,11 +70,6 @@
             <artifactId>weld-integration</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     
     <build>

--- a/appserver/data/data-core/pom.xml
+++ b/appserver/data/data-core/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>weld-integration</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/DynamicInterfaceDataProducer.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/DynamicInterfaceDataProducer.java
@@ -189,7 +189,13 @@ public class DynamicInterfaceDataProducer<T> implements Producer<T>, ProducerFac
             declaredEntityClass = inferEntityTypeFromLifecycleMethods(this.repository);
         }
         logger.finer("Processing entity class " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null"));
-        try (EntityManager entityManager = getEntityManagerSupplier(this.jakartaDataExtension.getApplicationName(), this.dataStore).get()) {
+        EntityManager entityManager = getEntityManagerSupplier(this.jakartaDataExtension.getApplicationName(), this.dataStore).get();
+        if (entityManager == null) {
+            logger.warning("No persistence unit available for repository " + repository.getName()
+                    + "; methods will throw UnsupportedOperationException at runtime.");
+            return;
+        }
+        try (entityManager) {
             for (Method method : this.repository.getMethods()) {
                 logger.finer("Processing query for " + (declaredEntityClass != null ? declaredEntityClass.getName() : "null") + "." + method.getName());
                 //skip if method is default

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
@@ -166,7 +166,19 @@ public class RepositoryImpl<T> implements InvocationHandler {
             return InvocationHandler.invokeDefault(proxy, method, args);
         }
 
+        if (method.getDeclaringClass().equals(Object.class)) {
+            return switch (method.getName()) {
+                case "toString" -> repositoryInterface.getName() + " Proxy";
+                case "hashCode" -> System.identityHashCode(proxy);
+                case "equals" -> proxy == args[0];
+                default -> method.invoke(this, args);
+            };
+        }
+
         QueryMetadata queryMetadata = queries.get(method);
+        if (queryMetadata == null) {
+            throw new UnsupportedOperationException("The method " + method.getName() + " is not supported by the Jakarta Data provider.");
+        }
         QueryData dataForQuery = new QueryData(queryMetadata);
         Object objectToReturn;
         startTransactionComponents();

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
@@ -662,18 +662,8 @@ public class RepositoryImpl<T> implements InvocationHandler {
                 entityManagerSupplier.get(), getTransactionManager(), dataParameter);
     }
 
-    public void setTransactionManager(TransactionManager transactionManager) {
-        this.transactionManager = transactionManager;
-    }
-
     public TransactionManager getTransactionManager() {
-        if (transactionManager != null) {
-            return transactionManager;
-        }
         ServiceLocator locator = Globals.get(ServiceLocator.class);
-        if (locator == null) {
-            return null;
-        }
         ServiceHandle<TransactionManager> inhabitant =
                 locator.getServiceHandle(TransactionManager.class);
         if (inhabitant != null && inhabitant.isActive()) {

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/cdi/extension/RepositoryImpl.java
@@ -116,9 +116,13 @@ public class RepositoryImpl<T> implements InvocationHandler {
     private final Map<Class<?>, Member> idAccessorCache = new ConcurrentHashMap<>();
 
     public RepositoryImpl(Class<T> repositoryInterface, Map<Class<?>, List<QueryMetadata>> queriesPerEntityClass, String applicationName, String dataStore) {
+        this(repositoryInterface, queriesPerEntityClass, applicationName, getEntityManagerSupplier(applicationName, dataStore));
+    }
+
+    public RepositoryImpl(Class<T> repositoryInterface, Map<Class<?>, List<QueryMetadata>> queriesPerEntityClass, String applicationName, Supplier<EntityManager> entityManagerSupplier) {
         this.repositoryInterface = repositoryInterface;
         this.applicationName = applicationName;
-        this.entityManagerSupplier = getEntityManagerSupplier(applicationName, dataStore);
+        this.entityManagerSupplier = entityManagerSupplier;
 
         Map<Method, QueryMetadata> r = queriesPerEntityClass.entrySet().stream().map(e -> e.getValue())
                 .flatMap(List::stream).collect(Collectors.toMap(QueryMetadata::getMethod, Function.identity()));
@@ -658,8 +662,18 @@ public class RepositoryImpl<T> implements InvocationHandler {
                 entityManagerSupplier.get(), getTransactionManager(), dataParameter);
     }
 
+    public void setTransactionManager(TransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
+
     public TransactionManager getTransactionManager() {
+        if (transactionManager != null) {
+            return transactionManager;
+        }
         ServiceLocator locator = Globals.get(ServiceLocator.class);
+        if (locator == null) {
+            return null;
+        }
         ServiceHandle<TransactionManager> inhabitant =
                 locator.getServiceHandle(TransactionManager.class);
         if (inhabitant != null && inhabitant.isActive()) {

--- a/appserver/data/data-core/src/main/java/fish/payara/data/core/util/DataCommonOperationUtility.java
+++ b/appserver/data/data-core/src/main/java/fish/payara/data/core/util/DataCommonOperationUtility.java
@@ -159,6 +159,10 @@ public class DataCommonOperationUtility {
         ApplicationInfo applicationInfo = applicationRegistry.get(applicationName);
         List<EntityManagerFactory> factoryList = applicationInfo.getTransientAppMetaData(EntityManagerFactory.class.toString(), List.class);
 
+        if (factoryList == null || factoryList.isEmpty()) {
+            return () -> null;
+        }
+
         if (factoryList.size() == 1) {
             EntityManagerFactory entityManagerFactory = factoryList.getFirst();
             return () -> entityManagerFactory.createEntityManager();

--- a/appserver/data/data-core/src/test/java/fish/payara/data/core/cdi/extension/RepositoryImplTest.java
+++ b/appserver/data/data-core/src/test/java/fish/payara/data/core/cdi/extension/RepositoryImplTest.java
@@ -40,6 +40,8 @@
 package fish.payara.data.core.cdi.extension;
 
 import org.junit.Test;
+import org.mockito.Mockito;
+import jakarta.transaction.TransactionManager;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.Map;
@@ -54,7 +56,11 @@ public class RepositoryImplTest {
     @Test(expected = UnsupportedOperationException.class)
     public void testUnsupportedMethodThrowsException() throws Throwable {
         Map<Class<?>, List<QueryMetadata>> queriesPerEntityClass = Collections.emptyMap();
-        RepositoryImpl<MyRepository> handler = new RepositoryImpl<>(MyRepository.class, queriesPerEntityClass, "testApp", null);
+        RepositoryImpl<MyRepository> handler = new RepositoryImpl<>(MyRepository.class, queriesPerEntityClass, "testApp", () -> null);
+        
+        // Inject a mock transaction manager to avoid NullPointerException
+        handler.setTransactionManager(Mockito.mock(TransactionManager.class));
+        
         MyRepository proxy = (MyRepository) Proxy.newProxyInstance(
                 MyRepository.class.getClassLoader(),
                 new Class[]{MyRepository.class},

--- a/appserver/data/data-core/src/test/java/fish/payara/data/core/cdi/extension/RepositoryImplTest.java
+++ b/appserver/data/data-core/src/test/java/fish/payara/data/core/cdi/extension/RepositoryImplTest.java
@@ -1,0 +1,65 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/main/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.data.core.cdi.extension;
+
+import org.junit.Test;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Map;
+import java.util.List;
+
+public class RepositoryImplTest {
+
+    interface MyRepository {
+        void unsupportedMethod();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnsupportedMethodThrowsException() throws Throwable {
+        Map<Class<?>, List<QueryMetadata>> queriesPerEntityClass = Collections.emptyMap();
+        RepositoryImpl<MyRepository> handler = new RepositoryImpl<>(MyRepository.class, queriesPerEntityClass, "testApp", null);
+        MyRepository proxy = (MyRepository) Proxy.newProxyInstance(
+                MyRepository.class.getClassLoader(),
+                new Class[]{MyRepository.class},
+                handler);
+        
+        proxy.unsupportedMethod();
+    }
+}

--- a/appserver/data/data-core/src/test/java/fish/payara/data/core/cdi/extension/RepositoryImplTest.java
+++ b/appserver/data/data-core/src/test/java/fish/payara/data/core/cdi/extension/RepositoryImplTest.java
@@ -39,33 +39,81 @@
  */
 package fish.payara.data.core.cdi.extension;
 
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-import jakarta.transaction.TransactionManager;
+
 import java.lang.reflect.Proxy;
 import java.util.Collections;
-import java.util.Map;
-import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class RepositoryImplTest {
 
-    interface MyRepository {
+    private interface UnsupportedMethodRepository {
         void unsupportedMethod();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testUnsupportedMethodThrowsException() throws Throwable {
-        Map<Class<?>, List<QueryMetadata>> queriesPerEntityClass = Collections.emptyMap();
-        RepositoryImpl<MyRepository> handler = new RepositoryImpl<>(MyRepository.class, queriesPerEntityClass, "testApp", () -> null);
-        
-        // Inject a mock transaction manager to avoid NullPointerException
-        handler.setTransactionManager(Mockito.mock(TransactionManager.class));
-        
-        MyRepository proxy = (MyRepository) Proxy.newProxyInstance(
-                MyRepository.class.getClassLoader(),
-                new Class[]{MyRepository.class},
+    private UnsupportedMethodRepository proxy;
+
+    @Before
+    public void setUp() {
+        RepositoryImpl<UnsupportedMethodRepository> handler = new RepositoryImpl<>(
+                UnsupportedMethodRepository.class,
+                Collections.emptyMap(),
+                "testApp",
+                () -> null);
+
+        proxy = (UnsupportedMethodRepository) Proxy.newProxyInstance(
+                UnsupportedMethodRepository.class.getClassLoader(),
+                new Class<?>[]{UnsupportedMethodRepository.class},
                 handler);
-        
-        proxy.unsupportedMethod();
+    }
+
+    @Test
+    public void unsupportedMethodThrowsUnsupportedOperationExceptionWithMethodName() {
+        UnsupportedOperationException ex = assertThrows(
+                UnsupportedOperationException.class,
+                proxy::unsupportedMethod);
+
+        assertTrue(
+                "Exception message should identify the offending method, but was: " + ex.getMessage(),
+                ex.getMessage().contains("unsupportedMethod"));
+    }
+
+    @Test
+    public void toStringReturnsRepositoryInterfaceName() {
+        String text = proxy.toString();
+
+        assertTrue(
+                "toString should reference the repository interface, but was: " + text,
+                text.contains(UnsupportedMethodRepository.class.getName()));
+    }
+
+    @Test
+    public void hashCodeIsStableAndMatchesIdentityHashCode() {
+        assertEquals(System.identityHashCode(proxy), proxy.hashCode());
+        assertEquals(proxy.hashCode(), proxy.hashCode());
+    }
+
+    @Test
+    public void equalsIsReflexiveAndDistinguishesDifferentProxies() {
+        assertTrue("Proxy should be equal to itself", proxy.equals(proxy));
+        assertFalse("Proxy should not be equal to null", proxy.equals(null));
+
+        RepositoryImpl<UnsupportedMethodRepository> otherHandler = new RepositoryImpl<>(
+                UnsupportedMethodRepository.class,
+                Collections.emptyMap(),
+                "testApp",
+                () -> null);
+        UnsupportedMethodRepository otherProxy = (UnsupportedMethodRepository) Proxy.newProxyInstance(
+                UnsupportedMethodRepository.class.getClassLoader(),
+                new Class<?>[]{UnsupportedMethodRepository.class},
+                otherHandler);
+
+        assertNotEquals("Distinct proxies should not be equal", proxy, otherProxy);
     }
 }

--- a/appserver/tests/payara-samples/samples/data/src/main/java/fish/payara/samples/data/repo/UnsupportedRepo.java
+++ b/appserver/tests/payara-samples/samples/data/src/main/java/fish/payara/samples/data/repo/UnsupportedRepo.java
@@ -1,0 +1,57 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/main/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.samples.data.repo;
+
+import jakarta.data.repository.Repository;
+
+/**
+ * Repository with a method that cannot be implemented by the provider.
+ * This should trigger an UnsupportedOperationException when invoked.
+ */
+@Repository
+public interface UnsupportedRepo {
+
+    /**
+     * This method doesn't follow any convention and has no annotations.
+     * It also doesn't return an entity type, and the repository itself 
+     * has no primary entity type.
+     */
+    void doSomethingUnsupported(String name);
+}

--- a/appserver/tests/payara-samples/samples/data/src/test/java/fish/payara/samples/data/UnsupportedMethodTest.java
+++ b/appserver/tests/payara-samples/samples/data/src/test/java/fish/payara/samples/data/UnsupportedMethodTest.java
@@ -1,0 +1,80 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/main/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
+package fish.payara.samples.data;
+
+import fish.payara.samples.data.repo.UnsupportedRepo;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test case for invoking an unsupported Jakarta Data repository method.
+ */
+@RunWith(Arquillian.class)
+public class UnsupportedMethodTest {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "unsupported-method-test.war")
+                .addPackages(true, "fish.payara.samples.data.entity")
+                .addPackages(true, "fish.payara.samples.data.repo")
+                .addAsResource("META-INF/persistence.xml")
+                .addAsWebInfResource("WEB-INF/web.xml", "web.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private UnsupportedRepo unsupportedRepo;
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testInvokeUnsupportedMethodThrowsException() {
+        assertNotNull("UnsupportedRepo should be injected", unsupportedRepo);
+        
+        // This method cannot be implemented by the provider and should throw UnsupportedOperationException
+        unsupportedRepo.doSomethingUnsupported("test");
+    }
+}

--- a/appserver/tests/payara-samples/samples/data/src/test/java/fish/payara/samples/data/UnsupportedMethodTest.java
+++ b/appserver/tests/payara-samples/samples/data/src/test/java/fish/payara/samples/data/UnsupportedMethodTest.java
@@ -50,6 +50,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test case for invoking an unsupported Jakarta Data repository method.
@@ -60,21 +62,23 @@ public class UnsupportedMethodTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, "unsupported-method-test.war")
-                .addPackages(true, "fish.payara.samples.data.entity")
-                .addPackages(true, "fish.payara.samples.data.repo")
-                .addAsResource("META-INF/persistence.xml")
-                .addAsWebInfResource("WEB-INF/web.xml", "web.xml")
+                .addClass(UnsupportedRepo.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject
     private UnsupportedRepo unsupportedRepo;
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testInvokeUnsupportedMethodThrowsException() {
+    @Test
+    public void invokingUnsupportedMethodThrowsWithMethodName() {
         assertNotNull("UnsupportedRepo should be injected", unsupportedRepo);
-        
-        // This method cannot be implemented by the provider and should throw UnsupportedOperationException
-        unsupportedRepo.doSomethingUnsupported("test");
+
+        UnsupportedOperationException ex = assertThrows(
+                UnsupportedOperationException.class,
+                () -> unsupportedRepo.doSomethingUnsupported("test"));
+
+        assertTrue(
+                "Exception message should identify the offending method, but was: " + ex.getMessage(),
+                ex.getMessage().contains("doSomethingUnsupported"));
     }
 }


### PR DESCRIPTION
## Description
This PR addresses the issue where invoking an unsupported Jakarta Data repository method at runtime resulted in a `NullPointerException` instead of the expected `UnsupportedOperationException`.

Previously, if a repository method could not be mapped to a valid query during deployment (e.g., due to an unresolvable entity type or an invalid method signature), the method's metadata was not generated. This led to a null `QueryMetadata` being retrieved at runtime, causing an NPE when attempting to access its properties.

**Changes included:**
* **Exception Handling:** The `RepositoryImpl.invoke` method now checks if `queryMetadata` is null and throws `UnsupportedOperationException`.
* **Object Methods handling:** Included explicit handling for common `Object` methods (`toString`, `hashCode`, `equals`) to ensure the proxy behaves correctly.
* **Spec Compliance:** This ensures compliance with the Jakarta Data specification regarding methods that cannot be implemented at deployment time.

## Important Info
### Blockers
* N/A

## Testing
### New tests
* `appserver/data/data-core/src/test/java/fish/payara/data/core/cdi/extension/RepositoryImplTest.java`
* `appserver/tests/payara-samples/samples/data/src/main/java/fish/payara/samples/data/repo/UnsupportedRepo.java`
* `appserver/tests/payara-samples/samples/data/src/test/java/fish/payara/samples/data/UnsupportedMethodTest.java`

### Testing Performed
* **Unit Testing:** Created `RepositoryImplTest.java` to verify the core logic of `RepositoryImpl` throwing `UnsupportedOperationException` when metadata is missing.
* **Integration Testing:** Added an Arquillian-based test (`UnsupportedMethodTest.java`) to confirm that invoking an unsupported method on an injected repository correctly results in the expected exception.

### Testing Environment
- JDK: Zulu JDK 21
- OS: Windows 11
- Maven: 3.9.9

## Documentation
* N/A


