### PR TITLE
FISH-13968 Jax-RS leak prevention also applies to Jax-RS client, not onl…

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/JaxRSJsonContextResolver.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/JaxRSJsonContextResolver.java
@@ -43,7 +43,6 @@ import jakarta.annotation.Priority;
 import jakarta.inject.Inject;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
-import jakarta.ws.rs.ConstrainedTo;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.FeatureContext;
 import jakarta.ws.rs.core.MediaType;
@@ -56,7 +55,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import static jakarta.ws.rs.RuntimeType.SERVER;
 import static org.glassfish.jersey.internal.spi.AutoDiscoverable.DEFAULT_PRIORITY;
 
 /**
@@ -65,7 +63,6 @@ import static org.glassfish.jersey.internal.spi.AutoDiscoverable.DEFAULT_PRIORIT
  *
  * This includes creating {@link Jsonb} instances that contains correct {@link jakarta.enterprise.inject.spi.BeanManager}
  */
-@ConstrainedTo(SERVER)
 @Priority(DEFAULT_PRIORITY)
 @Produces(MediaType.APPLICATION_JSON)
 public class JaxRSJsonContextResolver implements ContextResolver<Jsonb>, ForcedAutoDiscoverable {
@@ -81,8 +78,9 @@ public class JaxRSJsonContextResolver implements ContextResolver<Jsonb>, ForcedA
         this.existingResolverClasses = Collections.emptyList();
     }
 
-    private JaxRSJsonContextResolver(List<ContextResolver<?>> existingResolvers,
+    private JaxRSJsonContextResolver(InjectionManager injectionManager, List<ContextResolver<?>> existingResolvers,
                                      List<Class<ContextResolver<?>>> existingResolverClasses) {
+        this.injectionManager = injectionManager;
         this.existingResolvers = existingResolvers;
         this.existingResolverClasses = existingResolverClasses;
     }
@@ -98,7 +96,7 @@ public class JaxRSJsonContextResolver implements ContextResolver<Jsonb>, ForcedA
                 .filter(ContextResolver.class::isAssignableFrom)
                 .map(cls -> (Class<ContextResolver<?>>) cls)
                 .collect(Collectors.toList());
-        context.register(new JaxRSJsonContextResolver(resolvers, resolverClasses));
+        context.register(new JaxRSJsonContextResolver(injectionManager, resolvers, resolverClasses));
     }
 
     @Override


### PR DESCRIPTION
…y server

<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
`weld/JaxRSJsonContextResolver.java` was previously restricted to server-only, but this issue also applies to jax-rs clients. This PR removes this restriction, and thus fixes Jax-RS clients that integrate with multiple applications in CDI.

## Notes for Reviewers
This is an enhancement to the bug fix in #7314 that applies to Jax-RS Clients.
Same ClassLoader leaks that was fixed in the above PR appears in Jax-RS clients, which this PR fixes.