### PR TITLE
FISH-13873 Fix Nucleus admin test suite

### DIFF
--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -86,7 +86,6 @@ of COPY_LIB map constant.)
     <groupId>org.glassfish.tests</groupId>
     <artifactId>nucleus-admin</artifactId>
     <name>Nucleus Admin Devtests</name>
-    <!-- <version>4.1-SNAPSHOT</version> -->
     <description>This pom describes how to run admin developer tests on the Nucleus Bundle</description>
     <build>
         <plugins>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -85,7 +85,7 @@ of COPY_LIB map constant.)
     <groupId>org.glassfish.tests</groupId>
     <artifactId>nucleus-admin</artifactId>
     <name>Nucleus Admin Devtests</name>
-    <version>4.1-SNAPSHOT</version>
+    <!-- <version>4.1-SNAPSHOT</version> -->
     <description>This pom describes how to run admin developer tests on the Nucleus Bundle</description>
     <build>
         <plugins>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -174,7 +174,6 @@ of COPY_LIB map constant.)
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>1.1.5</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -94,14 +94,6 @@ of COPY_LIB map constant.)
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <properties>
-                <property>
-                  <name>listener</name>
-                  <value>org.testng.reporters.VerboseReporter</value>
-                </property>
-                <property>
-                  <name>reporter</name>
-                  <value>listenReport.Reporter</value>
-                </property>
                 <runOrder>alphabetical</runOrder>
               </properties>
             </configuration>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -182,7 +182,7 @@ of COPY_LIB map constant.)
         <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
-            <version>1.1</version>
+            <version>1.1.5</version>
         </dependency>
     </dependencies>
 </project>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -39,6 +39,7 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
+    Portions Copyright 2017-2026 Payara Foundation and/or affiliates
 -->
 <!--
 INSTRUCTIONS for running nucleus admin dev tests.

--- a/nucleus/tests/admin/src/test/java/org/glassfish/nucleus/admin/NucleusStartStopTest.java
+++ b/nucleus/tests/admin/src/test/java/org/glassfish/nucleus/admin/NucleusStartStopTest.java
@@ -37,6 +37,9 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+
+// Portions Copyright 2026 Payara Foundation and/or its affiliates
+
 package org.glassfish.nucleus.admin;
 
 import java.io.File;

--- a/nucleus/tests/admin/src/test/java/org/glassfish/nucleus/admin/NucleusStartStopTest.java
+++ b/nucleus/tests/admin/src/test/java/org/glassfish/nucleus/admin/NucleusStartStopTest.java
@@ -53,13 +53,12 @@ import java.util.Map;
 import org.glassfish.tests.utils.NucleusTestUtils;
 import static org.glassfish.tests.utils.NucleusTestUtils.*;
 import static org.testng.AssertJUnit.*;
-import org.testng.ITestContext;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 
 public class NucleusStartStopTest {
 
-    private static final String TEST_LIBS_KEY = "TEST_LIBS";
+    private static final Collection<File> testLibs = new ArrayList<>();
     private static final Map<String, String> COPY_LIB;
     static {
         HashMap<String, String> map = new HashMap<String, String>();
@@ -68,10 +67,8 @@ public class NucleusStartStopTest {
     }
 
     @BeforeSuite
-    public void setUp(ITestContext context) throws IOException {
+    public void setUp() throws IOException {
         //Copy testing libraries into Nucleus distribution
-        Collection<File> testLibs = new ArrayList<File>();
-        context.setAttribute(TEST_LIBS_KEY, testLibs);
         String basedir = System.getProperty("basedir");
         assertNotNull(basedir);
         File addondir = new File(basedir, "target/addon");
@@ -85,19 +82,16 @@ public class NucleusStartStopTest {
     }
 
     @AfterSuite(alwaysRun = true)
-    public void tearDown(ITestContext context) {
+    public void tearDown() {
         try {
             assertTrue(nadmin("stop-domain"));
         } finally {
-            Collection<File> libs = (Collection<File>) context.getAttribute(TEST_LIBS_KEY);
-            if (libs != null) {
-                for (File lib : libs) {
-                    if (lib.exists()) {
-                        try {
-                            lib.delete();
-                        } catch (Exception ex) {
-                            System.out.println("Can not delete " + lib.getAbsolutePath());
-                        }
+            for (File lib : testLibs) {
+                if (lib.exists()) {
+                    try {
+                        lib.delete();
+                    } catch (Exception ex) {
+                        System.out.println("Can not delete " + lib.getAbsolutePath());
                     }
                 }
             }

--- a/nucleus/tests/admin/src/test/java/org/glassfish/nucleus/admin/NucleusStartStopTest.java
+++ b/nucleus/tests/admin/src/test/java/org/glassfish/nucleus/admin/NucleusStartStopTest.java
@@ -62,7 +62,7 @@ public class NucleusStartStopTest {
     private static final Map<String, String> COPY_LIB;
     static {
         HashMap<String, String> map = new HashMap<String, String>();
-        map.put("modules", "modules");
+        map.put("modules", "glassfish/modules");
         COPY_LIB = Collections.unmodifiableMap(map);
     }
 
@@ -128,6 +128,7 @@ public class NucleusStartStopTest {
 
     private static void copy(File src, File dest) throws IOException {
         if (!dest.exists()) {
+            dest.getParentFile().mkdirs();
             dest.createNewFile();
         }
         FileChannel sch = null;


### PR DESCRIPTION
## Description
Fixes so that we can execute the suite at all and get individual unique test failures reported.

## Important Info

## Testing

### Testing Performed
The test suite is not run on CI current (probably not since 2024 or much earlier).

## Documentation
https://github.com/payara/Payara/blob/0fa69453527982b694d63bb4f28febfe0f97b2d1/nucleus/tests/admin/pom.xml#L43-L75

Stale "documentation" because we don't create a Nucleus distribution anymore. However you can run the suite by pointing it at our regular distribution.

`mvn test -Dnucleus.home=${REPO_ROOT}/appserver/distributions/payara/target/stage/payara7`