### PR TITLE
FISH-13447 Resolve NPE when access log log-to-console is enabled for …

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2019] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2026 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.web;
 
@@ -58,6 +58,7 @@ import org.glassfish.web.LogFacade;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -626,7 +627,8 @@ public final class PEAccessLogValve
                 charBuffer.flip();
                 String bufString = charBuffer.toString();
                 if (accessLogToConsole && !bufString.isEmpty()) {
-                    logManager.getOutStream().print(bufString.replaceAll("(?m)^", "AccessLog: "));
+                    PrintStream outStream = logManager != null ? logManager.getOutStream() : System.out;
+                    outStream.print(bufString.replaceAll("(?m)^", "AccessLog: "));
                 }
                 ByteBuffer byteBuffer =
                     ByteBuffer.wrap(bufString.getBytes(Charset.defaultCharset()));


### PR DESCRIPTION
…Micro

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
 When PEAccessLogValve is created, it immediately tries to grab a LogManager from the HK2 service locator:                                                          private final LogManager logManager = Globals.get(LogManager.class);                                                                                                       

The only implementation of LogManager is LogManagerService, but in Payara Micro, EmbeddedInhabitantsParser explicitly filters it out during HK2 startup population. So the lookup returns null.      
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Followed steps in JIRA
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.9, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.9-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "15.7.3", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a