### PR TITLE
FISH-13392: enabling unit tests after fixing issue for NullPointerException

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceMetrics.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceMetrics.java
@@ -309,9 +309,9 @@ public interface FaultToleranceMetrics {
                     {"result", "valueReturned", "exceptionThrown"}, fallbackTag});
             //place to register telemetry ft.invocations.total
             Meter currentMeter = getCurrentMeter();
+            FaultToleranceMethodContextImpl faultToleranceMethodContext = (FaultToleranceMethodContextImpl) context;
+            setClassAndMethodName(faultToleranceMethodContext.getClassName() + "." + faultToleranceMethodContext.getMethodName());
             if (currentMeter != null) {
-                FaultToleranceMethodContextImpl faultToleranceMethodContext = (FaultToleranceMethodContextImpl) context;
-                setClassAndMethodName(faultToleranceMethodContext.getClassName() + "." + faultToleranceMethodContext.getMethodName());
                 addFTInvocationTotalMeter(createFTInvocationTotalMeter(getClassAndMethodName(), currentMeter, policy.isFallbackPresent()));
             }
 
@@ -391,10 +391,11 @@ public interface FaultToleranceMetrics {
     }
 
     default Meter getCurrentMeter() {
-        if (getDefaultHabitat() == null) {
+        var habitat = getDefaultHabitat();
+        if (habitat == null) {
             return null;
         }
-        OpenTelemetryService service = getDefaultHabitat().getService(OpenTelemetryService.class);
+        var service = habitat.getService(OpenTelemetryService.class);
         return service != null ? service.getCurrentMeter() : null;
     }
     

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceMetrics.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceMetrics.java
@@ -309,8 +309,10 @@ public interface FaultToleranceMetrics {
                     {"result", "valueReturned", "exceptionThrown"}, fallbackTag});
             //place to register telemetry ft.invocations.total
             Meter currentMeter = getCurrentMeter();
-            FaultToleranceMethodContextImpl faultToleranceMethodContext = (FaultToleranceMethodContextImpl) context;
-            setClassAndMethodName(faultToleranceMethodContext.getClassName() + "." + faultToleranceMethodContext.getMethodName());
+            if(context instanceof FaultToleranceMethodContextImpl faultToleranceMethodContext) {
+                setClassAndMethodName(faultToleranceMethodContext.getClassName() + "." + faultToleranceMethodContext.getMethodName());
+            }
+            
             if (currentMeter != null) {
                 addFTInvocationTotalMeter(createFTInvocationTotalMeter(getClassAndMethodName(), currentMeter, policy.isFallbackPresent()));
             }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceMetrics.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/main/java/fish/payara/microprofile/faulttolerance/FaultToleranceMetrics.java
