### PR TITLE
FISH-11415 FISH-12293 FISH-13426 Grizzly 5.0.2 and Extra Header Validation

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2016-2025] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2026 Payara Foundation and/or its affiliates
 package com.sun.enterprise.v3.services.impl;
 
 import com.sun.appserv.server.util.Version;
@@ -84,6 +84,7 @@ import org.glassfish.hk2.utilities.AbstractActiveDescriptor;
 import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.glassfish.internal.grizzly.V3Mapper;
+import org.glassfish.kernel.KernelLoggerInfo;
 import org.jvnet.hk2.config.types.Property;
 
 public class GlassfishNetworkListener extends GenericGrizzlyListener {
@@ -433,14 +434,19 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
         }
 
         @Override
-        protected boolean onHttpHeaderParsed(final HttpHeader httpHeader,
-                final Buffer buffer,
-                final FilterChainContext ctx) {
-
-            final boolean result = super.onHttpHeaderParsed(httpHeader,
-                    buffer, ctx);
+        protected boolean onHttpHeaderParsed(final HttpHeader httpHeader, final Buffer buffer, final FilterChainContext ctx) {
+            boolean result = super.onHttpHeaderParsed(httpHeader, buffer, ctx);
 
             final HttpRequestPacket request = (HttpRequestPacket) httpHeader;
+
+            // Here we can add extra validation to prevent Http Server invalid use of headers
+            if (request.containsHeader(Header.ContentLength) && request.containsHeader(Header.TransferEncoding)) {
+                KernelLoggerInfo.getLogger().log(Level.SEVERE,
+                        "Can't use both headers Content-Length and Transfer-Encoding from the same request");
+                request.getProcessingState().setError(true);
+                result = true;
+            }
+
             final HttpResponsePacket response = request.getResponse();
 
             // Set response "Server" header

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/ThreadPoolMonitor.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/ThreadPoolMonitor.java
@@ -38,15 +38,15 @@
  * holder.
  */
 
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2026 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.v3.services.impl.monitor;
 
 import com.sun.enterprise.v3.services.impl.monitor.stats.ConnectionQueueStatsProvider;
 import com.sun.enterprise.v3.services.impl.monitor.stats.ThreadPoolStatsProvider;
 import com.sun.enterprise.v3.services.impl.monitor.stats.ThreadPoolStatsProviderGlobal;
-import org.glassfish.grizzly.threadpool.AbstractThreadPool;
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
+import org.glassfish.grizzly.threadpool.ThreadPoolInfo;
 import org.glassfish.grizzly.threadpool.ThreadPoolProbe;
 
 /**
@@ -91,38 +91,38 @@ public class ThreadPoolMonitor implements ThreadPoolProbe {
     }
 
     @Override
-    public void onThreadPoolStartEvent(AbstractThreadPool threadPool) {
+    public void onThreadPoolStartEvent(ThreadPoolInfo threadPool) {
     }
 
     @Override
-    public void onThreadPoolStopEvent(AbstractThreadPool threadPool) {
+    public void onThreadPoolStopEvent(ThreadPoolInfo threadPool) {
     }
 
     @Override
-    public void onThreadAllocateEvent(AbstractThreadPool threadPool, Thread thread) {
+    public void onThreadAllocateEvent(ThreadPoolInfo threadPool, Thread thread) {
         grizzlyMonitoring.getThreadPoolProbeProvider().threadAllocatedEvent(monitoringId, threadPool, thread.getId());
     }
 
     @Override
-    public void onThreadReleaseEvent(AbstractThreadPool threadPool, Thread thread) {
+    public void onThreadReleaseEvent(ThreadPoolInfo threadPool, Thread thread) {
         grizzlyMonitoring.getThreadPoolProbeProvider().threadReleasedEvent(monitoringId, threadPool, thread.getId());
     }
 
     @Override
-    public void onMaxNumberOfThreadsEvent(AbstractThreadPool threadPool, int maxNumberOfThreads) {
+    public void onMaxNumberOfThreadsEvent(ThreadPoolInfo threadPool, int maxNumberOfThreads) {
         grizzlyMonitoring.getThreadPoolProbeProvider().maxNumberOfThreadsReachedEvent(monitoringId, threadPool, 
                 maxNumberOfThreads);
     }
 
     @Override
-    public void onTaskDequeueEvent(AbstractThreadPool threadPool, Runnable task) {
+    public void onTaskDequeueEvent(ThreadPoolInfo threadPool, Runnable task) {
         grizzlyMonitoring.getThreadPoolProbeProvider().threadDispatchedFromPoolEvent(monitoringId, 
                 Thread.currentThread().getId());
         grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskDequeuedEvent(monitoringId, task.getClass().getName());
     }
 
     @Override
-    public void onTaskCancelEvent(AbstractThreadPool threadPool, Runnable task) {
+    public void onTaskCancelEvent(ThreadPoolInfo threadPool, Runnable task) {
         // when dequeued task is cancelled - we have to "return" the thread, that
         // we marked as dispatched from the pool
         grizzlyMonitoring.getThreadPoolProbeProvider().threadReturnedToPoolEvent(monitoringId, 
@@ -130,18 +130,18 @@ public class ThreadPoolMonitor implements ThreadPoolProbe {
     }
     
     @Override
-    public void onTaskCompleteEvent(AbstractThreadPool threadPool, Runnable task) {
+    public void onTaskCompleteEvent(ThreadPoolInfo threadPool, Runnable task) {
         grizzlyMonitoring.getThreadPoolProbeProvider().threadReturnedToPoolEvent(
                 monitoringId, Thread.currentThread().getId());
     }
 
     @Override
-    public void onTaskQueueEvent(AbstractThreadPool threadPool, Runnable task) {
+    public void onTaskQueueEvent(ThreadPoolInfo threadPool, Runnable task) {
         grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskQueuedEvent(monitoringId, task.getClass().getName());
     }
 
     @Override
-    public void onTaskQueueOverflowEvent(AbstractThreadPool threadPool) {
+    public void onTaskQueueOverflowEvent(ThreadPoolInfo threadPool) {
         grizzlyMonitoring.getConnectionQueueProbeProvider().onTaskQueueOverflowEvent(monitoringId);
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/probes/ThreadPoolProbeProvider.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/monitor/probes/ThreadPoolProbeProvider.java
@@ -38,14 +38,14 @@
  * holder.
  */
 
-// Portions Copyright [2016] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2016-2026 Payara Foundation and/or its affiliates
 
 package com.sun.enterprise.v3.services.impl.monitor.probes;
 
 import org.glassfish.external.probe.provider.annotations.Probe;
 import org.glassfish.external.probe.provider.annotations.ProbeParam;
 import org.glassfish.external.probe.provider.annotations.ProbeProvider;
-import org.glassfish.grizzly.threadpool.AbstractThreadPool;
+import org.glassfish.grizzly.threadpool.ThreadPoolInfo;
 
 /**
  * Probe provider interface for thread pool related events.
@@ -71,21 +71,21 @@ public class ThreadPoolProbeProvider {
     @Probe(name="threadAllocatedEvent")
     public void threadAllocatedEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPool") AbstractThreadPool threadPool,
+        @ProbeParam("threadPool") ThreadPoolInfo threadPool,
         @ProbeParam("threadId") long threadId) {}
 
 
     @Probe(name="threadReleasedEvent")
     public void threadReleasedEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPool") AbstractThreadPool threadPool,
+        @ProbeParam("threadPool") ThreadPoolInfo threadPool,
         @ProbeParam("threadId") long threadId) {}
 
 
     @Probe(name="maxNumberOfThreadsReachedEvent")
     public void maxNumberOfThreadsReachedEvent(
         @ProbeParam("monitoringId") String monitoringId,
-        @ProbeParam("threadPool") AbstractThreadPool threadPool,
+        @ProbeParam("threadPool") ThreadPoolInfo threadPool,
         @ProbeParam("maxNumberOfThreads") int maxNumberOfThreads) {}
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <osgi.dto.version>1.1.1</osgi.dto.version>
         <soteria.version>4.0.1.payara-p1</soteria.version>
         <cdi-api.version>4.1.0</cdi-api.version>
-        <grizzly.version>4.1.0-M1.payara-p2</grizzly.version>
+        <grizzly.version>5.0.1</grizzly.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <expressly.version>6.0.0</expressly.version>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <osgi.dto.version>1.1.1</osgi.dto.version>
         <soteria.version>4.0.1.payara-p1</soteria.version>
         <cdi-api.version>4.1.0</cdi-api.version>
-        <grizzly.version>5.0.1</grizzly.version>
+        <grizzly.version>5.0.2</grizzly.version>
         <servlet-api.version>6.1.0</servlet-api.version>
         <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <expressly.version>6.0.0</expressly.version>


### PR DESCRIPTION
## Description
Updates Grizzly to 5.0.2

## Important Info
### Blockers
Need to verify that our outstanding Grizzly patches don't need reapplying.
~~Need to release patched Jersey: https://github.com/payara/patched-src-jersey/pull/252~~

Remove unnecessary dependency from JavaEE7 samples which no longer exists: https://github.com/payara/patched-src-javaee7-samples/pull/116/

## Testing
### New tests
None

### Testing Performed
Started and loaded the admin console.
Reran old issue reproducers for FISH-11415 and FISH-9690

### Testing Environment
Windows 11, Maven 3.9.15, Zulu JDK 21.0.11

## Documentation
N/A

## Notes for Reviewers
None
