### PR TITLE
FISH-12270 Resolve misleading log entries with virtual server properties 

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebContainer.java
@@ -1299,6 +1299,7 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         // Initialize the docroot
         VirtualServer virtualServer = (VirtualServer) _embedded.createHost(virtualServerId, virtualServerBean, docroot, virtualServerBean.getLogFile(), mimeMap);
 
+        virtualServer.setServerContext(getServerContext());
         virtualServer.configureState();
         virtualServer.configureRemoteAddressFilterValve();
         virtualServer.configureRemoteHostFilterValve();
@@ -1306,7 +1307,6 @@ public class WebContainer implements org.glassfish.api.container.Container, Post
         virtualServer.configureRedirect();
         virtualServer.configureErrorPage();
         virtualServer.configureErrorReportValve();
-        virtualServer.setServerContext(getServerContext());
         virtualServer.setServerConfig(serverConfig);
         virtualServer.setGrizzlyService(grizzlyService);
         virtualServer.setWebContainer(this);

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -1419,10 +1419,26 @@ public class WebModule extends PwcWebModule implements Context {
             parseAlternateDocBase(name, value);
         } else if(CACHE_TTL_APP_PROPERTY.equalsIgnoreCase(name)) {
             setCacheTTL(Integer.parseInt(value));
-        } else if(name.startsWith("listener_") ||
-            name.startsWith("send-error_")) {
-            // do nothing; these properties are dealt with
+        } else if(name.startsWith("listener_")) {
+            // do nothing; the listener_ property is dealt with
             // in configureCatalinaProperties()
+        } else if ("allowRemoteAddress".equalsIgnoreCase(name) ||
+                "denyRemoteAddress".equalsIgnoreCase(name) ||
+                "allowRemoteHost".equalsIgnoreCase(name) ||
+                "denyRemoteHost".equalsIgnoreCase(name) ||
+                "contextXmlDefault".equalsIgnoreCase(name) ||
+                "sso-max-inactive-seconds".equalsIgnoreCase(name) ||
+                "sso-reap-interval-seconds".equalsIgnoreCase(name) ||
+                "errorReportValve".equalsIgnoreCase(name) ||
+                "authRealm".equalsIgnoreCase(name) ||
+                "setCacheControl".equalsIgnoreCase(name) ||
+                "accessLogBufferSize".equalsIgnoreCase(name) ||
+                "accessLogWriteInterval".equalsIgnoreCase(name) ||
+                "accessLogPrefix".equalsIgnoreCase(name) ||
+                "accessLoggingEnabled".equalsIgnoreCase(name) ||
+                name.startsWith("send-error_") ||
+                name.startsWith("redirect_")) {
+            // do nothing; these properties are handled at the VirtualServer level
         } else {
             Object[] params = {name, value};
             logger.log(Level.WARNING, LogFacade.INVALID_PROPERTY,

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationConfigListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationConfigListener.java
@@ -54,7 +54,6 @@ import com.sun.enterprise.admin.report.HTMLActionReporter;
 import java.beans.PropertyChangeEvent;
 import java.util.Calendar;
 import java.util.List;
-import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jakarta.inject.Inject;
@@ -162,7 +161,9 @@ public class ApplicationConfigListener implements TransactionListener, PostConst
                         appName = ((ApplicationRef)parent).getRef();
                         propertyName = event.getPropertyName();
                     } else if (parent instanceof Property) {
-                        appName = ((Property)parent).getParent(Application.class).getName();
+                        if (((Property) parent).getParent() instanceof Application grandparent) {
+                            appName = grandparent.getName();
+                        }
                         propertyName = ((Property)parent).getName();
                     }
                     // if it's not a user application, let's not do


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Fix misleading warnings and NPE when VirtualServer properties are set

When VirtualServer properties such as allowRemoteAddress or redirect_* were configured, an incorrect INVALID_PROPERTY warning was logged even though the properties were being applied correctly. This was because WebModule.configureProperty didn't account for properties owned by VirtualServer itself.                                                  
                                                            
Additionally, having a redirect_ property caused an NPE on startup because configureRedirect was called before setServerContext in WebContainer.createHost, causing a null serverContext when the pipeline was switched.             
                                                                                                                                                                                
Also fixes an IllegalArgumentException in ApplicationConfigListener due to an incorrect proxy type.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Followed steps in reproducer.

Additionally, swapped the virtual server with the following:
```
<virtual-server network-listeners="http-listener-1,http-listener-2" id="server" >
          <property name="sso-max-inactive-seconds" value="1000"></property>
          <property name="sso-reap-interval-seconds" value="1000"></property>
          <property name="setCacheControl" value="no-cache"></property>
          <property name="accessLoggingEnabled" value="true"></property>
          <property name="accessLogBufferSize" value="10000"></property>
          <property name="accessLogWriteInterval" value="1"></property>
          <property name="accessLogPrefix" value="test"></property>
          <property name="denyRemoteAddress" value="2.2.2.2"></property>
          <property name="denyRemoteHost" value="1.1.1.1"></property>
          <property name="authRealm" value="file"></property>
          <property name="securePagesWithPragma" value="false"></property>
          <property name="contextXmlDefault" value="/test/"></property>
          <property name="allowLinking" value="false"></property>
          <property name="alternatedocroot_1" value="from=/*.jpg dir=/tmp"></property>
          <property name="send-error_1" value="code=500 path=/error.html reason=Server-Error"></property>
          <property name="redirect_1" value="from=/old url-prefix=/new"></property>
          <property name="wrong" value="wrong"></property>
        </virtual-server>
```

With the above virtual server, 3 warnings messages are expected 

```
[#|2026-05-05T14:42:05.285+0100|WARNING|Payara 7.2026.5|jakarta.enterprise.web|_ThreadID=52;_ThreadName=RunLevelControllerThread-1777988523046;_TimeMillis=1777988525285;_LevelValue=900;_MessageID=AS-WEB-GLUE-00237;|
  URL pattern /*.jpg for alternate docbase is invalid|#]

[#|2026-05-05T14:42:05.285+0100|WARNING|Payara 7.2026.5|jakarta.enterprise.web|_ThreadID=52;_ThreadName=RunLevelControllerThread-1777988523046;_TimeMillis=1777988525285;_LevelValue=900;_MessageID=AS-WEB-GLUE-00241;|
  Ignoring invalid property wrong = wrong|#]

[#|2026-05-05T14:42:05.285+0100|WARNING|Payara 7.2026.5|jakarta.enterprise.web|_ThreadID=52;_ThreadName=RunLevelControllerThread-1777988523046;_TimeMillis=1777988525285;_LevelValue=900;_MessageID=AS-WEB-GLUE-00237;|
  URL pattern /*.jpg for alternate docbase is invalid|#]
```
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.9, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.9-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "15.7.3", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a