### PR TITLE
FISH-13649 Set `jakarta.security.jacc.policy.provider` property in Micro to Avoid Warning

### DIFF
--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/payara-boot.properties
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/payara-boot.properties
@@ -2,7 +2,7 @@
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
-# Copyright (c) 2016-2025 Payara Foundation. All rights reserved.
+# Copyright (c) 2016-2026 Payara Foundation. All rights reserved.
 #
 # The contents of this file are subject to the terms of the Common Development
 # and Distribution License("CDDL") (collectively, the "License").  You

--- a/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/payara-boot.properties
+++ b/appserver/extras/payara-micro/payara-micro-boot/src/main/resources/MICRO-INF/payara-boot.properties
@@ -31,4 +31,5 @@ org.glassfish.grizzly.DEFAULT_MEMORY_MANAGER=org.glassfish.grizzly.memory.HeapMe
 org.glassfish.grizzly.nio.DefaultSelectorHandler.force-selector-spin-detection=true
 org.glassfish.startupThreadPolicy=FULLY_THREADED
 jakarta.security.jacc.PolicyFactory.provider=org.glassfish.exousia.modules.def.DefaultPolicyFactory
+jakarta.security.jacc.policy.provider=org.glassfish.exousia.modules.def.DefaultPolicy
 # Make sure this file ends with a newline, since other properties may be appended to it when creating the uber jar


### PR DESCRIPTION
## Description
Sets the titular property to avoid the following warnings when starting Payara Micro:

```
Policy provider configuration overridden by property jakarta.security.jacc.policy.provider with value null.
No policy provider defined. Will use the default JDK Policy implementation.
```

This property is set on the Server so I've just aligned them.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Started Payara Micro: warning no longer thrown

### Testing Environment
Windows 11, Maven 3.9.15, Zulu JDK 21.0.11

## Documentation
N/A

## Notes for Reviewers
None
