### PR TITLE
Fish 13421 poc adding messages to change broker password

### DIFF
--- a/appserver/admingui/common/src/main/resources/commonTask.jsf
+++ b/appserver/admingui/common/src/main/resources/commonTask.jsf
@@ -106,15 +106,8 @@
                 <!beforeCreate
                     setSessionAttribute(key="gf_application_list_page" value="/common/applications/applications.jsf");
                     setSessionAttribute(key="gf_application_cancel_page" value="/common/commonTask.jsf");
-                    getRequestValue(key="configName" value=>$page{configName});
-                    setPageSessionAttribute(key="childType" value="jms-host");
-                    setPageSessionAttribute(key="parentUrl", value="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/jms-service");
-                    setPageSessionAttribute(key="selfUrl", value="#{pageSession.parentUrl}/#{pageSession.childType}/default_JMS_host");
-                    setPageSessionAttribute(key="rest-api" value="true");
-                    gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}.json", valueMap="#{pageSession.valueMap}");
                 />
             </event>
-              <sun:staticText style="color: red;" text="Your default broker instance from OpenMQ is using default admin password, we recommend you to change using the tool imqusermgr from OpenMQ. Also consider to change admin password for JMS configuration on the server using the asadmin set command to change the property server-config.jms-service.jms-host.default_JMS_host.admin-password" rendered="#{pageSession.valueMap['adminPassword'] == 'admin'}"/>
         </sun:commonTasksGroup>
 
         <sun:commonTasksGroup id="administration" title="$resource{i18n.commonTasks.group.Administration}" >

--- a/appserver/admingui/common/src/main/resources/commonTask.jsf
+++ b/appserver/admingui/common/src/main/resources/commonTask.jsf
@@ -106,8 +106,15 @@
                 <!beforeCreate
                     setSessionAttribute(key="gf_application_list_page" value="/common/applications/applications.jsf");
                     setSessionAttribute(key="gf_application_cancel_page" value="/common/commonTask.jsf");
+                    getRequestValue(key="configName" value=>$page{configName});
+                    setPageSessionAttribute(key="childType" value="jms-host");
+                    setPageSessionAttribute(key="parentUrl", value="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/jms-service");
+                    setPageSessionAttribute(key="selfUrl", value="#{pageSession.parentUrl}/#{pageSession.childType}/default_JMS_host");
+                    setPageSessionAttribute(key="rest-api" value="true");
+                    gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}.json", valueMap="#{pageSession.valueMap}");
                 />
             </event>
+              <sun:staticText style="color: red;" text="Your default broker instance from OpenMQ is using default admin password, we recommend you to change using the tool imqusermgr from OpenMQ. Also consider to change admin password for JMS configuration on the server using the asadmin set command to change the property server-config.jms-service.jms-host.default_JMS_host.admin-password" rendered="#{pageSession.valueMap['adminPassword'] == 'admin'}"/>
         </sun:commonTasksGroup>
 
         <sun:commonTasksGroup id="administration" title="$resource{i18n.commonTasks.group.Administration}" >

--- a/appserver/admingui/jms-plugin/src/main/resources/jmsHostEdit.jsf
+++ b/appserver/admingui/jms-plugin/src/main/resources/jmsHostEdit.jsf
@@ -61,9 +61,11 @@
             setPageSessionAttribute(key="selfUrl", value="#{pageSession.parentUrl}/#{pageSession.childType}/#{pageSession.name}");
             setPageSessionAttribute(key="rest-api" value="true");
             gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}.json", valueMap="#{pageSession.valueMap}");
+            setPageSessionAttribute(key="errorDefaultPassBroker" value="$resource{i18njms.defaultAdmin.usingDefaultBrokerPass}");
         />
     </event>
     <sun:form id="propertyForm" autoComplete="off">
+        <sun:alert type="error" summary="Admin default broker credentials used" detail="#{pageSession.errorDefaultPassBroker}" rendered="#{pageSession.valueMap['adminPassword'] == 'admin'}"/>
 #include "/jms/jmsHost.inc"
         <sun:hidden id="helpKey" value="$resource{helpjms.jmsHostEdit}" />
     </sun:form>

