### PR TITLE
FISH-13565: implement functional test for jms-ping and validate warning message

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -407,6 +407,11 @@ pipeline {
                                 -Dfailsafe.rerunFailingTestsCount=2 \
                                 -f appserver/tests/functional/payara-application-xml """
                         echo '*#*#*#*#*#*#*#*#*#*#*#*#  Ran payara-application.xml tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
+
+                        echo '*#*#*#*#*#*#*#*#*#*#*#*#  Running JMS ping tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
+                        sh """export PAYARA_HOME=${pwd()}/payara7 && python3 appserver/tests/functional/jms/test_jms_ping.py \
+                        --domain-name ${DOMAIN_NAME}"""
+                        echo '*#*#*#*#*#*#*#*#*#*#*#*#  Ran JMS ping tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                     }
                     post {
                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -410,7 +410,7 @@ pipeline {
 
                         echo '*#*#*#*#*#*#*#*#*#*#*#*#  Running JMS ping tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                         sh """export PAYARA_HOME=${pwd()}/payara7 && python3 appserver/tests/functional/jms/test_jms_ping.py \
-                        --domain-name ${DOMAIN_NAME}"""
+                        --domain-name ${env.DOMAIN_NAME} """
                         echo '*#*#*#*#*#*#*#*#*#*#*#*#  Ran JMS ping tests  *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                     }
                     post {

--- a/appserver/tests/functional/jms/README.md
+++ b/appserver/tests/functional/jms/README.md
@@ -21,3 +21,5 @@ Navigate to the tests directory:
     cd appserver/tests/functional/jms
     python3 test_jms_ping.py
 ```
+
+By default, the test_jms_pings.py test is using a timeout sleep of 3 seconds to wait between calls, and that value can be changed by using the property **--sleep_time**

--- a/appserver/tests/functional/jms/README.md
+++ b/appserver/tests/functional/jms/README.md
@@ -1,0 +1,23 @@
+# Payara JMS Functional Tests #
+
+This directory contains functional tests for Payara Server's asadmin commands. These tests verify the functionality of jms and its relationship with OpenMQ that is bundled with Payara Server.
+
+# Prerequisites #
+
+- Python 3.6 or higher
+- Payara Server 7 or later
+- Access to a running Payara Server instance
+
+## Setup
+The script expects a defined PAYARA_HOME environment variable to point to the Payara Server installation directory.
+e.g.:
+```bash
+    export PAYARA_HOME=/path/to/payara7
+```
+
+Navigate to the tests directory:
+
+```bash
+    cd appserver/tests/functional/jms
+    python3 test_jms_ping.py
+```

--- a/appserver/tests/functional/jms/test_jms_ping.py
+++ b/appserver/tests/functional/jms/test_jms_ping.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Functional test: start Payara, run jms-ping, validate server log entry.
+"""
+
+import argparse
+import logging
+import os
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Tuple
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+EXPECTED_LOG_TEXT = (
+    "The default broker instance for OpenMQ is using the default admin password"
+)
+
+
+class AsadminCommandError(Exception):
+    pass
+
+
+class TestJmsPing:
+    def __init__(self, asadmin_path: str, domain_name: str, log_dir: str):
+        self.asadmin_path = asadmin_path
+        self.domain_name = domain_name
+        self.log_dir = Path(log_dir)
+
+    def _run_asadmin(self, *args: str) -> Tuple[bool, str, str]:
+        cmd = [self.asadmin_path] + list(args)
+        try:
+            logger.debug(f"Running: {' '.join(cmd)}")
+            result = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False
+            )
+            if result.returncode != 0:
+                logger.error(
+                    f"Command failed (code {result.returncode}): {result.stderr.strip()}"
+                )
+                return False, result.stdout.strip(), result.stderr.strip()
+            return True, result.stdout.strip(), result.stderr.strip()
+        except Exception as e:
+            msg = f"Error running asadmin: {e}"
+            logger.error(msg)
+            return False, "", msg
+
+    def setup(self):
+        logger.info(f"Starting domain: {self.domain_name}")
+        success, stdout, stderr = self._run_asadmin('start-domain', self.domain_name)
+        if not success:
+            raise AsadminCommandError(f"start-domain failed: {stderr}")
+        logger.info("Domain started. Waiting 3 seconds...")
+        time.sleep(3)
+
+    def run_test(self) -> bool:
+        logger.info("Running jms-ping...")
+        success, stdout, stderr = self._run_asadmin('jms-ping')
+        if not success:
+            logger.error(f"jms-ping failed: {stderr}")
+            return False
+        logger.info(f"jms-ping output: {stdout}")
+
+        logger.info("Waiting 3 seconds...")
+        time.sleep(3)
+
+        log_file = self.log_dir / 'server.log'
+        logger.info(f"Reading log file: {log_file}")
+        if not log_file.exists():
+            raise FileNotFoundError(f"Log file not found: {log_file}")
+
+        content = log_file.read_text(encoding='utf-8', errors='replace')
+        if EXPECTED_LOG_TEXT in content:
+            logger.info("PASS: Expected log entry found.")
+            return True
+
+        logger.error("FAIL: Expected log entry not found.")
+        logger.error(f"Expected: {EXPECTED_LOG_TEXT!r}")
+        logger.error("Last 20 lines of log:")
+        for line in content.splitlines()[-20:]:
+            logger.error(f"  {line}")
+        return False
+
+    def cleanup(self):
+        logger.info(f"Stopping domain: {self.domain_name}")
+        success, _, stderr = self._run_asadmin('stop-domain', self.domain_name)
+        if not success:
+            logger.error(f"stop-domain failed (ignored): {stderr}")
+
+
+def _resolve_asadmin(asadmin_arg: str) -> str:
+    if asadmin_arg:
+        return asadmin_arg
+    payara_home = os.environ.get('PAYARA_HOME')
+    if not payara_home:
+        sys.exit("ERROR: --asadmin-path not provided and PAYARA_HOME is not set.")
+    ext = '.bat' if platform.system() == 'Windows' else ''
+    return str(Path(payara_home) / 'bin' / f'asadmin{ext}')
+
+
+def _resolve_log_dir(log_dir_arg: str, domain_name: str) -> str:
+    if log_dir_arg:
+        return log_dir_arg
+    payara_home = os.environ.get('PAYARA_HOME')
+    if not payara_home:
+        sys.exit("ERROR: --log-dir not provided and PAYARA_HOME is not set.")
+    return str(Path(payara_home) / 'glassfish' / 'domains' / domain_name / 'logs')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Functional test: start Payara, run jms-ping, validate server log.'
+    )
+    parser.add_argument(
+        '--asadmin-path',
+        help='Path to asadmin binary (default: $PAYARA_HOME/bin/asadmin[.bat])'
+    )
+    parser.add_argument(
+        '--domain-name', default='domain1',
+        help='Domain name (default: domain1)'
+    )
+    parser.add_argument(
+        '--log-dir',
+        help='Path to domain log directory '
+             '(default: $PAYARA_HOME/glassfish/domains/<domain-name>/logs)'
+    )
+    parser.add_argument('--debug', action='store_true', help='Enable debug logging')
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    asadmin_path = _resolve_asadmin(args.asadmin_path)
+    log_dir = _resolve_log_dir(args.log_dir, args.domain_name)
+
+    test = None
+    passed = False
+    try:
+        test = TestJmsPing(
+            asadmin_path=asadmin_path,
+            domain_name=args.domain_name,
+            log_dir=log_dir,
+        )
+        test.setup()
+        passed = test.run_test()
+    except Exception as e:
+        logger.error(f"Test error: {e}", exc_info=args.debug)
+        passed = False
+    finally:
+        if test:
+            test.cleanup()
+
+    if passed:
+        logger.info("TEST RESULT: PASSED")
+        return 0
+    else:
+        logger.error("TEST RESULT: FAILED")
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/appserver/tests/functional/jms/test_jms_ping.py
+++ b/appserver/tests/functional/jms/test_jms_ping.py
@@ -29,10 +29,11 @@ class AsadminCommandError(Exception):
 
 
 class TestJmsPing:
-    def __init__(self, asadmin_path: str, domain_name: str, log_dir: str):
+    def __init__(self, asadmin_path: str, domain_name: str, log_dir: str, sleep_time: int = 3):
         self.asadmin_path = asadmin_path
         self.domain_name = domain_name
         self.log_dir = Path(log_dir)
+        self.sleep_time = sleep_time
 
     def _run_asadmin(self, *args: str) -> Tuple[bool, str, str]:
         cmd = [self.asadmin_path] + list(args)
@@ -56,14 +57,6 @@ class TestJmsPing:
             logger.error(msg)
             return False, "", msg
 
-    def setup(self):
-        logger.info(f"Starting domain: {self.domain_name}")
-        success, stdout, stderr = self._run_asadmin('start-domain', self.domain_name)
-        if not success:
-            raise AsadminCommandError(f"start-domain failed: {stderr}")
-        logger.info("Domain started. Waiting 3 seconds...")
-        time.sleep(3)
-
     def run_test(self) -> bool:
         logger.info("Running jms-ping...")
         success, stdout, stderr = self._run_asadmin('jms-ping')
@@ -72,8 +65,8 @@ class TestJmsPing:
             return False
         logger.info(f"jms-ping output: {stdout}")
 
-        logger.info("Waiting 3 seconds...")
-        time.sleep(3)
+        logger.info(f"Waiting {self.sleep_time} seconds...")
+        time.sleep(self.sleep_time)
 
         log_file = self.log_dir / 'server.log'
         logger.info(f"Reading log file: {log_file}")
@@ -91,13 +84,6 @@ class TestJmsPing:
         for line in content.splitlines()[-20:]:
             logger.error(f"  {line}")
         return False
-
-    def cleanup(self):
-        logger.info(f"Stopping domain: {self.domain_name}")
-        success, _, stderr = self._run_asadmin('stop-domain', self.domain_name)
-        if not success:
-            logger.error(f"stop-domain failed (ignored): {stderr}")
-
 
 def _resolve_asadmin(asadmin_arg: str) -> str:
     if asadmin_arg:
@@ -135,6 +121,10 @@ def main() -> int:
         help='Path to domain log directory '
              '(default: $PAYARA_HOME/glassfish/domains/<domain-name>/logs)'
     )
+    parser.add_argument(
+        '--sleep-time', type=int, default=3,
+        help='Seconds to wait after domain start and after jms-ping (default: 3)'
+    )
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
     args = parser.parse_args()
 
@@ -144,22 +134,18 @@ def main() -> int:
     asadmin_path = _resolve_asadmin(args.asadmin_path)
     log_dir = _resolve_log_dir(args.log_dir, args.domain_name)
 
-    test = None
     passed = False
     try:
         test = TestJmsPing(
             asadmin_path=asadmin_path,
             domain_name=args.domain_name,
             log_dir=log_dir,
+            sleep_time=args.sleep_time,
         )
-        test.setup()
         passed = test.run_test()
     except Exception as e:
         logger.error(f"Test error: {e}", exc_info=args.debug)
         passed = False
-    finally:
-        if test:
-            test.cleanup()
 
     if passed:
         logger.info("TEST RESULT: PASSED")


### PR DESCRIPTION

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Adding functional test to validate default password warning message
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This is a feature to include functional tests to validate integration of JMS and default configuration
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
New Functional tests added withing the file: test_jms_ping.py
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
execution of new functional tests from Payara Server sources:

<img width="1435" height="249" alt="image" src="https://github.com/user-attachments/assets/d5f546e1-1dcb-4358-b242-15822c3cb47d" />

execution from the pipeline: 
<img width="1855" height="426" alt="image" src="https://github.com/user-attachments/assets/4d77f811-0c1a-4e73-85a5-477e7c09f739" />



### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Ubuntu 20.04, Python 3, azul jdk 21, maven 3.9.11
## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
