### PR TITLE
FISH-11896 Unquote arguments in boot command files

### DIFF
--- a/nucleus/admin/config-api/src/main/java/fish/payara/boot/runtime/BootCommands.java
+++ b/nucleus/admin/config-api/src/main/java/fish/payara/boot/runtime/BootCommands.java
@@ -157,16 +157,16 @@ public class BootCommands {
     }
 
     private static String unquote(String token) {
-        int eq = token.indexOf('=');
-        if (eq >= 0 && eq < token.length() - 1) {
-            String val = token.substring(eq + 1);
-            if (val.length() >= 2 &&
-                    ((val.startsWith("\"") && val.endsWith("\"")) ||
-                    (val.startsWith("'") && val.endsWith("'")))) {
-                val = val.substring(1, val.length() - 1)
+        int equalsIndex = token.indexOf('=');
+        if (equalsIndex >= 0 && equalsIndex < token.length() - 1) {
+            String textAfterEquals = token.substring(equalsIndex + 1);
+            if (textAfterEquals.length() >= 2 &&
+                    ((textAfterEquals.startsWith("\"") && textAfterEquals.endsWith("\"")) ||
+                    (textAfterEquals.startsWith("'") && textAfterEquals.endsWith("'")))) {
+                textAfterEquals = textAfterEquals.substring(1, textAfterEquals.length() - 1)
                         .replace("\\\"", "\"")
                         .replace("\\'", "'");
-                return token.substring(0, eq + 1) + val;
+                return token.substring(0, equalsIndex + 1) + textAfterEquals;
             }
         } else if (token.length() >= 2 &&
                 ((token.startsWith("\"") && token.endsWith("\"")) ||

--- a/nucleus/admin/config-api/src/main/java/fish/payara/boot/runtime/BootCommands.java
+++ b/nucleus/admin/config-api/src/main/java/fish/payara/boot/runtime/BootCommands.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -143,7 +143,7 @@ public class BootCommands {
                 List<String> elements = new ArrayList<>();
                 Matcher flagMatcher = COMMAND_FLAG_PATTERN.matcher(commandStr);
                 while (flagMatcher.find()) {
-                    elements.add(flagMatcher.group(1));
+                    elements.add(unquote(flagMatcher.group(1)));
                 }
                 command = elements.toArray(new String[elements.size()]);
                 if (command.length > 1) {
@@ -154,6 +154,28 @@ public class BootCommands {
             }
             commandStr = bufferReader.readLine();
         }
+    }
+
+    private static String unquote(String token) {
+        int eq = token.indexOf('=');
+        if (eq >= 0 && eq < token.length() - 1) {
+            String val = token.substring(eq + 1);
+            if (val.length() >= 2 &&
+                    ((val.startsWith("\"") && val.endsWith("\"")) ||
+                    (val.startsWith("'") && val.endsWith("'")))) {
+                val = val.substring(1, val.length() - 1)
+                        .replace("\\\"", "\"")
+                        .replace("\\'", "'");
+                return token.substring(0, eq + 1) + val;
+            }
+        } else if (token.length() >= 2 &&
+                ((token.startsWith("\"") && token.endsWith("\"")) ||
+                 (token.startsWith("'") && token.endsWith("'")))) {
+            return token.substring(1, token.length() - 1)
+                    .replace("\\\"", "\"")
+                    .replace("\\'", "'");
+        }
+        return token;
     }
 
     public boolean executeCommands(CommandRunner runner) {

--- a/nucleus/admin/config-api/src/test/java/fish/payara/boot/runtime/BootCommandsTest.java
+++ b/nucleus/admin/config-api/src/test/java/fish/payara/boot/runtime/BootCommandsTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2019-2022] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -55,6 +55,58 @@ import org.junit.Test;
 public class BootCommandsTest {
 
     @Test
+    public void parseCommandStripsDoubleQuotesFromValues() throws IOException {
+        BootCommands bootCommands = new BootCommands();
+        String commandText = "set-config value=\"example\"";
+        try (Reader reader = new StringReader(commandText)) {
+            bootCommands.parseCommandScript(reader, false);
+        }
+        assertThat(bootCommands.getCommands().size(), is(1));
+        BootCommand command = bootCommands.getCommands().get(0);
+        assertThat(command.getArguments().length, is(1));
+        assertEquals("value=example", command.getArguments()[0]);
+    }
+
+    @Test
+    public void parseCommandStripsSingleQuotesFromValues() throws IOException {
+        BootCommands bootCommands = new BootCommands();
+        String commandText = "set-config value='example'";
+        try (Reader reader = new StringReader(commandText)) {
+            bootCommands.parseCommandScript(reader, false);
+        }
+        assertThat(bootCommands.getCommands().size(), is(1));
+        BootCommand command = bootCommands.getCommands().get(0);
+        assertThat(command.getArguments().length, is(1));
+        assertEquals("value=example", command.getArguments()[0]);
+    }
+
+    @Test
+    public void parseCommandStripsQuotesFromValueContainingSpaces() throws IOException {
+        BootCommands bootCommands = new BootCommands();
+        String commandText = "set format=\"%header.X-Forwarded-For% %auth-user-name% %datetime% %request% %status% %response.length%\"";
+        try (Reader reader = new StringReader(commandText)) {
+            bootCommands.parseCommandScript(reader, false);
+        }
+        assertThat(bootCommands.getCommands().size(), is(1));
+        BootCommand command = bootCommands.getCommands().get(0);
+        assertThat(command.getArguments().length, is(1));
+        assertEquals("format=%header.X-Forwarded-For% %auth-user-name% %datetime% %request% %status% %response.length%", command.getArguments()[0]);
+    }
+
+    @Test
+    public void parseCommandUnescapesInnerQuotes() throws IOException {
+        BootCommands bootCommands = new BootCommands();
+        String commandText = "set-config --description=\"results \\\"in\\\" error\"";
+        try (Reader reader = new StringReader(commandText)) {
+            bootCommands.parseCommandScript(reader, false);
+        }
+        assertThat(bootCommands.getCommands().size(), is(1));
+        BootCommand command = bootCommands.getCommands().get(0);
+        assertThat(command.getArguments().length, is(1));
+        assertEquals("--description=results \"in\" error", command.getArguments()[0]);
+    }
+
+    @Test
     public void parseCommand() throws IOException {
         BootCommands bootCommands = new BootCommands();
         String commandText = "create-custom-resource --restype java.lang.String -s v --name='custom-res' --description=\"results \\\"in\\\" error\" --property value=\"${ENV=ini_ws_uri}\" vfp/vfp-menu/ini.ws.uri";
@@ -69,10 +121,10 @@ public class BootCommandsTest {
         assertEquals(command.getArguments()[1], "java.lang.String");
         assertEquals(command.getArguments()[2], "-s");
         assertEquals(command.getArguments()[3], "v");
-        assertEquals(command.getArguments()[4], "--name='custom-res'");
-        assertEquals(command.getArguments()[5], "--description=\"results \\\"in\\\" error\"");
+        assertEquals(command.getArguments()[4], "--name=custom-res");
+        assertEquals(command.getArguments()[5], "--description=results \"in\" error");
         assertEquals(command.getArguments()[6], "--property");
-        assertEquals(command.getArguments()[7], "value=\"${ENV=ini_ws_uri}\"");
+        assertEquals(command.getArguments()[7], "value=${ENV=ini_ws_uri}");
         assertEquals(command.getArguments()[8], "vfp/vfp-menu/ini.ws.uri");
     }
 


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
When a boot command file contained a command such as 
```
set configs.config.server-config.http-service.access-log.format="%header.X-Forwarded-For% %auth-user-name% %datetime% %request% %status% %response.length%"
```

This would result in 
```
<access-log format="&quot;%header.X-Forwarded-For% %auth-user-name% %datetime% %request% %status% %response.length%&quot;"></access-log>
```

This PR changes this behaviour and strips the additional quotes (&quot;)

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
BootCommandsTest
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Tested on Payara Micro and Payara Server Docker Image.
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.9, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.9-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "26.4.1", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a