### PR TITLE
FISH-13490 Add Backwards Compatibility for Defining Implicit CDI via `glassfish-application.xml`

### DIFF
--- a/appserver/deployment/javaee-full/src/main/java/org/glassfish/javaee/full/deployment/EarHandler.java
+++ b/appserver/deployment/javaee-full/src/main/java/org/glassfish/javaee/full/deployment/EarHandler.java
@@ -158,6 +158,11 @@ public class EarHandler extends AbstractArchiveHandler implements CompositeHandl
         try {
             PayaraApplicationXmlParser payaraApplicationXMLParser = new PayaraApplicationXmlParser(archive);
             versionIdentifier = payaraApplicationXMLParser.extractVersionIdentifierValue(archive);
+
+            // Check glassfish-application.xml if no value provided in payara-application.xml
+            if (versionIdentifier == null) {
+                versionIdentifier = new GFApplicationXmlParser(archive).extractVersionIdentifierValue(archive);
+            }
         } catch (XMLStreamException e) {
             _logger.log(Level.SEVERE, e.getMessage());
         } catch (IOException e) {
@@ -546,6 +551,12 @@ public class EarHandler extends AbstractArchiveHandler implements CompositeHandl
         if (!context.getAppProps().containsKey(RuntimeTagNames.PAYARA_ENABLE_IMPLICIT_CDI)) {
             try {
                 Boolean cdiEnabled = new PayaraApplicationXmlParser(source).isEnableImplicitCDI();
+
+                // Check glassfish-application.xml if no value provided in payara-application.xml
+                if (cdiEnabled == null) {
+                    cdiEnabled = new GFApplicationXmlParser(source).isEnableImplicitCDI();
+                }
+
                 if (cdiEnabled != null) {
                     context.getAppProps().put(RuntimeTagNames.PAYARA_ENABLE_IMPLICIT_CDI, cdiEnabled.toString().toLowerCase());
                 }

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/glassfish-application-both.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/glassfish-application-both.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE glassfish-application PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Java EE Application 6.0//EN" "http://glassfish.org/dtds/glassfish-application_6_0-1.dtd">
+<glassfish-application>
+    <web>
+        <!-- This aligns to the name of the WAR defined in the test itself -->
+        <web-uri>helloworld.war</web-uri>
+        <context-root>/aufweidershen</context-root>
+    </web>
+</glassfish-application>

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/glassfish-application.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/glassfish-application.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE glassfish-application PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Java EE Application 6.0//EN" "http://glassfish.org/dtds/glassfish-application_6_0-1.dtd">
+<glassfish-application>
+    <web>
+        <!-- This aligns to the name of the WAR defined in the test itself -->
+        <web-uri>helloworld.war</web-uri>
+        <context-root>/farewell</context-root>
+    </web>
+</glassfish-application>

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application-both.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application-both.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application_11-0.dtd">
+<payara-application>
+    <web>
+        <!-- This aligns to the name of the WAR defined in the test itself -->
+        <web-uri>helloworld.war</web-uri>
+        <context-root>/sayonara</context-root>
+    </web>
+</payara-application>

--- a/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
+++ b/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
@@ -42,6 +42,7 @@ package fish.payara.tests.functional.payaraapplicationxml;
 import fish.payara.samples.NotMicroCompatible;
 import fish.payara.samples.PayaraArquillianTestRunner;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -67,10 +68,39 @@ public class HelloWorldIT {
     @ArquillianResource
     private URI uri;
 
-    @Deployment
+    @Deployment(name = "helloPayara")
+    public static EnterpriseArchive createPayaraApplicationDeployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, "helloworld-payara.ear")
+                .addAsManifestResource(new File("src/test/META-INF", "payara-application.xml"))
+                .addAsModule(ShrinkWrap.create(WebArchive.class, "helloworld.war")
+                        .addClasses(Resources.class, HelloWorld.class)
+                        .addAsWebInfResource(new File("src/test/webapp/WEB-INF", "beans.xml")));
+    }
+
+    @Deployment(name = "helloGlassFish")
+    public static EnterpriseArchive createGlassFishApplicationDeployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, "helloworld-glassfish.ear")
+                .addAsManifestResource(new File("src/test/META-INF", "glassfish-application.xml"))
+                .addAsModule(ShrinkWrap.create(WebArchive.class, "helloworld.war")
+                        .addClasses(Resources.class, HelloWorld.class)
+                        .addAsWebInfResource(new File("src/test/webapp/WEB-INF", "beans.xml")));
+    }
+
+    @Deployment(name = "helloPayaraGlassFish")
+    public static EnterpriseArchive createBothApplicationDeployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, "helloworld-both.ear")
+                .addAsManifestResource(new File("src/test/META-INF", "payara-application-both.xml"),
+                        "payara-application.xml")
+                .addAsManifestResource(new File("src/test/META-INF", "glassfish-application-both.xml"),
+                        "glassfish-application.xml")
+                .addAsModule(ShrinkWrap.create(WebArchive.class, "helloworld.war")
+                        .addClasses(Resources.class, HelloWorld.class)
+                        .addAsWebInfResource(new File("src/test/webapp/WEB-INF", "beans.xml")));
+    }
+
+    @Deployment(name = "helloNeither")
     public static EnterpriseArchive createDeployment() {
         return ShrinkWrap.create(EnterpriseArchive.class, "helloworld.ear")
-                .addAsManifestResource(new File("src/test/META-INF", "payara-application.xml"))
                 .addAsModule(ShrinkWrap.create(WebArchive.class, "helloworld.war")
                         .addClasses(Resources.class, HelloWorld.class)
                         .addAsWebInfResource(new File("src/test/webapp/WEB-INF", "beans.xml")));
@@ -78,17 +108,69 @@ public class HelloWorldIT {
 
     @Test
     @RunAsClient
-    public void checkFacesContextImplementationVersionApplicationXml() {
+    @OperateOnDeployment("helloPayara")
+    public void checkContextRootVersionPayaraApplicationXml() {
         WebTarget target = ClientBuilder.newClient().target(uri).path("resources").path("hello");
         Response response = target.request().get();
 
         System.out.println("Context root should be \"goodbye\" as defined by the EAR's payara-application.xml, " +
-                "overriding the default context root of \"helloworld\" obtained from the EAR's name: " + uri.getPath());
+                "overriding the default context root of \"helloworld-payara\" obtained from the EAR's name: " + uri.getPath());
 
         String message = response.readEntity(String.class);
 
         Assert.assertEquals(200, response.getStatus());
         Assert.assertEquals("Hello World!", message);
         Assert.assertTrue(uri.getPath().equals("/goodbye/"));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("helloGlassFish")
+    public void checkContextRootGlassFishApplicationXml() {
+        WebTarget target = ClientBuilder.newClient().target(uri).path("resources").path("hello");
+        Response response = target.request().get();
+
+        System.out.println("Context root should be \"farewell\" as defined by the EAR's glassfish-application.xml, " +
+                "overriding the default context root of \"helloworld-glassfish\" obtained from the EAR's name: " + uri.getPath());
+
+        String message = response.readEntity(String.class);
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals("Hello World!", message);
+        Assert.assertTrue(uri.getPath().equals("/farewell/"));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("helloPayaraGlassFish")
+    public void checkCheckContextBothApplicationXml() {
+        WebTarget target = ClientBuilder.newClient().target(uri).path("resources").path("hello");
+        Response response = target.request().get();
+
+        System.out.println("Context root should be \"sayonara\" as defined by the EAR's payara-application.xml, " +
+                "overriding the default context root of \"helloworld-both\" obtained from the EAR's name: " + uri.getPath() +
+                "and the value of \"aufwiedersehn\" defined in glassfish-application.xml");
+
+        String message = response.readEntity(String.class);
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals("Hello World!", message);
+        Assert.assertTrue(uri.getPath().equals("/sayonara/"));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("helloNeither")
+    public void checkContextRootNoApplicationXml() {
+        WebTarget target = ClientBuilder.newClient().target(uri).path("resources").path("hello");
+        Response response = target.request().get();
+
+        System.out.println("Context root should be \"helloworld\" obtained from the EAR's name: " + uri.getPath());
+
+        String message = response.readEntity(String.class);
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals("Hello World!", message);
+        Assert.assertTrue(uri.getPath().equals("/helloworld/"));
     }
 }


### PR DESCRIPTION
## Description
Add Backwards Compatibility for Defining Implicit CDI via `glassfish-application.xml` as it was removed in https://github.com/payara/Payara/pull/8125

## Important Info
### Blockers
None

## Testing
### New tests
payara-application-xml functional tests extended to check that payara-application.xml and glassfish-application.xml can both be read from, and that the payara-application.xml overrides the glassfish-application.xml.

### Testing Performed
Ran the new tests.

### Testing Environment
Windows 11, Maven 3.9.16, Zulu JDK 21.0.11

## Documentation
N/A

## Notes for Reviewers
None