--- a/appserver/admingui/jms-plugin/src/main/resources/jmsHostEdit.jsf
+++ b/appserver/admingui/jms-plugin/src/main/resources/jmsHostEdit.jsf
@@ -65,7 +65,7 @@
         />
     </event>
     <sun:form id="propertyForm" autoComplete="off">
-        <sun:alert type="error" summary="Admin default broker credentials used" detail="#{pageSession.errorDefaultPassBroker}" rendered="#{pageSession.valueMap['adminPassword'] == 'admin'}"/>
+        <sun:alert type="warning" summary="Admin default broker credentials used" detail="#{pageSession.errorDefaultPassBroker}" rendered="#{pageSession.valueMap['adminPassword'] == 'admin'}"/>
 #include "/jms/jmsHost.inc"
         <sun:hidden id="helpKey" value="$resource{helpjms.jmsHostEdit}" />
     </sun:form>

--- a/appserver/admingui/jms-plugin/src/main/resources/org/glassfish/jms/admingui/Strings.properties
+++ b/appserver/admingui/jms-plugin/src/main/resources/org/glassfish/jms/admingui/Strings.properties
@@ -116,6 +116,7 @@ jmsHosts.ListPageTitle=JMS Hosts
 jmsHosts.ListPageHelp=The Java Message Service (JMS) host specifies the system where the JMS service is running. Click New to create a new JMS host. Click the name of a JMS host to modify its properties.
 newJmsHost.NewJmsHost=New JMS Host
 newJmsHost.NewPageHelp=The Java Message Service (JMS) host specifies the system where the JMS service is running.
+defaultAdmin.usingDefaultBrokerPass=Your default broker instance from OpenMQ is using default admin password, it is recommended that you change it using the imqusermgr tool from OpenMQ. When doing so, also update the JMS configuration of the server using the asadmin set command to change the property server-config.jms-service.jms-host.default_JMS_host.admin-password
 
 ## JMS Resources
 jmsResources.pageTitle=JMS Resources

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/JMSLoggerInfo.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/JMSLoggerInfo.java
@@ -235,4 +235,10 @@ public class JMSLoggerInfo {
             action = "unknown"
     )
     public static final String JMSRA_UPGRADE_CHECK_FAILED = LOGMSG_PREFIX + "-00027";
+    
+    @LogMessageInfo(message = "Your default broker instance from OpenMQ is using default admin password, " +
+            "it is recommended that you change it using the imqusermgr tool from OpenMQ. " +
+            "When doing so, also update the JMS configuration of the server using the asadmin set command to change " +
+            "the property server-config.jms-service.jms-host.default_JMS_host.admin-password")
+    public static final String JMSRA_UPGRADE_DEFAULT_BROKER_PASSWORD = LOGMSG_PREFIX + "-00028";
 }

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
@@ -1017,6 +1017,10 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
             brkrPort = brokerPort;
             String adminUserName = jmsHost.getAdminUserName();
             String adminPassword = JmsRaUtil.getUnAliasedPwd(jmsHost.getAdminPassword());
+            
+            if (adminPassword.equals("admin")) {
+                _logger.log(Level.WARNING, "Your default broker instance from OpenMQ is using default admin password, we recommend you to change using the tool imqusermgr from OpenMQ. Also consider to change admin password for JMS configuration on the server using the asadmin set command to change the property server-config.jms-service.jms-host.default_JMS_host.admin-password");
+            }
             List jmsHostProps= getJmsService().getProperty();
 
             String username = null;

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
@@ -1019,7 +1019,7 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
             String adminPassword = JmsRaUtil.getUnAliasedPwd(jmsHost.getAdminPassword());
             
             if (adminPassword.equals("admin")) {
-                _logger.log(Level.WARNING, "Your default broker instance from OpenMQ is using default admin password, we recommend you to change using the tool imqusermgr from OpenMQ. Also consider to change admin password for JMS configuration on the server using the asadmin set command to change the property server-config.jms-service.jms-host.default_JMS_host.admin-password");
+                _logger.log(Level.WARNING, JMSLoggerInfo.JMSRA_UPGRADE_DEFAULT_BROKER_PASSWORD);
             }
             List jmsHostProps= getJmsService().getProperty();
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
POC to show an strategy to indicate if you are using default admin credentials
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a feature to indicate on logs and the admin home a message to change the current default credentials used on the default OpenMQ broker instance
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
