### PR TITLE
FISH-13091 Assorted Deployment Group Fixes

### DIFF
--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/jws/AppClientHTTPAdapter.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/jws/AppClientHTTPAdapter.java
@@ -398,23 +398,16 @@ public class AppClientHTTPAdapter extends RestrictedContentAdapter {
     }
 
     /**
-     * Returns the expression "-targetserver=host:port[,...]" representing the
+     * Returns the expression "host:port[,...]" representing the
      * currently-active ORBs to which the ACC could attempt to bootstrap.
+     * The preceding "-targetserver=" gets added by the constructor of
+     * {@link ACCArgQueryParams}
      * @return
      */
     private String targetServerSetting(final Properties props) {
-        String result = null;
-        try {
-            result = orbFactory.getIIOPEndpoints();
-        } catch (NullPointerException npe) {
-            /*
-             * orbFactory.getIIOPEndpoints is supposed to return a valid
-             * answer whether this server is in a cluster or not.  A bug
-             * causes it to throw a NullPointerException in the non-cluster case.
-             * So catch that and use the configured listener for this server.
-             *
-             * Find the IIOP listener with the default listener ID.
-             */
+        String result = orbFactory.getIIOPEndpoints();
+        if (result == null || result.isEmpty()) {
+            // Find the IIOP listener with the default listener ID.
             String port = null;
             for (IiopListener listener : iiopService.getIiopListener()) {
                 if (listener.getId().equals(DEFAULT_ORB_LISTENER_ID)) {
@@ -424,6 +417,7 @@ public class AppClientHTTPAdapter extends RestrictedContentAdapter {
             }
             result = props.getProperty("request.host") + ":" + port;
         }
+
         return result;
     }
 

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -314,6 +314,9 @@ public class IiopFolbGmsClient implements ClusterListener {
         String hostName = nodeName ;
         if (nodes != null) {
             Node node = nodes.getNode( nodeName ) ;
+            if (node == null) {
+                node = nodes.getDefaultLocalNode();
+            }
             if (node != null) {
                 // If this is the local node, and the useNodeHostForLocalNode property has not been set at the ORB or
                 // System level, use the local host name

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2017-2018] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2017-2026 Payara Foundation and/or its affiliates
 
 package org.glassfish.enterprise.iiop.impl;
 
@@ -268,17 +268,21 @@ public class IiopFolbGmsClient implements ClusterListener {
     }
 
     private int resolvePort( Server server, IiopListener listener ) {
-        fineLog( "resolvePort: server {0} listener {1}", server, listener ) ;
+        fineLog( "resolvePort: server {0} listener {1}", server.getName(), listener .getId()) ;
 
         IiopListener ilRaw = GlassFishConfigBean.getRawView( listener ) ;
-        fineLog( "resolvePort: ilRaw {0}", ilRaw ) ;
+
 
         PropertyResolver pr = new PropertyResolver( domain, server.getName() ) ;
-        fineLog( "resolvePort: pr {0}", pr ) ;
+
 
         String port = pr.getPropertyValue( ilRaw.getPort() ) ;
         fineLog( "resolvePort: port {0}", port ) ;
 
+        if (port == null) {
+            fineLog("resolvePort: getPropertyValue returned null, setting port to raw value {0}", ilRaw.getPort());
+            port = ilRaw.getPort();
+        }
         return Integer.parseInt(port) ;
     }
 

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -398,7 +398,7 @@ public class IiopFolbGmsClient implements ClusterListener {
                     fineLog("getAllClusterInstanceInfo: serverConfig {0}", serverConfig.getName());
 
                     if (serverConfig != null) {
-                        result.put(server.getName(), getClusterInstanceInfo(myServer, myConfig, false));
+                        result.put(server.getName(), getClusterInstanceInfo(server, myConfig, false));
                     }
                 }
             }

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -141,7 +141,7 @@ public class IiopFolbGmsClient implements ClusterListener {
                 fineLog("IiopFolbGmsClient: IIOP GIS created");
 
                 currentMembers = getAllClusterInstanceInfo() ;
-                fineLog( "IiopFolbGmsClient: currentMembers = ", currentMembers ) ;
+                fineLog( "IiopFolbGmsClient: currentMembers = {0}", currentMembers ) ;
 
                 fineLog( "iiop instance info = " + getIIOPEndpoints() ) ;
 

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -41,61 +41,56 @@
 
 package org.glassfish.enterprise.iiop.impl;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-import java.util.logging.Level;
-
-import com.sun.logging.LogDomains;
-
-import com.sun.corba.ee.spi.orb.ORB ;
+import com.sun.corba.ee.impl.folb.GroupInfoServiceBase;
 import com.sun.corba.ee.spi.folb.ClusterInstanceInfo;
 import com.sun.corba.ee.spi.folb.GroupInfoService;
-import com.sun.corba.ee.impl.folb.GroupInfoServiceBase;
 import com.sun.corba.ee.spi.folb.GroupInfoServiceObserver;
 import com.sun.corba.ee.spi.folb.SocketInfo;
 import com.sun.corba.ee.spi.misc.ORBConstants;
+import com.sun.corba.ee.spi.orb.ORB;
 import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.config.serverbeans.Configs;
 import com.sun.enterprise.config.serverbeans.Domain;
-import org.glassfish.orb.admin.config.IiopListener;
-import org.glassfish.orb.admin.config.IiopService;
+import com.sun.enterprise.config.serverbeans.Node;
+import com.sun.enterprise.config.serverbeans.Nodes;
 import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.config.serverbeans.Servers;
-import com.sun.enterprise.config.serverbeans.Nodes;
-import com.sun.enterprise.config.serverbeans.Node;
-import fish.payara.nucleus.cluster.PayaraCluster;
+import com.sun.logging.LogDomains;
 import fish.payara.nucleus.cluster.ClusterListener;
 import fish.payara.nucleus.cluster.MemberEvent;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import static org.glassfish.api.naming.NamingClusterInfo.IIOP_CLUSTER_UPDATE_PROPERTY;
+import fish.payara.nucleus.cluster.PayaraCluster;
 import org.glassfish.config.support.GlassFishConfigBean;
 import org.glassfish.config.support.PropertyResolver;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.orb.admin.config.IiopListener;
+import org.glassfish.orb.admin.config.IiopService;
 import org.omg.CORBA.ORBPackage.InvalidName;
 
-// REVISIT impl
-//import com.sun.corba.ee.impl.folb.ServerGroupManager;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.glassfish.api.naming.NamingClusterInfo.IIOP_CLUSTER_UPDATE_PROPERTY;
 
 /**
  * @author Harold Carr
  */
 public class IiopFolbGmsClient implements ClusterListener {
-    private static final Logger _logger =
-       LogDomains.getLogger(IiopFolbGmsClient.class,
-           LogDomains.CORBA_LOGGER);
+    private static final Logger _logger = LogDomains.getLogger(IiopFolbGmsClient.class, LogDomains.CORBA_LOGGER);
 
     private ServiceLocator services;
 
-    private Domain domain ;
+    private Domain domain;
 
-    private Server myServer ;
+    private Server myServer;
 
-    private Nodes nodes ;
+    private Nodes nodes;
 
     private Map<String, ClusterInstanceInfo> currentMembers;
 
@@ -108,337 +103,305 @@ public class IiopFolbGmsClient implements ClusterListener {
     private static final String USE_NODE_HOST_FOR_LOCAL_NODE_SYSTEM_PROPERTY = "fish.payara.iiop.gmsClient."
             + USE_NODE_HOST_FOR_LOCAL_NODE_PROPERTY;
 
-    private void fineLog( String fmt, Object... args ) {
-        if(_logger.isLoggable(Level.FINE)) {
-		_logger.log(Level.FINE, fmt, args ) ;
+    private void fineLog(String fmt, Object... args) {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.FINE, fmt, args);
         }
     }
 
-    public IiopFolbGmsClient( ServiceLocator services ) {
-        fineLog( "IiopFolbGmsClient: constructor: services {0}",
-            services ) ;
-        this.services = services ;
+    public IiopFolbGmsClient(ServiceLocator services) {
+        fineLog("IiopFolbGmsClient: constructor: services {0}", services);
+        this.services = services;
 
         cluster = services.getService(PayaraCluster.class);
-	try {
+        try {
             if (cluster != null && cluster.isEnabled()) {
-                domain = services.getService( Domain.class );
-                fineLog( "IiopFolbGmsClient: domain {0}", domain) ;
+                domain = services.getService(Domain.class);
+                fineLog("IiopFolbGmsClient: domain {0}", domain);
 
-                Servers servers = services.getService(Servers.class );
-                fineLog( "IiopFolbGmsClient: servers {0}", servers );
+                Servers servers = services.getService(Servers.class);
+                fineLog("IiopFolbGmsClient: servers {0}", servers);
 
                 nodes = services.getService(Nodes.class);
-                fineLog( "IiopFolbGmsClient: nodes {0}", nodes );
+                fineLog("IiopFolbGmsClient: nodes {0}", nodes);
 
-                String instanceName = cluster.getUnderlyingHazelcastService().getMemberName() ;
-                fineLog( "IiopFolbGmsClient: instanceName {0}", instanceName );
+                String instanceName = cluster.getUnderlyingHazelcastService().getMemberName();
+                fineLog("IiopFolbGmsClient: instanceName {0}", instanceName);
 
-                myServer = servers.getServer(instanceName) ;
-                fineLog( "IiopFolbGmsClient: myServer {0}", myServer );
+                myServer = servers.getServer(instanceName);
+                fineLog("IiopFolbGmsClient: myServer {0}", myServer);
 
-                gis = new GroupInfoServiceGMSImpl() ;
+                gis = new GroupInfoServiceGMSImpl();
                 fineLog("IiopFolbGmsClient: IIOP GIS created");
 
-                currentMembers = getAllClusterInstanceInfo() ;
-                fineLog( "IiopFolbGmsClient: currentMembers = {0}", currentMembers ) ;
+                currentMembers = getAllClusterInstanceInfo();
+                fineLog("IiopFolbGmsClient: currentMembers = {0}", currentMembers);
 
-                fineLog( "iiop instance info = " + getIIOPEndpoints() ) ;
+                fineLog("iiop instance info = " + getIIOPEndpoints());
 
                 cluster.addClusterListener(this);
 
-                fineLog( "IiopFolbGmsClient: GMS action factories added");
+                fineLog("IiopFolbGmsClient: GMS action factories added");
             } else {
-                fineLog( "IiopFolbGmsClient: gmsAdapterService is null") ;
-                gis = new GroupInfoServiceNoGMSImpl() ;
+                fineLog("IiopFolbGmsClient: gmsAdapterService is null");
+                gis = new GroupInfoServiceNoGMSImpl();
             }
 
-	} catch (Throwable t) {
+        } catch (Throwable t) {
             _logger.log(Level.SEVERE, t.getLocalizedMessage(), t);
-	} finally {
-            fineLog( "IiopFolbGmsClient: Payara Cluster {0}", cluster ) ;
-	}
+        } finally {
+            fineLog("IiopFolbGmsClient: Payara Cluster {0}", cluster);
+        }
     }
 
-    public void setORB( ORB orb ) {
+    public void setORB(ORB orb) {
         try {
-            orb.register_initial_reference(
-                    ORBConstants.FOLB_SERVER_GROUP_INFO_SERVICE,
-                    (org.omg.CORBA.Object) gis);
-            fineLog( ".initGIS: naming registration complete: {0}", gis);
+            orb.register_initial_reference(ORBConstants.FOLB_SERVER_GROUP_INFO_SERVICE, (org.omg.CORBA.Object) gis);
+            fineLog(".initGIS: naming registration complete: {0}", gis);
 
             // Just for logging
-            GroupInfoService gisRef = (GroupInfoService)orb.resolve_initial_references(
-                ORBConstants.FOLB_SERVER_GROUP_INFO_SERVICE);
-            List<ClusterInstanceInfo> lcii =
-                    gisRef.getClusterInstanceInfo(null);
-            fineLog( "Results from getClusterInstanceInfo:");
+            GroupInfoService gisRef = (GroupInfoService) orb.resolve_initial_references(ORBConstants.FOLB_SERVER_GROUP_INFO_SERVICE);
+            List<ClusterInstanceInfo> lcii = gisRef.getClusterInstanceInfo(null);
+            fineLog("Results from getClusterInstanceInfo:");
             if (lcii != null) {
                 for (ClusterInstanceInfo cii : lcii) {
-                    fineLog( cii.toString() );
+                    fineLog(cii.toString());
                 }
             }
         } catch (InvalidName e) {
-            fineLog( ".initGIS: registering GIS failed: {0}", e);
+            fineLog(".initGIS: registering GIS failed: {0}", e);
         }
     }
 
     public GroupInfoService getGroupInfoService() {
-        return gis ;
+        return gis;
     }
 
     public boolean isGMSAvailable() {
         return isDeploymentGroupsActive() || isTraditionalClusterActive();
     }
 
-    ////////////////////////////////////////////////////
+    /// /////////////////////////////////////////////////
     //
     // Implementation
     //
-
     private boolean isDeploymentGroupsActive() {
-    	return cluster != null && cluster.isEnabled() && cluster.getClusterMembers().size() > 1;
+        return cluster != null && cluster.isEnabled() && cluster.getClusterMembers().size() > 1;
     }
 
     private boolean isTraditionalClusterActive() {
-    	return myServer != null && myServer.getCluster() != null;
+        return myServer != null && myServer.getCluster() != null;
     }
 
-    private void removeMember(final String signal)
-    {
+    private void removeMember(final String signal) {
         // TBD really need to map to real member name
-	String instanceName = signal;
-	try {
-            fineLog( "IiopFolbGmsClient.removeMember->: {0}",
-                instanceName);
+        String instanceName = signal;
+        try {
+            fineLog("IiopFolbGmsClient.removeMember->: {0}", instanceName);
 
-	    synchronized (this) {
-		if (currentMembers.get(instanceName) != null) {
-		    currentMembers.remove(instanceName);
+            synchronized (this) {
+                if (currentMembers.get(instanceName) != null) {
+                    currentMembers.remove(instanceName);
 
-                    fineLog(
-                        "IiopFolbGmsClient.removeMember: {0} removed - notifying listeners",
-                        instanceName);
+                    fineLog("IiopFolbGmsClient.removeMember: {0} removed - notifying listeners", instanceName);
 
-		    gis.notifyObservers();
+                    gis.notifyObservers();
 
-                    fineLog(
-                        "IiopFolbGmsClient.removeMember: {0} - notification complete",
-                        instanceName);
-		} else {
-                    fineLog(
-                        "IiopFolbGmsClient.removeMember: {0} not present: no action",
-                        instanceName);
-		}
-	    }
-	} finally {
-            fineLog( "IiopFolbGmsClient.removeMember<-: {0}", instanceName);
-	}
+                    fineLog("IiopFolbGmsClient.removeMember: {0} - notification complete", instanceName);
+                } else {
+                    fineLog("IiopFolbGmsClient.removeMember: {0} not present: no action", instanceName);
+                }
+            }
+        } finally {
+            fineLog("IiopFolbGmsClient.removeMember<-: {0}", instanceName);
+        }
     }
 
-    private void addMember(final String signal)
-    {
-	final String instanceName = signal;
-	try {
-            fineLog( "IiopFolbGmsClient.addMember->: {0}", instanceName);
+    private void addMember(final String signal) {
+        final String instanceName = signal;
+        try {
+            fineLog("IiopFolbGmsClient.addMember->: {0}", instanceName);
 
-	    synchronized (this) {
-		if (currentMembers.get(instanceName) != null) {
-                    fineLog( "IiopFolbGmsClient.addMember: {0} already present: no action",
-                            instanceName);
-		} else {
-		    ClusterInstanceInfo clusterInstanceInfo =
-                        getClusterInstanceInfo(instanceName) ;
+            synchronized (this) {
+                if (currentMembers.get(instanceName) != null) {
+                    fineLog("IiopFolbGmsClient.addMember: {0} already present: no action", instanceName);
+                } else {
+                    ClusterInstanceInfo clusterInstanceInfo = getClusterInstanceInfo(instanceName);
 
-		    currentMembers.put( clusterInstanceInfo.name(),
-                        clusterInstanceInfo);
+                    currentMembers.put(clusterInstanceInfo.name(), clusterInstanceInfo);
 
-                    fineLog( "IiopFolbGmsClient.addMember: {0} added - notifying listeners",
-                        instanceName);
+                    fineLog("IiopFolbGmsClient.addMember: {0} added - notifying listeners", instanceName);
 
-		    gis.notifyObservers();
+                    gis.notifyObservers();
 
-                    fineLog( "IiopFolbGmsClient.addMember: {0} - notification complete",
-                        instanceName);
-		}
-	    }
-	} finally {
-            fineLog( "IiopFolbGmsClient.addMember<-: {0}", instanceName);
-	}
+                    fineLog("IiopFolbGmsClient.addMember: {0} - notification complete", instanceName);
+                }
+            }
+        } finally {
+            fineLog("IiopFolbGmsClient.addMember<-: {0}", instanceName);
+        }
     }
 
-    private int resolvePort( Server server, IiopListener listener ) {
-        fineLog( "resolvePort: server {0} listener {1}", server.getName(), listener .getId()) ;
+    private int resolvePort(Server server, IiopListener listener) {
+        fineLog("resolvePort: server {0} listener {1}", server.getName(), listener.getId());
 
-        IiopListener ilRaw = GlassFishConfigBean.getRawView( listener ) ;
+        IiopListener ilRaw = GlassFishConfigBean.getRawView(listener);
 
+        PropertyResolver pr = new PropertyResolver(domain, server.getName());
 
-        PropertyResolver pr = new PropertyResolver( domain, server.getName() ) ;
-
-
-        String port = pr.getPropertyValue( ilRaw.getPort() ) ;
-        fineLog( "resolvePort: port {0}", port ) ;
+        String port = pr.getPropertyValue(ilRaw.getPort());
+        fineLog("resolvePort: port {0}", port);
 
         if (port == null) {
             fineLog("resolvePort: getPropertyValue returned null, setting port to raw value {0}", ilRaw.getPort());
             port = ilRaw.getPort();
         }
-        return Integer.parseInt(port) ;
+        return Integer.parseInt(port);
     }
 
-    private ClusterInstanceInfo getClusterInstanceInfo( Server server,
-        Config config, boolean assumeInstanceIsRunning ) {
+    private ClusterInstanceInfo getClusterInstanceInfo(Server server, Config config, boolean assumeInstanceIsRunning) {
         if (server == null) {
-            return null ;
+            return null;
         }
 
         if (!assumeInstanceIsRunning) {
             if (!server.isRunning()) {
-                return null ;
+                return null;
             }
         }
 
-        fineLog( "getClusterInstanceInfo: server {0}, config {1}",
-            server, config ) ;
+        fineLog("getClusterInstanceInfo: server {0}, config {1}", server, config);
 
-        final String name = server.getName() ;
-        fineLog( "getClusterInstanceInfo: name {0}", name ) ;
+        final String name = server.getName();
+        fineLog("getClusterInstanceInfo: name {0}", name);
 
-        final int weight = Integer.parseInt( server.getLbWeight() ) ;
-        fineLog( "getClusterInstanceInfo: weight {0}", weight ) ;
+        final int weight = Integer.parseInt(server.getLbWeight());
+        fineLog("getClusterInstanceInfo: weight {0}", weight);
 
-        final IiopService iservice = config.getExtensionByType(IiopService.class) ;
-        fineLog( "getClusterInstanceInfo: iservice {0}", iservice ) ;
+        final IiopService iservice = config.getExtensionByType(IiopService.class);
+        fineLog("getClusterInstanceInfo: iservice {0}", iservice);
 
-        final String nodeName = server.getNodeRef() ;
-        String hostName = nodeName ;
+        final String nodeName = server.getNodeRef();
+        String hostName = nodeName;
         if (nodes != null) {
-            Node node = nodes.getNode( nodeName ) ;
+            Node node = nodes.getNode(nodeName);
             if (node == null) {
                 node = nodes.getDefaultLocalNode();
             }
             if (node != null) {
                 // If this is the local node, and the useNodeHostForLocalNode property has not been set at the ORB or
                 // System level, use the local host name
-                if ((node.isLocal() && !Boolean.getBoolean(USE_NODE_HOST_FOR_LOCAL_NODE_SYSTEM_PROPERTY))
-                        && (node.isLocal() && !Boolean.parseBoolean(iservice.getOrb().getPropertyValue(
-                                USE_NODE_HOST_FOR_LOCAL_NODE_PROPERTY, "false")))) {
+                if ((node.isLocal() && !Boolean.getBoolean(USE_NODE_HOST_FOR_LOCAL_NODE_SYSTEM_PROPERTY)) &&
+                        (node.isLocal() && !Boolean.parseBoolean(iservice.getOrb().getPropertyValue(USE_NODE_HOST_FOR_LOCAL_NODE_PROPERTY, "false")))) {
                     try {
-                        hostName = InetAddress.getLocalHost().getHostName() ;
+                        hostName = InetAddress.getLocalHost().getHostName();
                     } catch (UnknownHostException exc) {
-                        fineLog( "getClusterInstanceInfo: caught exception for localhost lookup {0}",
-                            exc )  ;
+                        fineLog("getClusterInstanceInfo: caught exception for localhost lookup {0}", exc);
                     }
                 } else {
-                    hostName = node.getNodeHost() ;
+                    hostName = node.getNodeHost();
                 }
             }
         }
 
-        fineLog( "getClusterInstanceInfo: host {0}", hostName ) ;
+        fineLog("getClusterInstanceInfo: host {0}", hostName);
 
-        final List<IiopListener> listeners = iservice.getIiopListener() ;
-        fineLog( "getClusterInstanceInfo: listeners {0}", listeners ) ;
+        final List<IiopListener> listeners = iservice.getIiopListener();
+        fineLog("getClusterInstanceInfo: listeners {0}", listeners);
 
-        final List<SocketInfo> sinfos = new ArrayList<SocketInfo>() ;
+        final List<SocketInfo> sinfos = new ArrayList<>();
         for (IiopListener il : listeners) {
-            SocketInfo sinfo = new SocketInfo( il.getId(), hostName,
-                resolvePort( server, il ) ) ;
-            sinfos.add( sinfo ) ;
+            SocketInfo sinfo = new SocketInfo(il.getId(), hostName, resolvePort(server, il));
+            sinfos.add(sinfo);
         }
-        fineLog( "getClusterInstanceInfo: sinfos {0}", sinfos ) ;
+        fineLog("getClusterInstanceInfo: sinfos {0}", sinfos);
 
-        final ClusterInstanceInfo result = new ClusterInstanceInfo( name, weight,
-            sinfos ) ;
-        fineLog( "getClusterInstanceInfo: result {0}", result ) ;
+        final ClusterInstanceInfo result = new ClusterInstanceInfo(name, weight, sinfos);
+        fineLog("getClusterInstanceInfo: result {0}", result);
 
-        return result ;
+        return result;
     }
 
-    private Config getConfigForServer( Server server ) {
-        fineLog( "getConfigForServer: server {0}", server ) ;
+    private Config getConfigForServer(Server server) {
+        fineLog("getConfigForServer: server {0}", server);
 
-        String configRef = server.getConfigRef() ;
-        fineLog( "getConfigForServer: configRef {0}", configRef ) ;
+        String configRef = server.getConfigRef();
+        fineLog("getConfigForServer: configRef {0}", configRef);
 
-        Configs configs = services.getService( Configs.class ) ;
-        fineLog( "getConfigForServer: configs {0}", configs ) ;
+        Configs configs = services.getService(Configs.class);
+        fineLog("getConfigForServer: configs {0}", configs);
 
-        Config config = configs.getConfigByName(configRef) ;
-        fineLog( "getConfigForServer: config {0}", config ) ;
+        Config config = configs.getConfigByName(configRef);
+        fineLog("getConfigForServer: config {0}", config);
 
-        return config ;
+        return config;
     }
 
     // For addMember.
-    private ClusterInstanceInfo getClusterInstanceInfo( String instanceName) {
-        fineLog( "getClusterInstanceInfo: instanceName {0}", instanceName ) ;
+    private ClusterInstanceInfo getClusterInstanceInfo(String instanceName) {
+        fineLog("getClusterInstanceInfo: instanceName {0}", instanceName);
 
-        final Servers servers = services.getService( Servers.class );
-        fineLog( "getClusterInstanceInfo: servers {0}", servers ) ;
+        final Servers servers = services.getService(Servers.class);
+        fineLog("getClusterInstanceInfo: servers {0}", servers);
 
-        final Server server = servers.getServer(instanceName) ;
-        fineLog( "getClusterInstanceInfo: server {0}", server ) ;
+        final Server server = servers.getServer(instanceName);
+        fineLog("getClusterInstanceInfo: server {0}", server);
 
-        final Config config = getConfigForServer( server ) ;
-        fineLog( "getClusterInstanceInfo: servers {0}", servers ) ;
+        final Config config = getConfigForServer(server);
+        fineLog("getClusterInstanceInfo: servers {0}", servers);
 
         // assumeInstanceIsRunning is set to true since this is
         // coming from addMember, because shoal just told us that the instance is up.
-        ClusterInstanceInfo result = getClusterInstanceInfo( server, config,
-            true ) ;
-        fineLog( "getClusterInstanceInfo: result {0}", result ) ;
+        ClusterInstanceInfo result = getClusterInstanceInfo(server, config, true);
+        fineLog("getClusterInstanceInfo: result {0}", result);
 
-        return result ;
+        return result;
     }
 
-    private Map<String,ClusterInstanceInfo> getAllClusterInstanceInfo() {
-        final Cluster myCluster = myServer.getCluster() ;
-        fineLog( "getAllClusterInstanceInfo: myCluster {0}", myCluster ) ;
+    private Map<String, ClusterInstanceInfo> getAllClusterInstanceInfo() {
+        final Cluster myCluster = myServer.getCluster();
+        fineLog("getAllClusterInstanceInfo: myCluster {0}", myCluster);
 
-        final Config myConfig = getConfigForServer( myServer ) ;
-        fineLog( "getAllClusterInstanceInfo: myConfig {0}", myConfig ) ;
+        final Config myConfig = getConfigForServer(myServer);
+        fineLog("getAllClusterInstanceInfo: myConfig {0}", myConfig);
 
-        final Map<String,ClusterInstanceInfo> result =
-            new HashMap<String,ClusterInstanceInfo>() ;
+        final Map<String, ClusterInstanceInfo> result = new HashMap<>();
 
         //When myServer is DAS's situation, myCluster is null.
         //null check is needed.
         if (myCluster != null) {
             for (Server server : myCluster.getInstances()) {
-                ClusterInstanceInfo cii = getClusterInstanceInfo(server,
-                        myConfig, false);
+                ClusterInstanceInfo cii = getClusterInstanceInfo(server, myConfig, false);
                 if (cii != null) {
                     result.put(server.getName(), cii);
                 }
             }
         }
 
-        fineLog( "getAllClusterInstanceInfo: result {0}", result ) ;
-        return result ;
+        fineLog("getAllClusterInstanceInfo: result {0}", result);
+        return result;
     }
 
     // return host:port,... string for all clear text ports in the cluster
     // instance info.
     public final String getIIOPEndpoints() {
-        final Map<String,ClusterInstanceInfo> cinfos = getAllClusterInstanceInfo() ;
-        final StringBuilder result = new StringBuilder() ;
-        boolean first = true ;
-        for (ClusterInstanceInfo cinfo : cinfos.values() ) {
+        final Map<String, ClusterInstanceInfo> cinfos = getAllClusterInstanceInfo();
+        final StringBuilder result = new StringBuilder();
+        boolean first = true;
+        for (ClusterInstanceInfo cinfo : cinfos.values()) {
             for (SocketInfo sinfo : cinfo.endpoints()) {
-                if (!sinfo.type().startsWith( "SSL" )) {
+                if (!sinfo.type().startsWith("SSL")) {
                     if (first) {
-                        first = false ;
+                        first = false;
                     } else {
-                        result.append( ',' ) ;
+                        result.append(',');
                     }
 
-                    result.append( sinfo.host() ).append( ':' )
-                        .append( sinfo.port() ) ;
+                    result.append(sinfo.host()).append(':').append(sinfo.port());
                 }
             }
         }
-        return result.toString() ;
+        return result.toString();
     }
 
     @Override
@@ -459,18 +422,15 @@ public class IiopFolbGmsClient implements ClusterListener {
 
     class GroupInfoServiceGMSImpl extends GroupInfoServiceBase {
         @Override
-        public List<ClusterInstanceInfo> internalClusterInstanceInfo(
-            List<String> endpoints) {
+        public List<ClusterInstanceInfo> internalClusterInstanceInfo(List<String> endpoints) {
 
-            fineLog( "internalClusterInstanceInfo: currentMembers {0}",
-                currentMembers ) ;
+            fineLog("internalClusterInstanceInfo: currentMembers {0}", currentMembers);
 
             boolean disableClusterUpdate = !Boolean.parseBoolean(System.getProperty(IIOP_CLUSTER_UPDATE_PROPERTY, "true"));
             if (currentMembers == null || disableClusterUpdate) {
-                return new ArrayList<ClusterInstanceInfo>() ;
+                return new ArrayList<>();
             } else {
-                return new ArrayList<ClusterInstanceInfo>(
-                    currentMembers.values() ) ;
+                return new ArrayList<>(currentMembers.values());
             }
         }
     }
@@ -497,5 +457,3 @@ public class IiopFolbGmsClient implements ClusterListener {
         }
     }
 }
-
-// End of file.

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -73,6 +73,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -359,21 +360,46 @@ public class IiopFolbGmsClient implements ClusterListener {
     }
 
     private Map<String, ClusterInstanceInfo> getAllClusterInstanceInfo() {
-        final Cluster myCluster = myServer.getCluster();
-        fineLog("getAllClusterInstanceInfo: myCluster {0}", myCluster);
+        Map<String, ClusterInstanceInfo> result = new HashMap<>();
 
         final Config myConfig = getConfigForServer(myServer);
-        fineLog("getAllClusterInstanceInfo: myConfig {0}", myConfig);
+        fineLog("getAllClusterInstanceInfo: myConfig {0}", myConfig.getName());
+        result.put(myServer.getName(), getClusterInstanceInfo(myServer, myConfig, false));
 
-        final Map<String, ClusterInstanceInfo> result = new HashMap<>();
+        // Iterate over cluster or deployment group
+        // When myServer is DAS's situation, myCluster is null - we check we're not adding the same server twice
+        if (isTraditionalClusterActive()) {
+            final Cluster myCluster = myServer.getCluster();
+            fineLog("getAllClusterInstanceInfo: myCluster {0}", myCluster.getName());
 
-        //When myServer is DAS's situation, myCluster is null.
-        //null check is needed.
-        if (myCluster != null) {
             for (Server server : myCluster.getInstances()) {
+                if (server.getName().equals(myServer.getName())) {
+                    // Should™ already be added
+                    continue;
+                }
+
                 ClusterInstanceInfo cii = getClusterInstanceInfo(server, myConfig, false);
                 if (cii != null) {
                     result.put(server.getName(), cii);
+                }
+            }
+        } else if (isDeploymentGroupsActive()) {
+            for (UUID clusterMemberId : cluster.getClusterMembers()) {
+                if (clusterMemberId.equals(cluster.getLocalUUID())) {
+                    // Should™ already be added
+                    continue;
+                }
+
+                Server server = domain.getServerNamed(cluster.getMemberName(clusterMemberId));
+
+                if (server != null) {
+                    final Config serverConfig = getConfigForServer(server);
+
+                    fineLog("getAllClusterInstanceInfo: serverConfig {0}", serverConfig.getName());
+
+                    if (serverConfig != null) {
+                        result.put(server.getName(), getClusterInstanceInfo(myServer, myConfig, false));
+                    }
                 }
             }
         }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/MonitoringReporter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/MonitoringReporter.java
@@ -692,8 +692,9 @@ public class MonitoringReporter extends V2DottedNameSupport {
             return false;
         }
 
-        if (targetService.isCluster(targetName) && targets.size() > 1)
+        if ((targetService.isCluster(targetName) || targetService.isDeploymentGroup(targetName)) && targets.size() > 1) {
             targetIsMultiInstanceCluster = true;
+        }
 
         return true;
     }

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/CollectLogFiles.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/commands/CollectLogFiles.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019-2021] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2019-2026 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.server.logging.commands;
 
@@ -50,6 +50,7 @@ import com.sun.enterprise.server.logging.LogFacade;
 import com.sun.enterprise.server.logging.logviewer.backend.LogFilterForInstance;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.SystemPropertyConstants;
+import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
 import org.glassfish.admin.payload.PayloadImpl;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
@@ -314,9 +315,18 @@ public class CollectLogFiles implements AdminCommand {
             /******************************************************/
 
 
-            com.sun.enterprise.config.serverbeans.Cluster cluster = domain.getClusterNamed(target);
+            Cluster cluster = domain.getClusterNamed(target);
+            List<Server> instances = List.of();
 
-            List<Server> instances = cluster.getInstances();
+            // Check for a cluster first, before checking for a deployment group
+            if (cluster != null) {
+                instances = cluster.getInstances();
+            } else {
+                DeploymentGroup deploymentGroup = domain.getDeploymentGroupNamed(target);
+                if (deploymentGroup != null) {
+                    instances = deploymentGroup.getInstances();
+                }
+            }
 
             int instanceCount = 0;
             int errorCount = 0;

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/cluster/MemberEvent.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/cluster/MemberEvent.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -59,11 +59,19 @@ public class MemberEvent {
     }
     
     public String getServer() {
-        return hzCore.getAttribute(member.getUuid(), HazelcastCore.INSTANCE_ATTRIBUTE);
+        String serverName = hzCore.getAttribute(member.getUuid(), HazelcastCore.INSTANCE_ATTRIBUTE);
+        if (serverName == null) {
+            serverName = member.getAttribute(HazelcastCore.INSTANCE_ATTRIBUTE);
+        }
+        return serverName;
     }
     
     public String getServerGroup() {
-        return member.getAttribute(HazelcastCore.INSTANCE_GROUP_ATTRIBUTE);
+        String serverGroup = hzCore.getAttribute(member.getUuid(), HazelcastCore.INSTANCE_GROUP_ATTRIBUTE);
+        if (serverGroup == null) {
+            serverGroup = member.getAttribute(HazelcastCore.INSTANCE_GROUP_ATTRIBUTE);
+        }
+        return serverGroup;
     }
     
     private final HazelcastCore hzCore;

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/cluster/PayaraCluster.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/cluster/PayaraCluster.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2023] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -245,7 +245,13 @@ public class PayaraCluster implements MembershipListener, EventListener {
             message.append("Instances: {").append(NL);
             for (Member member : members) {
                 String name = hzCore.getAttribute(member.getUuid(), HazelcastCore.INSTANCE_ATTRIBUTE);
+                if (name == null) {
+                    name =  member.getAttribute(HazelcastCore.INSTANCE_ATTRIBUTE);
+                }
                 String group = hzCore.getAttribute(member.getUuid(), HazelcastCore.INSTANCE_GROUP_ATTRIBUTE);
+                if (group == null) {
+                    group =  member.getAttribute(HazelcastCore.INSTANCE_GROUP_ATTRIBUTE);
+                }
                 message.append(" DataGrid: ").append(dataGridName);
                 if (group != null) {
                     message.append(" Instance Group: ").append(group);

--- a/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
+++ b/nucleus/payara-modules/hazelcast-bootstrap/src/main/java/fish/payara/nucleus/hazelcast/HazelcastCore.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2024 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -581,6 +581,14 @@ public class HazelcastCore implements EventListener, ConfigListener {
             try {
                 // remove "CP Subsystem Unsafe" warning on startup
                 cpSubsystemLogger.setLevel(Level.SEVERE);
+
+                if (env.isMicro()) {
+                    if (Boolean.valueOf(configuration.getGenerateNames()) || memberName == null) {
+                        memberName = PayaraMicroNameGenerator.generateName();
+                    }
+                }
+
+                config.getMemberAttributeConfig().setAttribute(INSTANCE_ATTRIBUTE, memberName);
                 config.getMemberAttributeConfig().setAttribute(INSTANCE_GROUP_ATTRIBUTE, memberGroup);
                 theInstance = Hazelcast.newHazelcastInstance(config);
                 autoPromoteCPMembers(config);
@@ -589,7 +597,6 @@ public class HazelcastCore implements EventListener, ConfigListener {
             }
             if (env.isMicro()) {
                 if (Boolean.valueOf(configuration.getGenerateNames()) || memberName == null) {
-                    memberName = PayaraMicroNameGenerator.generateName();
                     Set<com.hazelcast.cluster.Member> clusterMembers = theInstance.getCluster().getMembers();
 
                     // If the instance name was generated, we need to compile a list of all the instance names in use within
@@ -609,7 +616,6 @@ public class HazelcastCore implements EventListener, ConfigListener {
                     if (takenNames.contains(memberName)) {
                         memberName = PayaraMicroNameGenerator.generateUniqueName(takenNames,
                                 theInstance.getCluster().getLocalMember().getUuid());
-                        setAttribute(theInstance.getCluster().getLocalMember().getUuid(), HazelcastCore.INSTANCE_ATTRIBUTE, memberName);
                     }
                 }
             }
@@ -637,7 +643,7 @@ public class HazelcastCore implements EventListener, ConfigListener {
                     if (map == null) {
                         map = new HashMap<>();
                     }
-                    map.put(HazelcastCore.INSTANCE_ATTRIBUTE, memberName);
+                    map.put(key, value);
                     return map;
                 });
     }


### PR DESCRIPTION
## Description
Ports some of the fixes we made to the cluster removal feature branch to main while we figure out what to do with it, as they're not strictly related to the removal of clusters.

Ports across:
* Fixes to Corba clustering (IIOP Fail Over Load Balancing) related to deployment groups - it should no longer constantly hit NPEs due to not knowing about configs
* Timing fixes for Hazelcast names - it is now a bit more aggressive in setting the instance and group names, falling back to member group config values if there isn't anything configured in the instance group map (yet). This means you should, among other things, more reliably see the instance and group names printed out when an instance joins the data grid
* Collecting aggregate monitoring data for deployment groups
* Collecting logs from deployment groups

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed

#### IIOP FOLB
* Start the DAS
* Create a new config based off of _default-config_ called _Gruppy-config_
* Enable `FINEST` logging on the `javax.enterprise.resource.corba` logger in _Gruppy-config_
* Set the Hazelcast instance group in _Gruppy-config_ to _GruppyShoal_
* Create a deployment group named _Gruppy_
* Deploy the attached `remoteview.jar` to _Gruppy_
  * This comes from quicklook if you want to rebuild this JAR yourself
  * [remoteview.zip](https://github.com/user-attachments/files/25790465/remoteview.zip)
* Create a new instance named _Insty1_, referencing _Gruppy-config_ (not copying), and add it to _Gruppy_
* Create a new instance named _Insty2_, referencing _Gruppy-config_ (not copying), and add it to _Gruppy_
* Start _Insty1_ and let it sort itself out
  * You should see in the logs that Corba FOLB has started with only _Insty1_ registered: `org.glassfish.enterprise.iiop.impl.IiopFolbGmsClient;MethodName=fineLog;|
  internalClusterInstanceInfo: currentMembers {Insty1=ClusterInstanceInfo[name=Insty1 weight=100 endpoints=[SocketInfo[type=orb-listener-1 host=Pandrex-PC port=23700], SocketInfo[type=SSL host=Pandrex-PC port=23820], SocketInfo[type=SSL_MUTUALAUTH host=Pandrex-PC port=23920]]]}|#]`
  * You should also see that the JAR was deployed and printed some messages: `HellohelloRemote.hello() says hello, world`
* Start _Insty2_ and let it sort itself out
  * You should see in the logs that Corba FOLB has started with **both** instances registered: `org.glassfish.enterprise.iiop.impl.IiopFolbGmsClient;MethodName=fineLog;|
  internalClusterInstanceInfo: currentMembers {Insty2=ClusterInstanceInfo[name=Insty2 weight=100 endpoints=[SocketInfo[type=orb-listener-1 host=Pandrex-PC port=23701], SocketInfo[type=SSL host=Pandrex-PC port=23821], SocketInfo[type=SSL_MUTUALAUTH host=Pandrex-PC port=23921]]], Insty1=ClusterInstanceInfo[name=Insty1 weight=100 endpoints=[SocketInfo[type=orb-listener-1 host=Pandrex-PC port=23700], SocketInfo[type=SSL host=Pandrex-PC port=23820], SocketInfo[type=SSL_MUTUALAUTH host=Pandrex-PC port=23920]]]}|#]`
  * You should also see that the JAR was deployed and printed some messages: `HellohelloRemote.hello() says hello, world`
* You should also see in the logs of _Insty1_ that it has added _Insty2_ to its cluster: `IiopFolbGmsClient.addMember<-: Insty2|#]`
* Stop _Insty2_ - you should see in the logs that Insty1 registered that it was removed: `IiopFolbGmsClient.removeMember<-: Insty2`
* Start _Insty2_ again - you should see in the logs that it gets reregistered: `IiopFolbGmsClient.addMember<-: Insty2`
* Create a cluster, _Clusty_, with two instances in it: _Wibbles_ and _Wobbles_
* Enable `FINEST` logging on the `javax.enterprise.resource.corba` logger in _Clusty-config_
* Deploy the attached `remoteview.jar` to _Clusty_
* Start the cluster
* Check the `currentMembers` log of the cluster instances: should only list _Wibbles_ and _Wobbles_
  * The logs of _Insty1_ and _Insty2_ should also not show additional instances being added to the Corba cluster (it will to Hazelcast but that's something else)


#### Datagrid Names

* Start the DAS
* Create a new config based off of _default-config_ called _Gruppy-config_
* Set the Hazelcast instance group in _Gruppy-config_ to _GruppyShoal_
* Create a deployment group named _Gruppy_
* Create a new instance named _Insty1_, referencing _Gruppy-config_ (not copying), and add it to _Gruppy_
* Create a new instance named _Insty2_, referencing _Gruppy-config_ (not copying), and add it to _Gruppy_
* Start the deployment group and check the logs of the DAS, Insty1, and Insty2 - you should see the names and groups present on all instances:
```
Instances: {
 DataGrid: development Instance Group: MicroShoal Name: server Lite: false This: true UUID: 6df02dc9-e666-48cb-bf39-8ddebe440321 Address: /172.26.144.1:4900
 DataGrid: development Instance Group: GruppyShoal Name: Insty1 Lite: false This: false UUID: 80b466e0-be6a-4664-8515-8c72e19ce558 Address: /172.26.144.1:5900
 DataGrid: development Instance Group: GruppyShoal Name: Insty2 Lite: false This: false UUID: f560b335-da23-42ff-9719-1a37247da281 Address: /172.26.144.1:5901
}|#]
```

#### Get Logs

* Start the DAS
* Create a new config based off of _default-config_ called _Gruppy-config_
* Create a deployment group named _Gruppy_
* Create a new instance named _Insty1_, referencing _Gruppy-config_ (not copying), and add it to _Gruppy_
* Create a new instance named _Insty2_, referencing _Gruppy-config_ (not copying), and add it to _Gruppy_
* Start the deployment group
* Create a cluster, _Clusty_, with two instances in it: _Wibbles_ and _Wobbles_
* Start the cluster
* Collect the logs from the deployment group: `asadmin collect-log-files --target Gruppy`
* Collect the logs from the cluster: `asadmin collect-log-files --target Clusty`
* Check the zips - should contain the logs from the respective member instances of the group/cluster

#### Get Aggregate Monitoring Data
* Start the DAS
* Create a new config based off of _default-config_ called _Gruppy-config_
* Create a deployment group named _Gruppy_
* Create a new instance named _Insty1_, referencing _Gruppy-config_ (not copying), and add it to _Gruppy_
* Create a new instance named _Insty2_, referencing _Gruppy-config_ (not copying), and add it to _Gruppy_
* Start the deployment group
* Create a cluster, _Clusty_, with two instances in it: _Wibbles_ and _Wobbles_
* Start the cluster
* Set all monitoring to high and enable JMX for _Gruppy-config_ and _Clusty-config_
* Collect the aggregate monitoring data from the deployment group: `asadmin get --monitor --aggregatedataonly=true Gruppy` - should only get `Gruppy.*` data
* Collect all monitoring data from the deployment group: `asadmin get --monitor Gruppy` - should get `Gruppy.*` data **and** _Insty1_ & _Insty2_ data
* Collect the aggregate monitoring data from the cluster: `asadmin get --monitor --aggregatedataonly=true Clusty` - should only get `Clusty.*` data
* Collect all monitoring data from the cluster: `asadmin get --monitor Clusty` - should get `Clusty.*` data **and** _Wibbles_ & _Wobbles_ data


### Testing Environment
Windows 11, Maven 3.9.15, Zulu JDK 21.0.11

## Documentation
N/A - I don't think anything here needs documenting?

## Notes for Reviewers
None
