### PR TITLE
FISH-13779 - Changing the admin password in the Admin Console does not work

### DIFF
--- a/appserver/admingui/common/src/main/resources/appServer/serverInstAdminPassword.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/serverInstAdminPassword.jsf
@@ -53,7 +53,7 @@
     <event>
     <!beforeCreate
         setSessionAttribute(key="domainTabs" value="adminPassword");
-        setPageSessionAttribute(key="selfUrl", value="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/admin-service/jmx-connector/system");
+        setPageSessionAttribute(key="selfUrl", value="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/admin-service");
         gf.getEntityAttrs(endpoint="#{pageSession.selfUrl}.json", valueMap="#{pageSession.valueMap}");
         setPageSessionAttribute(key="authRealm" value="#{pageSession.valueMap['authRealmName']}");
         getUserInfo(Realm="#{pageSession.authRealm}", configName="#{pageSession.configName}", User="#{sessionScope.userName}", GroupList="#{pageSession.group}" );


### PR DESCRIPTION
Changed the endpoint of `setPageSessionAttribute` in `serverInstAdminPassword.jsf` to `/admin-service` instead of `/admin-service/jmx-connector/system` (because FISH-10866 removed the attribute from JmxConnector)

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
This PR addresses the issue mentioned in https://github.com/payara/Payara/issues/8220

## Testing

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Only tested the affected page by compiling and loading the page, changing the password and seeing if it has the desired effect.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Windows 11, Zulu JDK 21.0.10 with Maven 3.9.16
