### PR TITLE
FISH-12800 Dont write standard metric scopes multiple times

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/MetricsWriterImpl.java
+++ b/appserver/payara-appserver-modules/microprofile/metrics/src/main/java/fish/payara/microprofile/metrics/writer/MetricsWriterImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2020-2023 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -97,17 +97,52 @@ public class MetricsWriterImpl implements MetricsWriter {
     }
 
     @Override
-    public void write() throws IOException {
-        MetricExporter exporter = this.exporter;
+    public void write() {
+        final MetricExporter exporter = this.exporter;
+
+        // Write standard scopes
+        writeScope(exporter, MetricRegistry.BASE_SCOPE);
+        writeScope(exporter, MetricRegistry.VENDOR_SCOPE);
+        writeScope(exporter, MetricRegistry.APPLICATION_SCOPE);
+
+        if (contextNames == null || getContextByName == null) {
+            exporter.exportComplete();
+            return;
+        }
+
         for (String contextName : contextNames) {
+            if (contextName == null) {
+                continue;
+            }
+
             MetricsContext context = getContextByName.apply(contextName);
+            if (context == null) {
+                continue;
+            }
+
             ConcurrentMap<String, MetricRegistry> registries = context.getRegistries();
-            for(String scope:registries.keySet()) {
-                exporter = exporter.in(scope);
-                writeRegistries(exporter, scope);
+            if (registries == null || registries.isEmpty()) {
+                continue;
+            }
+
+            for (String scope : registries.keySet()) {
+                if (scope == null ||
+                        MetricRegistry.BASE_SCOPE.equals(scope) ||
+                        MetricRegistry.VENDOR_SCOPE.equals(scope) ||
+                        MetricRegistry.APPLICATION_SCOPE.equals(scope)) {
+                    continue;
+                }
+
+                writeScope(exporter, scope);
             }
         }
+
         exporter.exportComplete();
+    }
+
+    private void writeScope(MetricExporter exporter, String scope) {
+        MetricExporter scopedExporter = exporter.in(scope);
+        writeRegistries(scopedExporter, scope);
     }
 
     private void writeRegistries(MetricExporter exporter, String scope) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
With the addition of custom scopes, the standard scopes were incorrectly printed every time for each application context.

First, we can print the standard scopes and then loop through each context to retrieve and print the custom scopes, ensuring that they are not the standard scopes already printed.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Deployed application in JIRA ticket and verified metrics weren't duplicated.
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.9, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.9-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "15.7.3", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a