### PR TITLE
FISH-13170 OpenAPI TCK: PetStoreAppTest

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/OperationImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -345,32 +345,16 @@ public class OperationImpl extends ExtensibleImpl<Operation> implements Operatio
         exceptionTypes.add(type);
     }
 
-    public static void merge(Operation from, Operation to,
-            boolean override) {
+    public static void merge(Operation from, Operation to, boolean override) {
         if (from == null) {
             return;
         }
         to.setOperationId(mergeProperty(to.getOperationId(), from.getOperationId(), override));
-        to.setSummary(mergeProperty(to.getSummary(), from.getSummary(), override));
-        to.setDescription(mergeProperty(to.getDescription(), from.getDescription(), override));
-        to.setExtensions(mergeProperty(to.getExtensions(), from.getExtensions(), override));
         to.setDeprecated(mergeProperty(to.getDeprecated(), from.getDeprecated(), override));
-        // Handle @SecurityRequirement
-        if (from.getSecurity() != null) {
-            for (SecurityRequirement requirement : from.getSecurity()) {
-                if (requirement != null) {
-                    SecurityRequirement newRequirement = new SecurityRequirementImpl();
-                    SecurityRequirementImpl.merge(requirement, newRequirement);
-                    if (!to.getSecurity().contains(newRequirement)) {
-                        to.addSecurityRequirement(newRequirement);
-                    }
-                }
-            }
-        }
+        merge(from, to, override, null);
     }
 
-    public static void merge(Operation from, Operation to,
-            boolean override, ApiContext context) {
+    public static void merge(Operation from, Operation to, boolean override, ApiContext context) {
         if (from == null) {
             return;
         }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathItemImpl.java
@@ -50,6 +50,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import fish.payara.microprofile.openapi.impl.model.util.ModelUtils;
 import org.eclipse.microprofile.openapi.models.Operation;
 import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
@@ -386,4 +388,21 @@ public class PathItemImpl extends ExtensibleImpl<PathItem> implements PathItem {
         return hash;
     }
 
+    public static void merge (PathItem from, PathItem to, boolean override) {
+        ExtensibleImpl.merge(from, to, override);
+
+        to.setRef(ModelUtils.mergeProperty(from.getRef(), to.getRef(), override));
+        to.setSummary(ModelUtils.mergeProperty(from.getSummary(), to.getSummary(), override));
+        to.setDescription(ModelUtils.mergeProperty(from.getDescription(), to.getDescription(), override));
+        OperationImpl.merge(from.getGET(), to.getGET(), override);
+        OperationImpl.merge(from.getPUT(), to.getPUT(), override);
+        OperationImpl.merge(from.getPOST(), to.getPOST(), override);
+        OperationImpl.merge(from.getDELETE(), to.getDELETE(), override);
+        OperationImpl.merge(from.getOPTIONS(), to.getOPTIONS(), override);
+        OperationImpl.merge(from.getHEAD(), to.getHEAD(), override);
+        OperationImpl.merge(from.getPATCH(), to.getPATCH(), override);
+        OperationImpl.merge(from.getTRACE(), to.getTRACE(), override);
+        ModelUtils.mergeImmutableList(from.getServers(), to.getServers(), to::setServers);
+        ModelUtils.mergeImmutableList(from.getParameters(), to.getParameters(), to::setParameters);
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathsImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/PathsImpl.java
@@ -87,11 +87,11 @@ public class PathsImpl extends ExtensibleTreeMap<PathItem, Paths> implements Pat
         if (from == null || to == null) {
             return;
         }
-        from.getPathItems().entrySet().forEach(entry -> {
-            if (!to.hasPathItem(entry.getKey())) {
-                to.addPathItem(entry.getKey(), entry.getValue());
+        from.getPathItems().forEach((name, fromPathItem) -> {
+            if (!to.hasPathItem(name)) {
+                to.addPathItem(name, fromPathItem);
             } else {
-                ModelUtils.merge(entry.getValue(), to.getPathItem(entry.getKey()), override);
+                PathItemImpl.merge(fromPathItem, to.getPathItem(name), override);
             }
         });
     }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/LicenseImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/info/LicenseImpl.java
@@ -95,6 +95,7 @@ public class LicenseImpl extends ExtensibleImpl<License> implements License {
         }
         to.setName(mergeProperty(to.getName(), from.getName(), override));
         to.setUrl(mergeProperty(to.getUrl(), from.getUrl(), override));
+        to.setIdentifier(mergeProperty(to.getIdentifier(), from.getIdentifier(), override));
         to.setExtensions(mergeProperty(to.getExtensions(), from.getExtensions(), override));
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/EncodingImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -68,7 +68,12 @@ public class EncodingImpl extends ExtensibleImpl<Encoding> implements Encoding {
         HeaderImpl.createInstances(annotation, context).forEach(from::addHeader);
         String styleEnum = annotation.getValue("style", String.class);
         if (styleEnum != null) {
-            from.setStyle(Style.valueOf(styleEnum.toUpperCase()));
+            for (Style potentialStyle : Style.values()) {
+                if (potentialStyle.toString().equals(styleEnum)) {
+                    from.setStyle(potentialStyle);
+                    break;
+                }
+            }
         }
         from.setExplode(annotation.getValue("explode", Boolean.class));
         from.setAllowReserved(annotation.getValue("allowReserved", Boolean.class));

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/media/SchemaImpl.java
@@ -159,7 +159,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
     private Integer maxProperties;
     private Integer minProperties;
     private List<String> required = createList();
-    private List<SchemaType> type = createList();
+    private List<SchemaType> type;
     private Map<String, Schema> properties = createMap();
     private String description;
     private String format;
@@ -1439,7 +1439,7 @@ public class SchemaImpl extends ExtensibleImpl<Schema> implements Schema {
                     List<SchemaType> schemaType = ModelUtils.getSchemaType(implementationClass, context);
                     copyFrom = new SchemaImpl().type(schemaType);
                 }
-                if (schema.getType().contains(SchemaType.ARRAY)) {
+                if (schema.getType() != null && schema.getType().contains(SchemaType.ARRAY)) {
                     schema.setItems(new SchemaImpl());
                     ModelUtils.merge(copyFrom, schema.getItems(), false);
                 } else {

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecurityRequirementImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/model/security/SecurityRequirementImpl.java
@@ -40,23 +40,29 @@
 package fish.payara.microprofile.openapi.impl.model.security;
 
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.createList;
+import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.createMap;
 import static fish.payara.microprofile.openapi.impl.model.util.ModelUtils.readOnlyView;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import fish.payara.microprofile.openapi.api.visitor.ApiContext;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
 import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
 
-public class SecurityRequirementImpl extends LinkedHashMap<String, List<String>> implements SecurityRequirement {
+public class SecurityRequirementImpl implements SecurityRequirement {
 
     private static final long serialVersionUID = -677783376083861245L;
+
+    @JsonIgnore
+    private Map<String, List<String>> contents = createMap();
 
     public static SecurityRequirement createInstance(AnnotationModel annotation, ApiContext context) {
         SecurityRequirement from = new SecurityRequirementImpl();
@@ -83,43 +89,61 @@ public class SecurityRequirementImpl extends LinkedHashMap<String, List<String>>
         super();
     }
 
-    public SecurityRequirementImpl(Map<? extends String, ? extends List<String>> items) {
-        super(items);
-    }
-
     @Override
     public SecurityRequirement addScheme(String name, String item) {
-        this.put(name, item == null ? createList() : Arrays.asList(item));
-        return this;
+        if (item == null) {
+            return addScheme(name, createList());
+        }
+        return addScheme(name, List.of(item));
     }
 
     @Override
     public SecurityRequirement addScheme(String name, List<String> item) {
-        this.put(name, item == null ? createList() : item);
+        if (item == null) {
+            item = createList();
+        }
+        if (contents == null) {
+            contents = createMap();
+        }
+
+        contents.put(name, item);
         return this;
     }
 
     @Override
     public SecurityRequirement addScheme(String name) {
-        this.put(name, createList());
-        return this;
+        return addScheme(name, createList());
     }
 
     @Override
     public void removeScheme(String securitySchemeName) {
-        this.remove(securitySchemeName);
+        if (contents != null) {
+            contents.remove(securitySchemeName);
+        }
     }
 
     @Override
+    @JsonAnyGetter
+    @JsonInclude(value = JsonInclude.Include.NON_ABSENT, content = JsonInclude.Include.NON_ABSENT)
     public Map<String, List<String>> getSchemes() {
-        return readOnlyView(this);
+        return readOnlyView(contents);
     }
 
     @Override
     public void setSchemes(Map<String, List<String>> items) {
-        clear();
+        contents = createMap();
         if (items != null) {
-            putAll(items);
+            contents.putAll(items);
+        }
+    }
+
+    @JsonAnySetter
+    public void addAnyScheme(String name, Object item) {
+        if (item instanceof String schemeName) {
+            addScheme(name, schemeName);
+        }
+        else if (item instanceof List<?> schemeNames) {
+            addScheme(name, schemeNames.stream().map(Object::toString).toList());
         }
     }
 

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/ApplicationProcessor.java
@@ -73,6 +73,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.logging.Level;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
@@ -82,7 +84,6 @@ import java.util.stream.Collectors;
 
 import fish.payara.microprofile.openapi.util.BeanValidationType;
 import jakarta.validation.groups.Default;
-import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.FormParam;
@@ -183,17 +184,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             return;
         }
 
-        // Get or create the path item
-        PathItem pathItem = context.getApi().getPaths().getPathItems().getOrDefault(context.getPath(), new PathItemImpl());
-        context.getApi().getPaths().addPathItem(context.getPath(), pathItem);
-
-        OperationImpl operation = new OperationImpl();
-        pathItem.setGET(operation);
-        operation.setOperationId(element.getName());
-        operation.setMethod(HttpMethod.GET);
-
-        // Add the default response
-        insertDefaultResponse(context, operation, element);
+        visitJaxRSMethodHandler(get, element, context, HttpMethod.GET, PathItem::getGET, PathItem::setGET);
     }
 
     @Override
@@ -202,20 +193,11 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             return;
         }
 
-        // Get or create the path item
-        PathItem pathItem = context.getApi().getPaths().getPathItems().getOrDefault(context.getPath(), new PathItemImpl());
-        context.getApi().getPaths().addPathItem(context.getPath(), pathItem);
-
-        OperationImpl operation = new OperationImpl();
-        pathItem.setPOST(operation);
-        operation.setOperationId(element.getName());
-        operation.setMethod(HttpMethod.POST);
+        OperationImpl operation = visitJaxRSMethodHandler(post, element, context,
+                HttpMethod.POST, PathItem::getPOST, PathItem::setPOST);
 
         // Add the default request
         insertDefaultRequestBody(context, operation, element);
-
-        // Add the default response
-        insertDefaultResponse(context, operation, element);
     }
 
     @Override
@@ -224,20 +206,11 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             return;
         }
 
-        // Get or create the path item
-        PathItem pathItem = context.getApi().getPaths().getPathItems().getOrDefault(context.getPath(), new PathItemImpl());
-        context.getApi().getPaths().addPathItem(context.getPath(), pathItem);
-
-        OperationImpl operation = new OperationImpl();
-        pathItem.setPUT(operation);
-        operation.setOperationId(element.getName());
-        operation.setMethod(HttpMethod.PUT);
+        OperationImpl operation = visitJaxRSMethodHandler(put, element, context,
+                HttpMethod.PUT, PathItem::getPUT, PathItem::setPUT);
 
         // Add the default request
         insertDefaultRequestBody(context, operation, element);
-
-        // Add the default response
-        insertDefaultResponse(context, operation, element);
     }
 
     @Override
@@ -246,17 +219,7 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             return;
         }
 
-        // Get or create the path item
-        PathItem pathItem = context.getApi().getPaths().getPathItems().getOrDefault(context.getPath(), new PathItemImpl());
-        context.getApi().getPaths().addPathItem(context.getPath(), pathItem);
-
-        OperationImpl operation = new OperationImpl();
-        pathItem.setDELETE(operation);
-        operation.setOperationId(element.getName());
-        operation.setMethod(HttpMethod.DELETE);
-
-        // Add the default response
-        insertDefaultResponse(context, operation, element);
+        visitJaxRSMethodHandler(delete, element, context, HttpMethod.DELETE, PathItem::getDELETE, PathItem::setDELETE);
     }
 
     @Override
@@ -265,20 +228,11 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             return;
         }
 
-        // Get or create the path item
-        PathItem pathItem = context.getApi().getPaths().getPathItems().getOrDefault(context.getPath(), new PathItemImpl());
-        context.getApi().getPaths().addPathItem(context.getPath(), pathItem);
-
-        OperationImpl operation = new OperationImpl();
-        pathItem.setHEAD(operation);
-        operation.setOperationId(element.getName());
-        operation.setMethod(HttpMethod.HEAD);
+        OperationImpl operation = visitJaxRSMethodHandler(head, element, context,
+                HttpMethod.HEAD, PathItem::getHEAD, PathItem::setHEAD);
 
         // Add the default request
         insertDefaultRequestBody(context, operation, element);
-
-        // Add the default response
-        insertDefaultResponse(context, operation, element);
     }
 
     @Override
@@ -287,20 +241,11 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             return;
         }
 
