### PR TITLE
FISH-13437 FISH-13441 Upgrade Docker JDKs

### DIFF
--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -57,7 +57,7 @@
         <docker.noCache>true</docker.noCache>
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
-        <docker.jdk21.tag>21.0.10-jdk</docker.jdk21.tag>
+        <docker.jdk21.tag>21.0.11-jdk</docker.jdk21.tag>
         <docker.jdk25.tag>25.0.2-jdk</docker.jdk25.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -

--- a/appserver/extras/docker-images/pom.xml
+++ b/appserver/extras/docker-images/pom.xml
@@ -58,7 +58,7 @@
 
         <docker.java.repository>azul/zulu-openjdk</docker.java.repository>
         <docker.jdk21.tag>21.0.11-jdk</docker.jdk21.tag>
-        <docker.jdk25.tag>25.0.2-jdk</docker.jdk25.tag>
+        <docker.jdk25.tag>25.0.3-jdk</docker.jdk25.tag>
 
         <!-- List of platform architectures which we wish to build Docker images for -
                 shouldn't have anything not provided as an option by ${docker.java.repository}.


### PR DESCRIPTION
## Description
Upgrades the Docker JDKs to 21.0.11 and 25.0.3

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Built the Docker images and ran the unit tests

### Testing Environment
Windows 11

## Documentation
N/A

## Notes for Reviewers
None
