### PR TITLE
FISH-12353 Verify archive type in MicroprofileSniffer

### DIFF
--- a/appserver/payara-appserver-modules/microprofile/microprofile-connector/src/main/java/fish/payara/microprofile/connector/MicroProfileSniffer.java
+++ b/appserver/payara-appserver-modules/microprofile/microprofile-connector/src/main/java/fish/payara/microprofile/connector/MicroProfileSniffer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020-2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -46,10 +46,12 @@ import java.util.logging.Logger;
 
 import com.sun.enterprise.module.HK2Module;
 
+import jakarta.inject.Inject;
 import org.glassfish.api.container.Sniffer;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.api.deployment.archive.ReadableArchive;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.web.sniffer.WarType;
 import org.jvnet.hk2.annotations.Contract;
 
@@ -58,8 +60,16 @@ public abstract class MicroProfileSniffer implements Sniffer {
 
     private static final Logger LOGGER = Logger.getLogger(MicroProfileSniffer.class.getName());
 
+    @Inject
+    private ServiceLocator serviceLocator;
+
     @Override
     public boolean handles(DeploymentContext context) {
+        ArchiveType archiveType = serviceLocator.getService(ArchiveType.class,
+                context.getArchiveHandler().getArchiveType());
+        if (archiveType != null && !supportsArchiveType(archiveType)) {
+            return false;
+        }
         final ReadableArchive archive = context.getSource();
 
         final String archivePath = archive.getURI().getPath();


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
Title.

When a RAR was deployed and a metrics.xml was placed in domain1/config the MetricsSniffer was incorrectly being added and caused an error due to being incompatible with the ConnectorsSniifer. 

The fix is to verified the archive type in MicroprofileSniffer. 

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Placed metrics.xml in domain1/config
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.9, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.9-zulu/zulu-21.jdk/Contents/Home
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "26.4.1", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
See JIRA for RAR and metrics.xml