-        // Get or create the path item
-        PathItem pathItem = context.getApi().getPaths().getPathItems().getOrDefault(context.getPath(), new PathItemImpl());
-        context.getApi().getPaths().addPathItem(context.getPath(), pathItem);
-
-        OperationImpl operation = new OperationImpl();
-        pathItem.setOPTIONS(operation);
-        operation.setOperationId(element.getName());
-        operation.setMethod(HttpMethod.OPTIONS);
+        OperationImpl operation = visitJaxRSMethodHandler(options, element, context,
+                HttpMethod.OPTIONS, PathItem::getOPTIONS, PathItem::setOPTIONS);
 
         // Add the default request
         insertDefaultRequestBody(context, operation, element);
-
-        // Add the default response
-        insertDefaultResponse(context, operation, element);
     }
 
     @Override
@@ -309,20 +254,11 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
             return;
         }
 
-        // Get or create the path item
-        PathItem pathItem = context.getApi().getPaths().getPathItems().getOrDefault(context.getPath(), new PathItemImpl());
-        context.getApi().getPaths().addPathItem(context.getPath(), pathItem);
-
-        OperationImpl operation = new OperationImpl();
-        pathItem.setPATCH(operation);
-        operation.setOperationId(element.getName());
-        operation.setMethod(HttpMethod.PATCH);
+        OperationImpl operation = visitJaxRSMethodHandler(patch, element, context,
+                HttpMethod.PATCH, PathItem::getPATCH, PathItem::setPATCH);
 
         // Add the default request
         insertDefaultRequestBody(context, operation, element);