@@ -302,17 +302,18 @@ public interface FaultToleranceMetrics {
      */
     default FaultToleranceMetrics boundTo(FaultToleranceMethodContext context, FaultTolerancePolicy policy) {
         if (policy.isMetricsEnabled) {
-            OpenTelemetryService openTelemetryService = getDefaultHabitat().getService(OpenTelemetryService.class);
             String[] fallbackTag = policy.isFallbackPresent()
                     ? new String[]{"fallback", "applied", "notApplied"}
                     : new String[]{"fallback", "notDefined"};
             register(Counter.class.getTypeName(), "ft.invocations.total", new String[][]{
                     {"result", "valueReturned", "exceptionThrown"}, fallbackTag});
             //place to register telemetry ft.invocations.total
-            Meter currentMeter = openTelemetryService.getCurrentMeter();
-            FaultToleranceMethodContextImpl faultToleranceMethodContext = (FaultToleranceMethodContextImpl) context;
-            setClassAndMethodName(faultToleranceMethodContext.getClassName() + "." + faultToleranceMethodContext.getMethodName());
-            addFTInvocationTotalMeter(createFTInvocationTotalMeter(getClassAndMethodName(), currentMeter, policy.isFallbackPresent()));
+            Meter currentMeter = getCurrentMeter();
+            if (currentMeter != null) {
+                FaultToleranceMethodContextImpl faultToleranceMethodContext = (FaultToleranceMethodContextImpl) context;
+                setClassAndMethodName(faultToleranceMethodContext.getClassName() + "." + faultToleranceMethodContext.getMethodName());
+                addFTInvocationTotalMeter(createFTInvocationTotalMeter(getClassAndMethodName(), currentMeter, policy.isFallbackPresent()));
+            }
 
             if (policy.isRetryPresent()) {
                 List<String> retryResultTag = new ArrayList<>(asList("retryResult", "valueReturned", "exceptionNotRetryable"));
@@ -326,15 +327,19 @@ public interface FaultToleranceMetrics {
                         {"retried", "true", "false"}, retryResultTag.toArray(new String[0])});
                 register(Counter.class.getTypeName(), "ft.retry.retries.total");
                 //place to register telemetry ft.retry.calls.total and ft.retry.retries.total
-                addFTRetryCallsCounter(createFTRetryCallsTotal(getClassAndMethodName(), currentMeter, policy.retry.isMaxRetriesSet(), policy.retry.isMaxDurationSet()));
-                addFTRetryRetriesCounter(createFTRetryRetriesTotal(getClassAndMethodName(), currentMeter));
+                if (currentMeter != null) {
+                    addFTRetryCallsCounter(createFTRetryCallsTotal(getClassAndMethodName(), currentMeter, policy.retry.isMaxRetriesSet(), policy.retry.isMaxDurationSet()));
+                    addFTRetryRetriesCounter(createFTRetryRetriesTotal(getClassAndMethodName(), currentMeter));
+                }
             }
             if (policy.isTimeoutPresent()) {
                 register(Counter.class.getTypeName(), "ft.timeout.calls.total", new String[][]{
                         {"timedOut", "true", "false"}});
                 register(Histogram.class.getTypeName(), "ft.timeout.executionDuration");
-                addFTTimeoutCallsTotal(createFTTimeoutCallsTotal(getClassAndMethodName(), currentMeter));
-                addFTTimeoutExecutionDuration(createFTTimeoutExecutionDuration(currentMeter));
+                if (currentMeter != null) {
+                    addFTTimeoutCallsTotal(createFTTimeoutCallsTotal(getClassAndMethodName(), currentMeter));
+                    addFTTimeoutExecutionDuration(createFTTimeoutExecutionDuration(currentMeter));
+                }
             }
             if (policy.isCircuitBreakerPresent()) {
                 register(Counter.class.getTypeName(), "ft.circuitbreaker.calls.total", new String[][]{
@@ -344,37 +349,53 @@ public interface FaultToleranceMetrics {
                 register("ft.circuitbreaker.state.total", MetricUnits.NANOSECONDS, state::nanosHalfOpen, "state", "halfOpen");
                 register("ft.circuitbreaker.state.total", MetricUnits.NANOSECONDS, state::nanosClosed, "state", "closed");
                 register(Counter.class.getTypeName(), "ft.circuitbreaker.opened.total");
-                addCircuitBreakerCallsTotal(createFTCircuitBreakerCallsTotal(getClassAndMethodName(), currentMeter));
-                addCircuitBreakerOpenedTotal(createFTCircuitBreakerOpenedTotal(getClassAndMethodName(), currentMeter));
-                createFTCircuitBreakerStateTotal(getClassAndMethodName(), currentMeter);
+                if (currentMeter != null) {
+                    addCircuitBreakerCallsTotal(createFTCircuitBreakerCallsTotal(getClassAndMethodName(), currentMeter));
+                    addCircuitBreakerOpenedTotal(createFTCircuitBreakerOpenedTotal(getClassAndMethodName(), currentMeter));
+                    createFTCircuitBreakerStateTotal(getClassAndMethodName(), currentMeter);
+                }
             }
             if (policy.isBulkheadPresent()) {
                 register(Counter.class.getTypeName(), "ft.bulkhead.calls.total", new String[][]{
                         {"bulkheadResult", "accepted", "rejected"}});
-                addBulkheadCallsTotal(createFTBulkheadCallsTotal(getClassAndMethodName(), currentMeter));
                 register(Histogram.class.getTypeName(), "ft.bulkhead.runningDuration");
-                addFTBulkheadRunningDuration(createFTBulkheadRunningDuration(currentMeter));
+                if (currentMeter != null) {
+                    addBulkheadCallsTotal(createFTBulkheadCallsTotal(getClassAndMethodName(), currentMeter));
+                    addFTBulkheadRunningDuration(createFTBulkheadRunningDuration(currentMeter));
+                }
                 if (policy.isAsynchronous()) {
                     BlockingQueue<Thread> running = context.getConcurrentExecutions();
                     register("ft.bulkhead.executionsRunning", null, running::size);
                     this.setExecutionBulkheadRunningSupplier(running::size);
-                    addFTBulkheadExecutionRunning(createFTBulkheadExecutionsRunning(currentMeter, this));
                     AtomicInteger queuingOrRunning = context.getQueuingOrRunningPopulation();
                     register("ft.bulkhead.executionsWaiting", null, () -> Math.max(0, queuingOrRunning.get() - policy.bulkhead.value));
                     this.setExecutionBulkheadWaitingSupplier(() -> Math.max(0, queuingOrRunning.get() - policy.bulkhead.value));
-                    addFTBulkheadExecutionWaiting(createFTBulkheadExecutionWaiting(currentMeter, this));
                     register(Histogram.class.getTypeName(), "ft.bulkhead.waitingDuration");
-                    addFTBulkheadWaitingDuration(createFTBulkheadWaitingDuration(currentMeter));
+                    if (currentMeter != null) {
+                        addFTBulkheadExecutionRunning(createFTBulkheadExecutionsRunning(currentMeter, this));
+                        addFTBulkheadExecutionWaiting(createFTBulkheadExecutionWaiting(currentMeter, this));
+                        addFTBulkheadWaitingDuration(createFTBulkheadWaitingDuration(currentMeter));
+                    }
                 } else {
                     AtomicInteger running = context.getQueuingOrRunningPopulation();
                     register("ft.bulkhead.executionsRunning", null, running::get);
                     this.setExecutionBulkheadRunningSupplier(running::get);
-                    addFTBulkheadExecutionRunning(createFTBulkheadExecutionsRunning(currentMeter, this));
+                    if (currentMeter != null) {
+                        addFTBulkheadExecutionRunning(createFTBulkheadExecutionsRunning(currentMeter, this));
+                    }
                 }
 
             }
         }
         return this;
+    }
+
+    default Meter getCurrentMeter() {
+        if (getDefaultHabitat() == null) {
+            return null;
+        }
+        OpenTelemetryService service = getDefaultHabitat().getService(OpenTelemetryService.class);
+        return service != null ? service.getCurrentMeter() : null;
     }
     
     /*

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AllMetricsTckTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AllMetricsTckTest.java
@@ -93,7 +93,7 @@ public class AllMetricsTckTest extends AbstractMetricTest {
     /**
      * Scenario is inspired by the TCK test of same name but more strict
      */
-   // @Test
+   @Test
     public void testMetricUnits() throws Exception  {
         Future<?> res = (Future<?>) callMethodDirectly(null);
         assertNoExceptionsThrown();
@@ -121,7 +121,7 @@ public class AllMetricsTckTest extends AbstractMetricTest {
     /**
      * Scenario does not exist in TCK, it makes a more strict assertions about the metrics expected after 1 successful call
      */
-    //@Test
+    @Test
     public void testMetricRegistrations() throws Exception {
         Future<?> res = (Future<?>) callMethodDirectly(null);
         assertNoExceptionsThrown();

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AsyncronousExceptionHandlingTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/AsyncronousExceptionHandlingTest.java
@@ -80,7 +80,7 @@ public class AsyncronousExceptionHandlingTest {
      * When returning a {@link Future} there is only 1 attempt made since a {@link Future} instance is returned on first
      * attempt.
      */
-    //@Test
+    @Test
     public void asyncFutureWithRetry() throws Exception {
         Future<?> result = proceedToDoneFuture();
         assertEquals("no retry attempt should occur", 1, asyncFutureWithRetryCallCount.get());
@@ -98,7 +98,7 @@ public class AsyncronousExceptionHandlingTest {
      * When the method returning a {@link Future} throws an {@link Exception} the {@link Retry} is applied and further
      * attempts are made.
      */
-    //@Test
+    @Test
     public void asyncFutureWithRetryThrowsException() throws Exception {
         Future<?> result = proceedToDoneFuture();
         assertEquals("all retry attempts should occur", 4, asyncFutureWithRetryThrowsExceptionCallCount.get());
@@ -116,7 +116,7 @@ public class AsyncronousExceptionHandlingTest {
      * A method returning {@link CompletionStage} must complete successful otherwise {@link Retry} is effective and
      * further attempts are made.
      */
-    //@Test
+    @Test
     public void asyncCompletionStageWithRetry() throws Exception {
         Future<?> result = proceedToDoneFuture();
         assertEquals("all retry attempts should occur", 3, asyncCompletionStageWithRetryCallCount.get());
@@ -134,7 +134,7 @@ public class AsyncronousExceptionHandlingTest {
      * For a method returning {@link CompletionStage} throwing an exception is similarly handled to returning a value
      * that later completes exceptionally. Therefore retry attempts should occur.
      */
-    //@Test
+    @Test
     public void asyncCompletionStageWithRetryThrowsException() throws Exception {
         Future<?> result = proceedToDoneFuture();
         assertEquals("all retry attempts should occur", 3, asyncCompletionStageWithRetryThrowsExceptionCallCount.get());
@@ -152,7 +152,7 @@ public class AsyncronousExceptionHandlingTest {
      * A {@link CompletionStage} that first completes exceptionally should make further {@link Retry} attempts and
      * complete successful in this scenario.
      */
-    //@Test
+    @Test
     public void asyncCompletionStageWithRetrySuccessOnRetry() throws Exception {
         Future<?> result = proceedToDoneFuture();
         assertEquals("one retry should lead to success", 2, asyncCompletionStageWithRetrySuccessOnRetryCallCount.get());

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadAsyncRetryTckTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadAsyncRetryTckTest.java
@@ -60,7 +60,7 @@ import org.junit.Test;
  */
 public class BulkheadAsyncRetryTckTest extends AbstractBulkheadTest {
 
-    //@Test(timeout = 60 * 1000)
+    @Test(timeout = 60 * 1000)
     public void testBulkheadClassAsynchronousPassiveRetry55() {
         assertExecutionResult("Success", loop(10, 5, 5));
     }
@@ -73,7 +73,7 @@ public class BulkheadAsyncRetryTckTest extends AbstractBulkheadTest {
         return bodyWaitThenReturnSuccess(waiter).toCompletableFuture();
     }
 
-    //@Test(timeout = 60 * 1000)
+    @Test(timeout = 60 * 1000)
     public void testBulkheadMethodAsynchronousRetry55() {
         assertExecutionResult("Success", loop(20, 5, 5));
     }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadBasicTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadBasicTest.java
@@ -73,7 +73,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
      *
      * Needs a timeout because incorrect implementation could otherwise lead to endless waiting.
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithoutQueue() {
         callAndWait(2);
     }
@@ -83,7 +83,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
         return bodyWaitThenReturnSuccessDirectly(waiter);
     }
 
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithoutQueueWithRetry() {
         callAndWait(4);
     }
@@ -95,7 +95,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
         return bodyWaitThenReturnSuccessDirectly(waiter);
     }
 
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithoutQueueNoWaiting() {
         callWithConcurrentCallers(100, 4);
     }
@@ -105,7 +105,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
         return bodyWaitThenReturnSuccessDirectly(waiter);
     }
 
-   // @Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithoutQueueNoWaitingWithRetry() {
         callWithConcurrentCallers(100, 4);
     }
@@ -124,7 +124,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
      *
      * Needs a timeout because incorrect implementation could otherwise lead to endless waiting.
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithQueue() {
         Thread exec1 = callMethodWithNewThreadAndWaitFor(commonWaiter);
         Thread exec2 = callMethodWithNewThreadAndWaitFor(commonWaiter);
@@ -153,7 +153,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
      * Similar to {@link #bulkheadWithQueue()} just that we interrupt the queueing threads and expect their permits to
      * be released.
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithQueueInterruptQueueing() {
         Thread exec1 = callMethodWithNewThreadAndWaitFor(commonWaiter);
         Thread exec2 = callMethodWithNewThreadAndWaitFor(commonWaiter);
@@ -187,7 +187,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
      * Similar to {@link #bulkheadWithQueue()} just that we interrupt the executing threads and expect their permits to
      * be released and waiting threads to become executing.
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithQueueInterruptExecuting() {
         CompletableFuture<Void> exec2Waiter = new CompletableFuture<>();
         Thread exec1 = callMethodWithNewThreadAndWaitFor(commonWaiter);
@@ -225,7 +225,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
      * Similar to {@link #bulkheadWithQueue()} but one thread executing fails by completing the {@link CompletionStage}
      * with an exception. This should exit the bulkhead and allow another thread to run.
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithQueueCompleteWithException() {
         CompletableFuture<Void> exec1Waiter = new CompletableFuture<>();
         Thread exec1 = callMethodWithNewThreadAndWaitFor(exec1Waiter);
@@ -263,7 +263,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
      * Similar to {@link #bulkheadWithQueue()} but one thread executing throws an exception which should exist the
      * bulkhead and allow another queueing thread to run.
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithQueueThrowsException() {
         CompletableFuture<Void> exec1Waiter = new CompletableFuture<>();
         Thread exec1 = callMethodWithNewThreadAndWaitFor(exec1Waiter);
@@ -296,7 +296,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
         });
     }
 
-   /// @Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithoutQueueWithAsyncCompletionStageExitsOnCompletion() {
         callMethodWithNewThreadAndWaitFor(commonWaiter);
         callMethodWithNewThreadAndWaitFor(commonWaiter);
@@ -317,7 +317,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
         return bodyReturnThenWaitOnCompletionWithSuccess(waiter);
     }
 
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithQueueWithAsyncCompletionStageExitsOnCompletion() {
         callMethodWithNewThreadAndWaitFor(commonWaiter);
         callMethodWithNewThreadAndWaitFor(commonWaiter);
@@ -341,7 +341,7 @@ public class BulkheadBasicTest extends AbstractBulkheadTest {
         return bodyReturnThenWaitOnCompletionWithSuccess(waiter);
     }
 
-   // @Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadWithoutQueueSingleCapacity() {
         callMethodWithNewThreadAndWaitFor(commonWaiter);
         waitUntilPermitsAquired(1, 0);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadLifecycleTckTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadLifecycleTckTest.java
@@ -112,7 +112,7 @@ public class BulkheadLifecycleTckTest extends AbstractRecordingTest {
     /**
      * Scenario is equivalent to the TCK test of same name but not 100% identical
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void noSharingBetweenClasses() throws Exception {
         Method service1 = BulkheadLifecycleService1.class.getDeclaredMethod("service", CompletableFuture.class);
         Method service2 = BulkheadLifecycleService2.class.getDeclaredMethod("service", CompletableFuture.class);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadMetricTckTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadMetricTckTest.java
@@ -70,7 +70,7 @@ public class BulkheadMetricTckTest extends AbstractMetricTest {
     /**
      * Scenario is equivalent to the TCK test of same name but not 100% identical
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadMetricAsyncTest() {
         callMethodWithNewThreadAndWaitFor(commonWaiter);
         callMethodWithNewThreadAndWaitFor(commonWaiter);
@@ -106,7 +106,7 @@ public class BulkheadMetricTckTest extends AbstractMetricTest {
     /**
      * Scenario is equivalent to the TCK test of same name but not 100% identical
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadMetricHistogramTest() {
         final long delayMs = 100;
         long beforeInitTimestamp = System.nanoTime();
@@ -151,7 +151,7 @@ public class BulkheadMetricTckTest extends AbstractMetricTest {
     /**
      * Scenario is equivalent to the TCK test of same name but not 100% identical
      */
-    //@Test(timeout = 3000)
+    @Test(timeout = 3000)
     public void bulkheadMetricRejectionTest() {
         callMethodWithNewThreadAndWaitFor(commonWaiter);
         callMethodWithNewThreadAndWaitFor(commonWaiter);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadStressTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/BulkheadStressTest.java
@@ -55,7 +55,7 @@ import org.junit.Test;
  */
 public class BulkheadStressTest extends AbstractBulkheadTest {
 
-    //@Test
+    @Test
     public void bulkheadWithQueueAndRetry_55_100() {
         loop(5, 100, 5);
     }
@@ -68,7 +68,7 @@ public class BulkheadStressTest extends AbstractBulkheadTest {
         return bodyWaitThenReturnSuccess(waiter).toCompletableFuture();
     }
 
-   // @Test
+    @Test
     public void bulkheadWithQueueAndRetry_55_100_NoDelay() {
         loop(1, 100, 5);
     }
@@ -81,7 +81,7 @@ public class BulkheadStressTest extends AbstractBulkheadTest {
         return bodyWaitThenReturnSuccess(null).toCompletableFuture();
     }
 
-    //@Test
+    @Test
     public void bulkheadWithoutQueueSingleCapacity() {
         loop(0, 100, 3);
         assertMaxConcurrentExecution(1);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerBasicTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/CircuitBreakerBasicTest.java
@@ -109,7 +109,7 @@ public class CircuitBreakerBasicTest {
      * The simplest possible {@link CircuitBreaker} without a delay between OPEN and HALF-OPEN whereby OPEN is not
      * observable short.
      */
-    //@Test
+    @Test
     public void circuitBreakerNoDelay() throws Exception {
         assertEquals(1, proceedToResultValue().intValue());
         assertProceedToResultValueFails(IllegalStateException.class);
@@ -132,7 +132,7 @@ public class CircuitBreakerBasicTest {
      * Tests the {@link CircuitBreaker} with delay whereby OPEN state is kept for a time here mocked by waiting for the
      * {@link #waitBeforeHalfOpenAgain} future to have the test control timing.
      */
-    //@Test
+    @Test
     public void circuitBreakerWithDelay() throws Exception {
         assertEquals(1, proceedToResultValue().intValue());
         assertProceedToResultValueFails(IllegalStateException.class);
@@ -160,7 +160,7 @@ public class CircuitBreakerBasicTest {
         return incrementAndFailingOnEveryOtherInvocationOnFirst6();
     }
 
-    //@Test
+    @Test
     public void circuitBreakerNotFailingOn() throws Exception {
         assertEquals(1, proceedToResultValue().intValue());
         assertProceedToResultValueFails(IllegalStateException.class);

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/FallbackBasicTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/FallbackBasicTest.java
@@ -61,7 +61,7 @@ public class FallbackBasicTest implements FallbackHandler<String> {
     /**
      * Most basic case where annotated method fails and the fallback returns a result (no method arguments)
      */
-    //@Test
+    @Test
     public void fallbackMethod( ) throws Exception {
         assertEquals("fallbackMethod", proceedToResultValue());
     }
@@ -78,7 +78,7 @@ public class FallbackBasicTest implements FallbackHandler<String> {
     /**
      * Annotated method fails and fallback returns a result with method arguments
      */
-    //@Test
+    @Test
     public void fallbackMethodWithArguments() throws Exception {
         assertEquals("fallbackMethodWithArguments:Peter", proceedToResultValue("Peter"));
     }
@@ -95,7 +95,7 @@ public class FallbackBasicTest implements FallbackHandler<String> {
     /**
      * Both annotated method and fallback method fail.
      */
-    //@Test(expected = IllegalStateException.class)
+    @Test(expected = IllegalStateException.class)
     public void fallbackMethodFailsToo() throws Exception {
         proceedToResultValue();
     }
@@ -112,7 +112,7 @@ public class FallbackBasicTest implements FallbackHandler<String> {
     /**
      * Most basic {@link FallbackHandler} test where annotated method fails and fallback returns a result value. 
      */
-    //@Test
+    @Test
     public void fallbackHandler() throws Exception {
         assertEquals("fallbackHandler", proceedToResultValue());
     }
@@ -125,7 +125,7 @@ public class FallbackBasicTest implements FallbackHandler<String> {
     /**
      * Basic case of a {@link FallbackHandler} for a method with arguments.
      */
-    //@Test
+    @Test
     public void fallbackHandlerWithArguments() throws Exception {
         assertEquals("fallbackHandlerWithArguments:Peter", proceedToResultValue("Peter"));
     }
@@ -138,7 +138,7 @@ public class FallbackBasicTest implements FallbackHandler<String> {
     /**
      * Both annotated method and fallback handler fail.
      */
-    //@Test(expected = IllegalStateException.class)
+    @Test(expected = IllegalStateException.class)
     public void fallbackHandlerFailsToo() throws Exception {
         proceedToResultValue();
     }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/FallbackInvalidTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/FallbackInvalidTest.java
@@ -77,7 +77,7 @@ public class FallbackInvalidTest extends FallbackMethodBeanB<Long> {
      * FallbackMethodOutOfPackageTest
      */
 
-    //@Test
+    @Test
     public void fallbackMethodOutOfPackage() {
         assertAnnotationInvalid("Fallback has a fallbackMethod value referring to a method that is not accessible.");
     }
@@ -91,7 +91,7 @@ public class FallbackInvalidTest extends FallbackMethodBeanB<Long> {
      * FallbackMethodSubclassTest
      */
 
-    //@Test
+    @Test
     public void fallbackMethodSubclass() {
         assertAnnotationInvalid("Fallback has a fallbackMethod value referring to a method that is not defined or has a incompatible method signature.");
     }
@@ -104,7 +104,7 @@ public class FallbackInvalidTest extends FallbackMethodBeanB<Long> {
      * FallbackMethodSuperclassPrivateTest
      */
 
-    //@Test
+    @Test
     public void fallbackMethodSuperclassPrivate() {
         assertAnnotationInvalid("Fallback has a fallbackMethod value referring to a method that is not accessible.");
     }
@@ -118,7 +118,7 @@ public class FallbackInvalidTest extends FallbackMethodBeanB<Long> {
      * FallbackMethodWildcardNegativeTest
      */
 
-    //@Test
+    @Test
     public void fallbackMethodWildcardNegative() {
         assertAnnotationInvalid("Fallback has a fallbackMethod value referring to a method that is not defined or has a incompatible method signature.");
     }
@@ -136,7 +136,7 @@ public class FallbackInvalidTest extends FallbackMethodBeanB<Long> {
      * IncompatibleFallbackMethodTest
      */
 
-    //@Test
+    @Test
     public void fallbackMethodInvalidReturnType() {
         assertAnnotationInvalid("Fallback has a fallbackMethod value whose return type of does not match.");
     }
@@ -158,7 +158,7 @@ public class FallbackInvalidTest extends FallbackMethodBeanB<Long> {
      * IncompatibleFallbackMethodWithArgsTest
      */
 
-    //@Test
+    @Test
     public void fallbackMethodIncompatibleArgumentList() {
         assertAnnotationInvalid("Fallback has a fallbackMethod value referring to a method that is not defined or has a incompatible method signature.");
     }
@@ -189,7 +189,7 @@ public class FallbackInvalidTest extends FallbackMethodBeanB<Long> {
 
     }
 
-   // @Test
+    @Test
     public void fallbackMethodAndHandlerDefined() {
         assertAnnotationInvalid("Fallback defined both a fallback handler and a fallback method.");
     }
@@ -207,7 +207,7 @@ public class FallbackInvalidTest extends FallbackMethodBeanB<Long> {
      * IncompatibleFallbackTest
      */
 
-    //@Test
+    @Test
     public void fallbackHandlerIncompatibleReturnType() {
         assertAnnotationInvalid("Fallback has a value whose return type of does not match.");
     }

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/FaultToleranceStressTest.java
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/src/test/java/fish/payara/microprofile/faulttolerance/policy/FaultToleranceStressTest.java
@@ -182,7 +182,7 @@ public class FaultToleranceStressTest implements FallbackHandler<Future<String>>
     final AtomicReference<BlockingQueue<Thread>> concurrentExecutions = service.getConcurrentExecutionsReference();
     final AtomicInteger waitingQueuePopulation = service.getWaitingQueuePopulationReference();
 
-    //@Test
+    @Test
     public void occasionallyFailingService() throws InterruptedException {
         Method annotatedMethod = TestUtils.getAnnotatedMethod();
         Runnable callerTask = () -> callServiceMethod(annotatedMethod);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Enabling unit test for Fault Tolerance previously disabled
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a fix to enable the unit test that previously were disabled when upgrading the version of Fault Tolerance for MicroProfile 7.1
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Build server from pipeline without any issue after passing all unit tests and the TCK from Fault Tolerance:

<img width="1265" height="836" alt="image" src="https://github.com/user-attachments/assets/9b837ad7-16d6-4c29-b2a6-c5df19963960" />

Fault Tolerance TCK:
<img width="1359" height="306" alt="image" src="https://github.com/user-attachments/assets/9aa43019-8721-4a23-b8f0-28a30cf560b0" />



### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04, azul jdk 21,  maven 3.9.11
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
