### PR TITLE
FISH-13707 Add Alternate Parsson Artefact to BOM

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
-  ~    Copyright (c) 2019-2025 Payara Foundation and/or its affiliates. All rights reserved.
+  ~    Copyright (c) 2019-2026 Payara Foundation and/or its affiliates. All rights reserved.
   ~
   ~    The contents of this file are subject to the terms of either the GNU
   ~    General Public License Version 2 only ("GPL") or the Common Development
@@ -864,6 +864,11 @@
             <dependency>
                 <groupId>org.eclipse.parsson</groupId>
                 <artifactId>jakarta.json</artifactId>
+                <version>${parsson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.parsson</groupId>
+                <artifactId>parsson</artifactId>
                 <version>${parsson.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Description
Adds the alternate Parsson artefact to the BOM.
This artefact is slightly different to the jakarta.json artefact that we're using, but we should include it in the BOM anyway for completeness.

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
N/A

### Testing Environment
Jenkins

## Documentation
N/A

## Notes for Reviewers
None
