### PR TITLE
FISH-13207 Fix `restart-deployment-group` Not Displaying Progress.

### DIFF
--- a/nucleus/cluster/admin/src/main/java/fish/payara/admin/cluster/RestartDeploymentGroupCommand.java
+++ b/nucleus/cluster/admin/src/main/java/fish/payara/admin/cluster/RestartDeploymentGroupCommand.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017-2022 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,10 +39,8 @@
  */
 package fish.payara.admin.cluster;
 
-import com.sun.enterprise.admin.remote.RemoteRestAdminCommand;
 import com.sun.enterprise.admin.util.TimeoutParamDefaultCalculator;
 import com.sun.enterprise.config.serverbeans.Domain;
-import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.v3.admin.cluster.ClusterCommandHelper;
 import com.sun.enterprise.v3.admin.cluster.Strings;
 import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
@@ -54,10 +52,6 @@ import org.glassfish.api.admin.*;
 import org.glassfish.hk2.api.PerLookup;
 import org.jvnet.hk2.annotations.Service;
 
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 /**
@@ -79,9 +73,8 @@ import java.util.logging.Logger;
                         @RestParam(name = "id", value = "$parent")
                 })
 })
+@Progress
 public class RestartDeploymentGroupCommand implements AdminCommand {
-
-    private static final String NL = System.lineSeparator();
 
     @Inject
     private ServerEnvironment env;
@@ -147,101 +140,21 @@ public class RestartDeploymentGroupCommand implements AdminCommand {
             return;
         }
 
-        if (rolling) {
-            CountDownLatch commandTimeout = new CountDownLatch(1);
-            ScheduledFuture<?> commandFuture = executor.schedule(() -> {
-                doRolling(context);
-                commandTimeout.countDown();
-            }, 500, TimeUnit.MILLISECONDS);
-            try {
-                if (!commandTimeout.await(timeout <= 0 ? RemoteRestAdminCommand.getReadTimeout() : timeout, TimeUnit.SECONDS)) {
-                    String msg = Strings.get("restart.dg.timeout", deploymentGroup);
+        ClusterCommandHelper clusterHelper = new ClusterCommandHelper(domain, runner);
 
-                    report.setActionExitCode(ActionReport.ExitCode.FAILURE);
-                    report.setMessage(msg);
-                    return;
-                }
-            } catch (InterruptedException e) {
-                return;
-            } finally {
-                commandFuture.cancel(true);
-            }
-        } else {
-
-            ClusterCommandHelper clusterHelper = new ClusterCommandHelper(domain,
-                    runner);
-
-            ParameterMap pm = new ParameterMap();
-            pm.add("delay", delay);
-            pm.add("timeout", String.valueOf(instanceTimeout));
-            try {
-                // Run restart-instance against each instance in the Deployment Group
-                String commandName = "restart-instance";
-                clusterHelper.setAdminTimeout(timeout * 1000);
-                clusterHelper.runCommand(commandName, pm, deploymentGroup, context,
-                        verbose, rolling);
-            } catch (CommandException e) {
-                String msg = e.getLocalizedMessage();
-                logger.warning(msg);
-                report.setActionExitCode(ActionReport.ExitCode.FAILURE);
-                report.setMessage(msg);
-            }
-        }
-    }
-
-    private void doRolling(AdminCommandContext context) {
-        List<Server> servers = domain.getServersInTarget(deploymentGroup);
-        StringBuilder output = new StringBuilder();
-        Logger logger = context.getLogger();
-
-        for (Server server : servers) {
-            ParameterMap instanceParameterMap = new ParameterMap();
-            // Set the instance name as the operand for the commnd
-            instanceParameterMap.set("DEFAULT", server.getName());
-            instanceParameterMap.add("timeout", String.valueOf(instanceTimeout));
-
-            ActionReport instanceReport = runner.getActionReport("plain");
-            instanceReport.setActionExitCode(ActionReport.ExitCode.SUCCESS);
-            CommandRunner.CommandInvocation invocation = runner.getCommandInvocation(
-                    "stop-instance", instanceReport, context.getSubject());
-            invocation.parameters(instanceParameterMap);
-
-            String msg = "stop-instance" + " " + server.getName();
-            logger.info(msg);
-            if (verbose) {
-                output.append(msg).append(NL);
-            }
-            invocation.execute();
-            logger.info(invocation.report().getMessage());
-            if (verbose) {
-                output.append(invocation.report().getMessage()).append(NL);
-            }
-            instanceParameterMap = new ParameterMap();
-            // Set the instance name as the operand for the commnd
-            instanceParameterMap.set("DEFAULT", server.getName());
-            instanceParameterMap.add("timeout", String.valueOf(instanceTimeout));
-            instanceReport.setActionExitCode(ActionReport.ExitCode.SUCCESS);
-            invocation = runner.getCommandInvocation(
-                    "start-instance", instanceReport, context.getSubject());
-            invocation.parameters(instanceParameterMap);
-            msg = "start-instance" + " " + server.getName();
-            logger.info(msg);
-            if (verbose) {
-                output.append(msg).append(NL);
-            }
-            invocation.execute();
-            logger.info(invocation.report().getMessage());
-            if (verbose) {
-                output.append(invocation.report().getMessage()).append(NL);
-            }
-            try {
-                long delayVal = Long.parseLong(delay);
-                if (delayVal > 0) {
-                    Thread.sleep(delayVal);
-                }
-            } catch (InterruptedException e) {
-                //ignore
-            }
+        ParameterMap pm = new ParameterMap();
+        pm.add("delay", delay);
+        pm.add("timeout", String.valueOf(instanceTimeout));
+        try {
+            // Run restart-instance against each instance in the Deployment Group
+            String commandName = "restart-instance";
+            clusterHelper.setAdminTimeout(timeout * 1000);
+            clusterHelper.runCommand(commandName, pm, deploymentGroup, context, verbose, rolling);
+        } catch (CommandException e) {
+            String msg = e.getLocalizedMessage();
+            logger.warning(msg);
+            report.setActionExitCode(ActionReport.ExitCode.FAILURE);
+            report.setMessage(msg);
         }
     }
 


### PR DESCRIPTION
## Description
Makes it so the `restart-deployment-group` command displays the progress of the command like the other group start/stop/restart commands.

Also clears away what seems like redundant code: the cluster command helper should be handling all of this.
_This isn't just cleanup, the progress mechanism only works when using `ClusterCommandHelper`_

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Create a deployment group with multiple instances in and start them all.

Run the `restart-deployment-group` command, you should see the instances restart in a rolling manner and the progress should be displayed (and not just jump from 0-100, it should work its way up based on the number of instances)

### Testing Environment
Windows 11, Maven 3.9.16, Zulu JDK 21.0.11

## Documentation
N/A

## Notes for Reviewers
None
