### PR TITLE
FISH-13340 Warlibs list-libraries

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/ListLibrariesCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/ListLibrariesCommand.java
@@ -37,8 +37,8 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright 2017-2026 Payara Foundation and/or its affiliates
 
-// Portions Copyright [2017-2021] [Payara Foundation and/or its affiliates]
 package org.glassfish.deployment.admin;
 
 import org.glassfish.api.ActionReport;
@@ -72,7 +72,7 @@ import org.glassfish.api.admin.AccessRequired;
 @AccessRequired(resource=DeploymentCommandUtils.LIBRARY_SECURITY_RESOURCE_PREFIX + "/$type", action="read")
 public class ListLibrariesCommand implements AdminCommand {
 
-    @Param(optional=true, acceptableValues="common, ext, app")
+    @Param(optional=true, acceptableValues="common, ext, app, war")
     String type = "common";
 
     @Inject
@@ -90,6 +90,8 @@ public class ListLibrariesCommand implements AdminCommand {
             libDir = new File(libDir, "ext");
         } else if (type.equals("app")) {
             libDir = new File(libDir, "applibs");
+        } else if (type.equals("war")) {
+            libDir = new File(libDir, "warlibs");
         }
 
         ActionReport.MessagePart part = report.getTopMessagePart();

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/list-libraries.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/list-libraries.1
@@ -4,7 +4,7 @@ NAME
        list-libraries - lists library JAR files on GlassFish Server
 
 SYNOPSIS
-           list-libraries [--help] [--type={common|ext|app}]
+           list-libraries [--help] [--type={common|ext|app|war}]
 
 DESCRIPTION
        The list-libraries subcommand lists library archive files on GlassFish
@@ -34,6 +34,10 @@ OPTIONS
            app
                Lists the library files for the application-specific class
                loader directory, domain-dir/lib/applibs.
+
+           war
+               Lists the library files for the war-packaged class loader
+               directory, domain-dir/lib/warlibs
 
            For more information about these directories, see "Class Loaders"
            in Oracle GlassFish Server Application Development Guide.


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-13340
  - Adds handling for `--type=war` to the `list-libraries` command.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
1. Built the [example project](https://github.com/flowlogix/cdi-scanning).
2. Used `asadmin add-library --type=war <filename>` for the example library.
3. Restarted the server.
4. Used `asadmin list-libraries --type=war`.
5. Observed that the file was indeed listed.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.14
Java version: 21.0.10, vendor: Azul Systems, Inc.
Default locale: en_GB, platform encoding: UTF-8
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
