### PR TITLE
[WIP] bugfix: remove slf4j-nop from mina-repackaged

### DIFF
--- a/nucleus/packager/external/apache-mina/pom.xml
+++ b/nucleus/packager/external/apache-mina/pom.xml
@@ -134,12 +134,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
-            <version>${slf4j.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>com.bloxbean.cardano</groupId>
             <artifactId>net-i2p-crypto-eddsa</artifactId>
             <version>0.3.1</version>


### PR DESCRIPTION
## Description
Bugfix. Inclusion of slf4j-nop in Apache Mina repackaged interferes with application that use other SLF4j providers such as slf4j-jdk14
This issue was introduced in #8204

fixes #8255 
Possibly superseded by #8251

## Logs
```
[#|2026-06-28T00:37:30.187-0500|SEVERE|Payara 7.2026.6||_ThreadID=130;_ThreadName=http-thread-pool::http-listener-1(2);_TimeMillis=1782625050187;_LevelValue=1000;|
  SLF4J(E): A service provider failed to instantiate:
org.slf4j.spi.SLF4JServiceProvider: org.slf4j.nop.NOPServiceProvider not a subtype|#]
```

## Important Info
### Blockers
The issue is that the repackaged modules are not shaded properly, and thus available for all class loaders

### Testing Performed
Errors appear when applications use slf4j. With this change, errors disappear

## Notes for Reviewers
This is a work in progress for now. Currently, this fixes the applications logging errors, but not sure why slf4j-nop was included in the first place

I believe the proper fix is to shade the dependencies with relocation if necessary, not "plain" additions to the JAR fiels