-
-        // Add the default response
-        insertDefaultResponse(context, operation, element);
     }
 
     @Override
@@ -1815,4 +1751,25 @@ public class ApplicationProcessor implements OASProcessor, ApiVisitor {
         return false;
     }
 
+    private OperationImpl visitJaxRSMethodHandler(AnnotationModel model, MethodModel element, ApiContext context,
+              String httpMethod, Function<PathItem, Operation> getter, BiConsumer<PathItem, Operation> setter) {
+        // Get or create the path item
+        PathItem pathItem = context.getApi().getPaths().getPathItems().getOrDefault(context.getPath(), new PathItemImpl());
+        context.getApi().getPaths().addPathItem(context.getPath(), pathItem);
+
+        OperationImpl operation = new OperationImpl();
+        operation.setOperationId(element.getName());
+        operation.setMethod(httpMethod);
+
+        Operation existing = getter.apply(pathItem);
+        if (existing != null) {
+            OperationImpl.merge(existing, operation, true);
+        }
+        setter.accept(pathItem, operation);
+
+        // Add the default response
+        insertDefaultResponse(context, operation, element);
+
+        return operation;
+    }
 }

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/ObjectMapperFactory.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/ObjectMapperFactory.java
@@ -87,7 +87,7 @@ public final class ObjectMapperFactory {
     public static <T extends Constructible> ObjectMapper create(JsonFactory factory) {
         ObjectMapper mapper = new ObjectMapper(factory);
         mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-        mapper.setDefaultPropertyInclusion(Include.NON_ABSENT);
+        mapper.setDefaultPropertyInclusion(Include.NON_EMPTY);
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);

--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/ObjectMapperFactory.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/rest/app/provider/ObjectMapperFactory.java
@@ -87,7 +87,7 @@ public final class ObjectMapperFactory {
     public static <T extends Constructible> ObjectMapper create(JsonFactory factory) {
         ObjectMapper mapper = new ObjectMapper(factory);
         mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-        mapper.setSerializationInclusion(Include.NON_EMPTY);
+        mapper.setDefaultPropertyInclusion(Include.NON_ABSENT);
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-13170
  - Adds the `identifier` field to the merge logic of `LicenseImpl`, which was not there prior.
  - Changes the default value of `SchemaImpl`'s `type` to `null` instead of an empty list to fit its existing null-handling.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
This branch was built on top of #8108 and must be reviewed after it because it contains commits from it.

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
[Jenkins](https://jenkins.payara.fish/view/TCKs/job/TCKs/job/MP-TCKs/3725/testReport/org.eclipse.microprofile.openapi.tck/PetStoreAppTest/)

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
