### PR TITLE
FISH-10485 FISH-13138 Move Micro Boot Properties Timing Earlier and Fix Launcher Not Reading Boot Properties

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExplodedURLClassloader.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExplodedURLClassloader.java
@@ -47,7 +47,6 @@ import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.CodeSource;
 import java.util.ArrayList;
@@ -58,8 +57,6 @@ import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static fish.payara.micro.boot.loader.Launcher.BOOT_PROPS_FILE;
-
 /**
  *
  * @author steve
@@ -67,8 +64,10 @@ import static fish.payara.micro.boot.loader.Launcher.BOOT_PROPS_FILE;
 public class ExplodedURLClassloader extends OpenURLClassLoader {
 
     private final File explodedDir;
-    private static final String JAR_DOMAIN_DIR = "MICRO-INF/runtime/";
-    private static final String LIB_DOMAIN_DIR = "MICRO-INF/lib/";
+    public static final String RUNTIME_DIR_NAME = "runtime";
+    public static final String LIB_DIR_NAME = "lib";
+    private static final String JAR_DOMAIN_DIR = "MICRO-INF/" + RUNTIME_DIR_NAME + "/";
+    private static final String LIB_DOMAIN_DIR = "MICRO-INF/" + LIB_DIR_NAME + "/";
 
     private List<File> filesForDeletion;
 
@@ -113,12 +112,12 @@ public class ExplodedURLClassloader extends OpenURLClassLoader {
     private void explodeJars() throws IOException {
 
         // create a runtime jar directory
-        File runtimeDir = new File(explodedDir, "runtime");
+        File runtimeDir = new File(explodedDir, RUNTIME_DIR_NAME);
         runtimeDir.mkdirs();
         registerForDeletion(runtimeDir);
 
         // create a lib directory
-        File libDir = new File(explodedDir,"lib");
+        File libDir = new File(explodedDir, LIB_DIR_NAME);
         libDir.mkdirs();
         registerForDeletion(libDir);
 
@@ -134,9 +133,6 @@ public class ExplodedURLClassloader extends OpenURLClassLoader {
                 String[] jars = src.getLocation().toURI().getSchemeSpecificPart().split("!");
                 File file = new File(jars[0]);
 
-                // Strip the preceding '/'
-                String bootPropsFile = BOOT_PROPS_FILE.substring(1);
-
                 try (JarFile jar = new JarFile(file)) {
                     Enumeration<JarEntry> entries = jar.entries();
                     while (entries.hasMoreElements()) {
@@ -146,8 +142,6 @@ public class ExplodedURLClassloader extends OpenURLClassLoader {
                             fileName = entry.getName().substring(JAR_DOMAIN_DIR.length());
                         } else if (entry.getName().startsWith(LIB_DOMAIN_DIR)) {
                             fileName = entry.getName().substring(LIB_DOMAIN_DIR.length());
-                        } else if (entry.getName().equals(bootPropsFile)) {
-                            fileName = Paths.get(BOOT_PROPS_FILE).getFileName().toString();
                         }
 
                         if (fileName != null) {

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExplodedURLClassloader.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/ExplodedURLClassloader.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -47,6 +47,7 @@ import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.CodeSource;
 import java.util.ArrayList;
@@ -56,6 +57,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static fish.payara.micro.boot.loader.Launcher.BOOT_PROPS_FILE;
 
 /**
  *
@@ -131,6 +134,9 @@ public class ExplodedURLClassloader extends OpenURLClassLoader {
                 String[] jars = src.getLocation().toURI().getSchemeSpecificPart().split("!");
                 File file = new File(jars[0]);
 
+                // Strip the preceding '/'
+                String bootPropsFile = BOOT_PROPS_FILE.substring(1);
+
                 try (JarFile jar = new JarFile(file)) {
                     Enumeration<JarEntry> entries = jar.entries();
                     while (entries.hasMoreElements()) {
@@ -140,6 +146,8 @@ public class ExplodedURLClassloader extends OpenURLClassLoader {
                             fileName = entry.getName().substring(JAR_DOMAIN_DIR.length());
                         } else if (entry.getName().startsWith(LIB_DOMAIN_DIR)) {
                             fileName = entry.getName().substring(LIB_DOMAIN_DIR.length());
+                        } else if (entry.getName().equals(bootPropsFile)) {
+                            fileName = Paths.get(BOOT_PROPS_FILE).getFileName().toString();
                         }
 
                         if (fileName != null) {

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
@@ -13,16 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Modified 2017 Payara Foundation
+// Modified 2017-2026 Payara Foundation
 package fish.payara.micro.boot.loader;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import fish.payara.micro.boot.loader.archive.Archive;
 import fish.payara.micro.boot.loader.archive.JarFileArchive;
@@ -35,6 +40,8 @@ import fish.payara.micro.boot.loader.archive.JarFileArchive;
  * @author Dave Syer
  */
 public abstract class Launcher {
+
+    private static final String BOOT_PROPS_FILE = "/MICRO-INF/payara-boot.properties";
 
     /**
      * Launch the application. This method is the initial entry point that
@@ -57,6 +64,8 @@ public abstract class Launcher {
             }
         }
 
+        setPayaraBootProperties();
+
         ClassLoader classLoader;
         if (!explode) {
             classLoader = createClassLoader(getClassPathArchives());
@@ -71,6 +80,26 @@ public abstract class Launcher {
             }
         }
         return launch(method, args, getMainClass(), classLoader);
+    }
+
+    public static Properties setPayaraBootProperties() {
+        Properties bootProperties = new Properties();
+
+        try (InputStream is = Launcher.class.getResourceAsStream(BOOT_PROPS_FILE)) {
+            if (is != null) {
+                bootProperties.load(is);
+                for (String key : bootProperties.stringPropertyNames()) {
+                    // Do not override an existing system property
+                    if (System.getProperty(key) == null) {
+                        System.setProperty(key, bootProperties.getProperty(key));
+                    }
+                }
+            }
+        } catch (IOException ioe) {
+            Logger.getLogger(Launcher.class.getName()).log(Level.WARNING, "Could not load the boot system properties from " + BOOT_PROPS_FILE, ioe);
+        }
+
+        return bootProperties;
     }
 
     /**

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Modified 2017-2026 Payara Foundation
+// Modified 2017-2026 Payara Foundation and/or its affiliates
 package fish.payara.micro.boot.loader;
 
 import java.io.File;
@@ -41,7 +41,7 @@ import fish.payara.micro.boot.loader.archive.JarFileArchive;
  */
 public abstract class Launcher {
 
-    private static final String BOOT_PROPS_FILE = "/MICRO-INF/payara-boot.properties";
+    public static final String BOOT_PROPS_FILE = "/MICRO-INF/payara-boot.properties";
 
     /**
      * Launch the application. This method is the initial entry point that
@@ -64,7 +64,9 @@ public abstract class Launcher {
             }
         }
 
-        setPayaraBootProperties();
+        try (InputStream inputStream = Launcher.class.getResourceAsStream(BOOT_PROPS_FILE)) {
+            setPayaraBootProperties(inputStream);
+        }
 
         ClassLoader classLoader;
         if (!explode) {
@@ -82,12 +84,20 @@ public abstract class Launcher {
         return launch(method, args, getMainClass(), classLoader);
     }
 
-    private static Properties setPayaraBootProperties() {
+    /**
+     * Loads the properties from the given {@link InputStream} and sets them as system properties if not already set.
+     *
+     * This method will not close the provided {@link InputStream}.
+     *
+     * @param inputStream the input stream to read the properties from.
+     * @return The properties read from the {@code inputStream} parameter.
+     */
+    public static Properties setPayaraBootProperties(InputStream inputStream) {
         Properties bootProperties = new Properties();
 
-        try (InputStream is = Launcher.class.getResourceAsStream(BOOT_PROPS_FILE)) {
-            if (is != null) {
-                bootProperties.load(is);
+        try {
+            if (inputStream != null) {
+                bootProperties.load(inputStream);
                 for (String key : bootProperties.stringPropertyNames()) {
                     // Do not override an existing system property
                     if (System.getProperty(key) == null) {
@@ -96,7 +106,7 @@ public abstract class Launcher {
                 }
             }
         } catch (IOException ioe) {
-            Logger.getLogger(Launcher.class.getName()).log(Level.WARNING, "Could not load the boot system properties from " + BOOT_PROPS_FILE, ioe);
+            Logger.getLogger(Launcher.class.getName()).log(Level.WARNING, "Could not load the boot system properties", ioe);
         }
 
         return bootProperties;

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
@@ -17,6 +17,7 @@
 package fish.payara.micro.boot.loader;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -41,7 +42,8 @@ import fish.payara.micro.boot.loader.archive.JarFileArchive;
  */
 public abstract class Launcher {
 
-    public static final String BOOT_PROPS_FILE = "/MICRO-INF/payara-boot.properties";
+    public static final String BOOT_PROPS_FILE_NAME = "payara-boot.properties";
+    public static final String BOOT_PROPS_FILE = "/MICRO-INF/" + BOOT_PROPS_FILE_NAME;
 
     /**
      * Launch the application. This method is the initial entry point that
@@ -66,6 +68,8 @@ public abstract class Launcher {
 
         try (InputStream inputStream = Launcher.class.getResourceAsStream(BOOT_PROPS_FILE)) {
             setPayaraBootProperties(inputStream);
+        } catch (FileNotFoundException fnfe) {
+            Logger.getLogger(Launcher.class.getName()).log(Level.WARNING, "Could not load the boot system properties", fnfe);
         }
 
         ClassLoader classLoader;

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
@@ -66,11 +66,7 @@ public abstract class Launcher {
             }
         }
 
-        try (InputStream inputStream = Launcher.class.getResourceAsStream(BOOT_PROPS_FILE)) {
-            setPayaraBootProperties(inputStream);
-        } catch (FileNotFoundException fnfe) {
-            Logger.getLogger(Launcher.class.getName()).log(Level.WARNING, "Could not load the boot system properties", fnfe);
-        }
+        setPayaraBootProperties(Launcher.class.getResourceAsStream(BOOT_PROPS_FILE));
 
         ClassLoader classLoader;
         if (!explode) {

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/java/fish/payara/micro/boot/loader/Launcher.java
@@ -82,7 +82,7 @@ public abstract class Launcher {
         return launch(method, args, getMainClass(), classLoader);
     }
 
-    public static Properties setPayaraBootProperties() {
+    private static Properties setPayaraBootProperties() {
         Properties bootProperties = new Properties();
 
         try (InputStream is = Launcher.class.getResourceAsStream(BOOT_PROPS_FILE)) {

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/PayaraMicroImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2016-2025] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -126,7 +126,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
     private static final Logger LOGGER = Logger.getLogger("PayaraMicro");
 
-    private static final String BOOT_PROPS_FILE = "/MICRO-INF/payara-boot.properties";
     private static final String USER_PROPS_FILE = "MICRO-INF/deploy/payaramicro.properties";
     private static final String CONTEXT_PROPS_FILE = "MICRO-INF/deploy/contexts.properties";
 
@@ -226,8 +225,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
     }
 
     public static PayaraMicroBoot create(String[] args) throws Exception {
-        // configure boot system properties
-        setBootProperties();
         PayaraMicroImpl main = getInstance();
         main.scanArgs(args);
         if (main.getUberJar() != null) {
@@ -2668,26 +2665,6 @@ public class PayaraMicroImpl implements PayaraMicroBoot {
 
         if (alternateHZConfigFile != null) {
             runtimeDir.setHZConfigFile(alternateHZConfigFile);
-        }
-    }
-
-    private static void setBootProperties() {
-        Properties bootProperties = new Properties();
-
-        // First Read from embedded boot preoprties
-        try (InputStream is = PayaraMicroImpl.class
-                .getResourceAsStream(BOOT_PROPS_FILE)) {
-            if (is != null) {
-                bootProperties.load(is);
-                for (String key : bootProperties.stringPropertyNames()) {
-                    // do not override an existing system property
-                    if (System.getProperty(key) == null) {
-                        System.setProperty(key, bootProperties.getProperty(key));
-                    }
-                }
-            }
-        } catch (IOException ioe) {
-            LOGGER.log(Level.WARNING, "Could not load the boot system properties from " + BOOT_PROPS_FILE, ioe);
         }
     }
 

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
@@ -45,16 +45,17 @@ import fish.payara.micro.boot.loader.Launcher;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static fish.payara.micro.boot.loader.Launcher.BOOT_PROPS_FILE;
+import static fish.payara.micro.boot.loader.Launcher.BOOT_PROPS_FILE_NAME;
+import static fish.payara.micro.impl.RuntimeDirectory.CONFIG_DIR_NAME;
 
 public class RootDirLauncher {
     static final String BOOT_JAR_URL = "fish.payara.micro.BootJar";
@@ -67,9 +68,11 @@ public class RootDirLauncher {
         System.setProperty(BOOT_JAR_URL, bootJar.toURI().toString());
         System.setProperty(ROOT_DIR_PATH, rootDir);
 
-        String bootPropsFile = rootDir + File.separator + "runtime" + File.separator + Paths.get(BOOT_PROPS_FILE).getFileName().toString();
+        String bootPropsFile = rootDir + File.separator + CONFIG_DIR_NAME + File.separator + BOOT_PROPS_FILE_NAME;
         try (FileInputStream fis = new FileInputStream(bootPropsFile)) {
             Launcher.setPayaraBootProperties(fis);
+        } catch (FileNotFoundException fnfe) {
+            LOGGER.log(Level.WARNING, "Could not load the expected boot system properties file", fnfe);
         }
 
         PayaraMicroImpl.main(prepareArgs(args, rootDir));

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
@@ -45,7 +45,7 @@ import fish.payara.micro.boot.loader.Launcher;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -71,8 +71,8 @@ public class RootDirLauncher {
 
         try (FileInputStream fis = new FileInputStream(Path.of(rootDir, CONFIG_DIR_NAME, BOOT_PROPS_FILE_NAME).toString())) {
             Launcher.setPayaraBootProperties(fis);
-        } catch (FileNotFoundException fnfe) {
-            LOGGER.log(Level.WARNING, "Could not load the expected boot system properties file", fnfe);
+        } catch (IOException ioe) {
+            LOGGER.log(Level.WARNING, "Could not load the expected boot system properties file", ioe);
         }
 
         PayaraMicroImpl.main(prepareArgs(args, rootDir));

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
@@ -1,7 +1,7 @@
 /*
  *    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *    Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ *    Copyright (c) 2020-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  *    The contents of this file are subject to the terms of either the GNU
  *    General Public License Version 2 only ("GPL") or the Common Development
@@ -41,15 +41,20 @@
 package fish.payara.micro.impl;
 
 import fish.payara.micro.PayaraMicro;
+import fish.payara.micro.boot.loader.Launcher;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static fish.payara.micro.boot.loader.Launcher.BOOT_PROPS_FILE;
 
 public class RootDirLauncher {
     static final String BOOT_JAR_URL = "fish.payara.micro.BootJar";
@@ -61,6 +66,12 @@ public class RootDirLauncher {
         String rootDir = bootJar.getParentFile().getAbsolutePath();
         System.setProperty(BOOT_JAR_URL, bootJar.toURI().toString());
         System.setProperty(ROOT_DIR_PATH, rootDir);
+
+        String bootPropsFile = rootDir + File.separator + "runtime" + File.separator + Paths.get(BOOT_PROPS_FILE).getFileName().toString();
+        try (FileInputStream fis = new FileInputStream(bootPropsFile)) {
+            Launcher.setPayaraBootProperties(fis);
+        }
+
         PayaraMicroImpl.main(prepareArgs(args, rootDir));
     }
 

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RootDirLauncher.java
@@ -48,6 +48,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
@@ -68,8 +69,7 @@ public class RootDirLauncher {
         System.setProperty(BOOT_JAR_URL, bootJar.toURI().toString());
         System.setProperty(ROOT_DIR_PATH, rootDir);
 
-        String bootPropsFile = rootDir + File.separator + CONFIG_DIR_NAME + File.separator + BOOT_PROPS_FILE_NAME;
-        try (FileInputStream fis = new FileInputStream(bootPropsFile)) {
+        try (FileInputStream fis = new FileInputStream(Path.of(rootDir, CONFIG_DIR_NAME, BOOT_PROPS_FILE_NAME).toString())) {
             Launcher.setPayaraBootProperties(fis);
         } catch (FileNotFoundException fnfe) {
             LOGGER.log(Level.WARNING, "Could not load the expected boot system properties file", fnfe);

--- a/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RuntimeDirectory.java
+++ b/appserver/extras/payara-micro/payara-micro-core/src/main/java/fish/payara/micro/impl/RuntimeDirectory.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2016-2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -57,6 +57,9 @@ import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static fish.payara.micro.boot.loader.Launcher.BOOT_PROPS_FILE;
+import static fish.payara.micro.boot.loader.Launcher.BOOT_PROPS_FILE_NAME;
+
 /**
  * Class for manipulating the Payara Micro runtime directory
  *
@@ -76,6 +79,9 @@ class RuntimeDirectory {
     private static final String JAR_DOMAIN_DIR = "MICRO-INF/domain/";
     private File domainXML;
     private File configDir;
+
+    public static final String DOCROOT_DIR_NAME = "docroot";
+    public static final String CONFIG_DIR_NAME = "config";
 
     /**
      * Default constructor unpacks into a temporary directory
@@ -129,10 +135,10 @@ class RuntimeDirectory {
     private void unpackRuntime() throws URISyntaxException, IOException {
 
         // make a docroot here
-        new File(directory, "docroot").mkdirs();
+        new File(directory, DOCROOT_DIR_NAME).mkdirs();
 
         // create a config dir and unpack
-        configDir = new File(directory, "config");
+        configDir = new File(directory, CONFIG_DIR_NAME);
         configDir.mkdirs();
 
         // Get our configuration files
@@ -143,12 +149,19 @@ class RuntimeDirectory {
             String jars[] = src.getLocation().toURI().getSchemeSpecificPart().split("!");
             File file = new File(jars[0]);
 
+            String bootPropsFile = BOOT_PROPS_FILE.substring(1);
+
             try (JarFile jar = new JarFile(file)) {
                 Enumeration<JarEntry> entries = jar.entries();
                 while (entries.hasMoreElements()) {
                     JarEntry entry = entries.nextElement();
+                    String fileName = null;
                     if (entry.getName().startsWith(JAR_DOMAIN_DIR)) {
-                        String fileName = entry.getName().substring(JAR_DOMAIN_DIR.length());
+                        fileName = entry.getName().substring(JAR_DOMAIN_DIR.length());
+                    } else if (entry.getName().equals(bootPropsFile)) {
+                        fileName = BOOT_PROPS_FILE_NAME;
+                    }
+                    if (fileName != null) {
                         File outputFile = new File(configDir, fileName);
 
                         if (isTempDir) {
@@ -160,7 +173,7 @@ class RuntimeDirectory {
                             if (entry.isDirectory()) {
                                 outputFile.mkdirs();
                             } else {
-                                // write out the conifugration file
+                                // write out the configuration file
                                 try (InputStream is = jar.getInputStream(entry)) {
                                     Files.copy(is, outputFile.toPath());
                                 }


### PR DESCRIPTION
## Description
Moves the setting of the boot properties for Payara Micro earlier.

Changes to when Java first performs the lookup for the `java.net.preferIPv4Stack` property meant that when using Java 21 or higher and not defining a directory for Payara Micro to unpack into (default behaviour is to unpack into a temp directory) then the payara-boot.properties file had not been read and applied yet (which includes setting this property).

This property is only looked up once, meaning that it was forever initialising as null.

This moves the reading and setting of properties to before a temp dir is created (since this is what causes the lookup).

However, the "stronger" way of configuring this property remains to be defining it on the command line itself. I don't think there is a way around this, and figuring out if there is becomes troublesome as you start heading into native code.

This PR also fixes the Payara Micro Launcher not reading from the boot properties

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
We never got a reproducer for the inciting issue to work on anything other than the issue raiser's environment. So all testing is essentially done via breakpoints.

Added break points to `InetAddress#initializePlatformLookupPolicy` (from the JDK itself) to see which class `impl` gets initialised as, and the values of `PREFER_IPV4_STACK_VALUE` and `PREFER_IPV6_ADDRESSES_VALUE`.

An interesting quirk which I can't yet fathom out (as it goes into `native` code) is why specifying `java.net.preferIPv4Stack` on the command line seems to be a "stronger" way of setting it: doing so makes `impl` be `Inet4AddressImpl` class rather than `Inet6AddressImpl` (default). Setting the property programmatically via `System.setProperty` does not replicate this behaviour, even though the static initialisation of the system properties has already happened by the time the class is initialised. 

Scenarios tested:
* No root dir, no property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" -jar payara-micro.jar`
  * IPv4 Preferred = true
  * impl = Inet6AddressImpl
  * LookupPolicy = IPV4
* No root dir, property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" "-Djava.net.preferIPv4Stack=true" -jar payara-micro.jar`
  * IPv4 Preferred = true
  * impl = Inet4AddressImpl
  * LookupPolicy = IPV4
* Clean root dir, no property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" -jar payara-micro.jar --rootdir C:\Users\pandr\Downloads\FISH-10485\explode`
  * IPv4 Preferred = true
  * impl = Inet6AddressImpl
  * LookupPolicy = IPV4
* Clean root dir, property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" "-Djava.net.preferIPv4Stack=true" -jar payara-micro.jar --rootdir C:\Users\pandr\Downloads\FISH-10485\explode`
  * IPv4 Preferred = true
  * impl = Inet4AddressImpl
  * LookupPolicy = IPV4
* Uberjar, no property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" -jar payara-micro.jar --outputuberjar C:\Users\andrew.pielage\Downloads\FISH-10485\uberjar.jar && java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" -jar C:\Users\andrew.pielage\Downloads\FISH-10485\uberjar.jar`
  * IPv4 Preferred = true
  * impl = Inet6AddressImpl
  * LookupPolicy = IPV4 
* Uberjar, property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" "-Djava.net.preferIPv4Stack=true" -jar payara-micro.jar --outputuberjar C:\Users\andrew.pielage\Downloads\FISH-10485\uberjar.jar` && java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" "-Djava.net.preferIPv4Stack=true" -jar C:\Users\andrew.pielage\Downloads\FISH-10485\uberjar.jar`
  * IPv4 Preferred = true
  * impl = Inet4AddressImpl
  * LookupPolicy = IPV4
* Launcher, no property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" -jar payara-micro.jar --rootdir C:\Users\andrew.pielage\Downloads\FISH-10485\explode --outputlauncher && java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" -jar C:\Users\andrew.pielage\Downloads\FISH-10485\explode\launch-micro.jar`
  * IPv4 Preferred = true
  * impl = Inet6AddressImpl
  * LookupPolicy = IPV4 
* Launcher, property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" "-Djava.net.preferIPv4Stack=true" -jar payara-micro.jar --rootdir C:\Users\andrew.pielage\Downloads\FISH-10485\explode --outputlauncher && java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" "-Djava.net.preferIPv4Stack=true" -jar C:\Users\andrew.pielage\Downloads\FISH-10485\explode\launch-micro.jar`
  * IPv4 Preferred = true
  * impl = Inet4AddressImpl
  * LookupPolicy = IPV4
* Nested: no property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" -jar payara-micro.jar --nested`
  * IPv4 Preferred = true
  * impl = Inet6AddressImpl
  * LookupPolicy = IPV4 
* Nested, property set: `java -Xdebug "-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y" "-Djava.net.preferIPv4Stack=true" -jar payara-micro.jar --nested`
  * IPv4 Preferred = true
  * impl = Inet4AddressImpl
  * LookupPolicy = IPV4

### Testing Environment
Windows 11, Maven 3.9.15, Zulu JDK 21.0.11

## Documentation
Pending...
It's probably worth mentioning in our docs that this property is configured by default (if it isn't already).

It's probably also worth mentioning the _very similar_ Hazelcast property: `hazelcast.prefer.ipv4.stack` which is true by default - disabling Hazelcast from using IPv6.

From their own docs:

> VM has two system properties for setting the preferred protocol stack (IPv4 or IPv6) as well as the preferred address family types (inet4 or inet6). On a dual stack machine, IPv6 stack is preferred by default, you can change this through the java.net.preferIPv4Stack=<true|false> system property. When querying name services, JVM prefers IPv4 addresses over IPv6 addresses and returns an IPv4 address if possible. You can change this through java.net.preferIPv6Addresses=<true|false> system property. 
By default, IPv6 support has been switched off. Some platforms have issues using the IPv6 stack. Other platforms have no IPv6 support at all. To enable IPv6 support, just set the configuration property hazelcast.prefer.ipv4.stack to false.

## Notes for Reviewers
None
