### PR TITLE
FISH-13161 FilterTest

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/FilterProcessor.java
+++ b/appserver/payara-appserver-modules/microprofile/openapi/src/main/java/fish/payara/microprofile/openapi/impl/processor/FilterProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2018-2023] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -45,10 +45,13 @@ import fish.payara.microprofile.openapi.impl.model.OpenAPIImpl;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import static java.util.logging.Level.WARNING;
+
+import java.util.Set;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
@@ -72,6 +75,7 @@ import org.eclipse.microprofile.openapi.models.tags.Tag;
 public class FilterProcessor implements OASProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(FilterProcessor.class.getName());
+    private final Set<Object> filterCache = new HashSet<>();
 
     /**
      * The OASFilter implementation provided by the application.
@@ -105,79 +109,85 @@ public class FilterProcessor implements OASProcessor {
 
     @SuppressWarnings("unchecked")
     private Object filterObject(Object object) {
-        if (object != null) {
+        if (object == null) {
+            return null;
+        }
 
-            // If the object is a map
-            if (object instanceof Map) {
-                List<Object> resultsToRemove = new ArrayList<>();
-
-                // Filter each object in the value list
-                for (Object item : Map.class.cast(object).values()) {
-                    Object result = filterObject(item);
-
-                    if (result == null) {
-                        resultsToRemove.add(item);
-                    }
-                }
-
-                // Remove all the null values
-                for (Object removeTarget : resultsToRemove) {
-                    Map.class.cast(object).values().remove(removeTarget);
-                }
-            }
-
-            // If the object is iterable
-            if (object instanceof Iterable) {
-                List<Object> resultsToRemove = new ArrayList<>();
-
-                // Filter each object in the list
-                for (Object item : Iterable.class.cast(object)) {
-                    Object result = filterObject(item);
-
-                    if (result == null) {
-                        resultsToRemove.add(item);
-                    }
-                }
-
-                for (Object removeTarget : resultsToRemove) {
-                    Iterator<Object> iterator = Iterable.class.cast(object).iterator();
-                    while (iterator.hasNext()) {
-                        if (iterator.next().equals(removeTarget)) {
-                            iterator.remove();
-                        }
-                    }
-                }
-            }
-
-            // If the object is a model item
-            Package pkg = object.getClass().getPackage();
-            if (pkg != null && pkg.getName().startsWith(OpenAPIImpl.class.getPackage().getName())) {
-
-                // Visit each field
-                for (Field field : object.getClass().getDeclaredFields()) {
-                    try {
-                        field.setAccessible(true);
-                        Object fieldValue = field.get(object);
-
-                        // Filter the object
-                        Object result = filterObject(fieldValue);
-
-                        // Remove it if it's null
-                        if (result == null) {
-                            field.set(object, null);
-                        }
-                    } catch (IllegalArgumentException | IllegalAccessException ex) {
-                        LOGGER.log(WARNING, "Unable to access field in OpenAPI model.", ex);
-                    }
-                }
-
-                // Visit the object
-                object = visitObject(object);
-            }
-
+        // Prevent infinite recursion for circular references
+        if (filterCache.contains(object)) {
             return object;
         }
-        return null;
+        filterCache.add(object);
+
+        // If the object is a map
+        if (object instanceof Map) {
+            List<Object> resultsToRemove = new ArrayList<>();
+
+            // Filter each object in the value list
+            for (Object item : Map.class.cast(object).values()) {
+                Object result = filterObject(item);
+
+                if (result == null) {
+                    resultsToRemove.add(item);
+                }
+            }
+
+            // Remove all the null values
+            for (Object removeTarget : resultsToRemove) {
+                Map.class.cast(object).values().remove(removeTarget);
+            }
+        }
+
+        // If the object is iterable
+        if (object instanceof Iterable) {
+            List<Object> resultsToRemove = new ArrayList<>();
+
+            // Filter each object in the list
+            for (Object item : Iterable.class.cast(object)) {
+                Object result = filterObject(item);
+
+                if (result == null) {
+                    resultsToRemove.add(item);
+                }
+            }
+
+            for (Object removeTarget : resultsToRemove) {
+                Iterator<Object> iterator = Iterable.class.cast(object).iterator();
+                while (iterator.hasNext()) {
+                    if (iterator.next().equals(removeTarget)) {
+                        iterator.remove();
+                    }
+                }
+            }
+        }
+
+        // If the object is a model item
+        Package pkg = object.getClass().getPackage();
+        if (pkg != null && pkg.getName().startsWith(OpenAPIImpl.class.getPackage().getName())) {
+            // Visit each field
+            for (Field field : object.getClass().getDeclaredFields()) {
+                try {
+                    field.setAccessible(true);
+                    Object fieldValue = field.get(object);
+
+                    // Filter the object
+                    Object result = filterObject(fieldValue);
+
+                    // Remove it if it's null
+                    if (result == null) {
+                        field.set(object, null);
+                    }
+                } catch (IllegalArgumentException | IllegalAccessException ex) {
+                    LOGGER.log(WARNING, "Unable to access field in OpenAPI model.", ex);
+                }
+            }
+
+            // Visit the object
+            object = visitObject(object);
+        }
+
+        filterCache.remove(object);
+        return object;
     }
 
     private Object visitObject(Object object) {


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-13161
  - Adds a cache to `FilterProcessor` to prevent infinite recursion. The TCK failures were caused by server errors caused by said recursion.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
[Jenkins](https://jenkins.payara.fish/view/TCKs/job/TCKs/job/MP-TCKs/4180/testReport/org.eclipse.microprofile.openapi.tck/FilterTest/)

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
