### PR TITLE
FISH-13493 FISH-13969 FISH-13982 Forward-Port Payara 6 Deployment Descriptors

### DIFF
--- a/appserver/admin/gf_template/src/main/resources/config/payara-acc.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/payara-acc.xml
@@ -49,7 +49,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client-container_1_4-1.dtd">
 
 <client-container>
   <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>

--- a/appserver/admin/gf_template/src/main/resources/config/payara-acc.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/payara-acc.xml
@@ -49,7 +49,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
 
 <client-container>
   <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>

--- a/appserver/admin/gf_template/src/main/resources/config/payara-acc.xml
+++ b/appserver/admin/gf_template/src/main/resources/config/payara-acc.xml
@@ -49,7 +49,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application-client-container_1_4.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client-container_1_4.dtd">
 
 <client-container>
   <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>

--- a/appserver/admin/gf_template_web/src/main/resources/config/payara-acc.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/payara-acc.xml
@@ -47,7 +47,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client-container_1_4-1.dtd">
 
 <client-container>
   <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>

--- a/appserver/admin/gf_template_web/src/main/resources/config/payara-acc.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/payara-acc.xml
@@ -47,7 +47,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
 
 <client-container>
   <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>

--- a/appserver/admin/gf_template_web/src/main/resources/config/payara-acc.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/payara-acc.xml
@@ -47,7 +47,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client-container_1_4.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
 
 <client-container>
   <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>

--- a/appserver/admin/gf_template_web/src/main/resources/config/payara-acc.xml
+++ b/appserver/admin/gf_template_web/src/main/resources/config/payara-acc.xml
@@ -47,7 +47,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application-client-container_1_4.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client-container_1_4.dtd">
 
 <client-container>
   <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>

--- a/appserver/appclient/client/acc-config/src/test/java/org/glassfish/appclient/client/acc/config/util/XMLTest.java
+++ b/appserver/appclient/client/acc-config/src/test/java/org/glassfish/appclient/client/acc/config/util/XMLTest.java
@@ -72,7 +72,7 @@ import static org.junit.Assert.*;
  */
 public class XMLTest {
 
-    private static final String[] SAMPLE_XML_PATH = {"/sun-acc.xml", "/glassfish-acc.xml", "/payara-acc.xml"};
+    private static final String[] SAMPLE_XML_PATH = {"/sun-acc.xml", "/glassfish-acc.xml", "/payara6-acc.xml", "/payara-acc.xml", "/payara7-acc-p1.xml"};
     
     private static final String FIRST_HOST = "glassfish.dev.java.net";
     private static final int FIRST_PORT = 3701;
@@ -175,9 +175,15 @@ public class XMLTest {
             GLASSFISH_ACC(
                 "-//GlassFish.org//DTD GlassFish Application Server 3.1 Application Client Container//EN",
                 "dtds/glassfish-application-client-container_1_3.dtd"),
+            PAYARA6_ACC(
+                    "-//Payara.fish//DTD Payara Application Server 6 Application Client Container//EN",
+                    "dtds/payara6-application-client-container_1_4-0.dtd"),
             PAYARA_ACC(
                 "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN",
-                        "dtds/payara-application-client-container_1_4.dtd");
+                        "dtds/payara-application-client-container_1_4.dtd"),
+            PAYARA7_ACC(
+                    "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Patch 1//EN",
+                    "dtds/payara7-application-client-container_1_4-1.dtd");
             
             private static final String SYSTEM_ID_PREFIX = "http://glassfish.org/";
             

--- a/appserver/appclient/client/acc-config/src/test/java/org/glassfish/appclient/client/acc/config/util/XMLTest.java
+++ b/appserver/appclient/client/acc-config/src/test/java/org/glassfish/appclient/client/acc/config/util/XMLTest.java
@@ -182,7 +182,7 @@ public class XMLTest {
                 "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN",
                         "dtds/payara-application-client-container_1_4.dtd"),
             PAYARA7_ACC(
-                    "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Patch 1//EN",
+                    "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN",
                     "dtds/payara7-application-client-container_1_4-1.dtd");
             
             private static final String SYSTEM_ID_PREFIX = "http://glassfish.org/";

--- a/appserver/appclient/client/acc-config/src/test/resources/payara-acc.xml
+++ b/appserver/appclient/client/acc-config/src/test/resources/payara-acc.xml
@@ -49,7 +49,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application-client-container_1_4.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client-container_1_4.dtd">
 
 <client-container>
   <target-server name="glassfish.dev.java.net" address="glassfish.dev.java.net" port="3701"/>

--- a/appserver/appclient/client/acc-config/src/test/resources/payara-acc.xml
+++ b/appserver/appclient/client/acc-config/src/test/resources/payara-acc.xml
@@ -49,7 +49,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client-container_1_4.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client-container_1_4.dtd">
 
 <client-container>
   <target-server name="glassfish.dev.java.net" address="glassfish.dev.java.net" port="3701"/>

--- a/appserver/appclient/client/acc-config/src/test/resources/payara6-acc.xml
+++ b/appserver/appclient/client/acc-config/src/test/resources/payara6-acc.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -49,10 +49,11 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Application Client Container//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara6-application-client-container_1_4-0.dtd">
 
 <client-container>
-  <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>
+  <target-server name="glassfish.dev.java.net" address="glassfish.dev.java.net" port="3701"/>
+  <target-server name="other.dev.java.net" address="other.dev.java.net" port="4701"/>
   <log-service file="" level="WARNING"/>
   <message-security-config auth-layer="SOAP">
     <!-- turned off by default -->
@@ -71,7 +72,9 @@
       <property name="signature.key.alias" value="s1as"/>
       <property name="dynamic.username.password" value="false"/>
       <property name="debug" value="false"/>
-      <property name="security.config" value="${com.sun.aas.installRoot}/lib/appclient/wss-client-config-1.0.xml"/>
+      <property name="security.config" value="/Users/dochez/java/cvs/v3/publish/lib/appclient/wss-client-config-1.0.xml"/> 
     </provider-config>
   </message-security-config>
+  <property name="firstProp" value="firstValue"/>
+  <property name="secondProp" value="secondValue"/>
 </client-container>

--- a/appserver/appclient/client/acc-config/src/test/resources/payara6-acc.xml
+++ b/appserver/appclient/client/acc-config/src/test/resources/payara6-acc.xml
@@ -49,7 +49,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Application Client Container//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara6-application-client-container_1_4-0.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Application Client Container//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client-container_1_4-0.dtd">
 
 <client-container>
   <target-server name="glassfish.dev.java.net" address="glassfish.dev.java.net" port="3701"/>

--- a/appserver/appclient/client/acc-config/src/test/resources/payara7-acc-p1.xml
+++ b/appserver/appclient/client/acc-config/src/test/resources/payara7-acc-p1.xml
@@ -49,7 +49,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client-container_1_4-1.dtd">
 
 <client-container>
   <target-server name="glassfish.dev.java.net" address="glassfish.dev.java.net" port="3701"/>

--- a/appserver/appclient/client/acc-config/src/test/resources/payara7-acc-p1.xml
+++ b/appserver/appclient/client/acc-config/src/test/resources/payara7-acc-p1.xml
@@ -49,7 +49,7 @@
    - Property security.config in message-security-config
 -->
 
-<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
 
 <client-container>
   <target-server name="glassfish.dev.java.net" address="glassfish.dev.java.net" port="3701"/>

--- a/appserver/appclient/client/acc-config/src/test/resources/payara7-acc-p1.xml
+++ b/appserver/appclient/client/acc-config/src/test/resources/payara7-acc-p1.xml
@@ -3,7 +3,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2004-2013 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -52,7 +52,8 @@
 <!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Application Client Container Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client-container_1_4-1.dtd">
 
 <client-container>
-  <target-server name="%%%SERVER_NAME%%%" address="localhost" port="%%%ORB_LISTENER1_PORT%%%"/>
+  <target-server name="glassfish.dev.java.net" address="glassfish.dev.java.net" port="3701"/>
+  <target-server name="other.dev.java.net" address="other.dev.java.net" port="4701"/>
   <log-service file="" level="WARNING"/>
   <message-security-config auth-layer="SOAP">
     <!-- turned off by default -->
@@ -71,7 +72,9 @@
       <property name="signature.key.alias" value="s1as"/>
       <property name="dynamic.username.password" value="false"/>
       <property name="debug" value="false"/>
-      <property name="security.config" value="${com.sun.aas.installRoot}/lib/appclient/wss-client-config-1.0.xml"/>
+      <property name="security.config" value="/Users/dochez/java/cvs/v3/publish/lib/appclient/wss-client-config-1.0.xml"/> 
     </provider-config>
   </message-security-config>
+  <property name="firstProp" value="firstValue"/>
+  <property name="secondProp" value="secondValue"/>
 </client-container>

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
@@ -287,7 +287,7 @@ public final class DTDRegistry {
     public static final String PAYARA_WEBAPP_610_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN";
     @Deprecated
     public static final String PAYARA_WEBAPP_610_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-web-app_6_1-0.dtd";
-    public static final String PAYARA7_WEBAPP_611_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Patch 1//EN";
+    public static final String PAYARA7_WEBAPP_611_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN";
     public static final String PAYARA7_WEBAPP_611_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd";
 
     @Deprecated
@@ -298,7 +298,7 @@ public final class DTDRegistry {
     public static final String PAYARA_APPCLIENT_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN";
     @Deprecated
     public static final String PAYARA_APPCLIENT_110_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client_11-0.dtd";
-    public static final String PAYARA7_APPCLIENT_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Patch 1//EN";
+    public static final String PAYARA7_APPCLIENT_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Revision 1//EN";
     public static final String PAYARA7_APPCLIENT_111_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd";
 
     @Deprecated
@@ -309,7 +309,7 @@ public final class DTDRegistry {
     public static final String PAYARA_APPLICATION_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN";
     @Deprecated
     public static final String PAYARA_APPLICATION_110_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd";
-    public static final String PAYARA7_APPLICATION_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Patch 1//EN";
+    public static final String PAYARA7_APPLICATION_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Revision 1//EN";
     public static final String PAYARA7_APPLICATION_111_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application_11-1.dtd";
 
     @Deprecated
@@ -320,7 +320,7 @@ public final class DTDRegistry {
     public static final String PAYARA_EJBJAR_400_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN";
     @Deprecated
     public static final String PAYARA_EJBJAR_400_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd";
-    public static final String PAYARA7_EJBJAR_401_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0 Patch 1//EN";
+    public static final String PAYARA7_EJBJAR_401_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0 Revision 1//EN";
     public static final String PAYARA7_EJBJAR_401_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd";
 
 }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
@@ -274,28 +274,55 @@ public final class DTDRegistry {
     
     
     // Payara DTDs
-    
+
+    @Deprecated
     public static final String PAYARA_WEBAPP_4_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 4 Servlet 3.0//EN";
+    @Deprecated
     public static final String PAYARA_WEBAPP_4_DTD_SYSTEM_ID = "https://docs.payara.fish/schemas/payara-web-app_4.dtd";
-
-    public static final String PAYARA_WEBAPP_600_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN";
-    public static final String PAYARA_WEBAPP_600_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-web-app_6_0-0.dtd";
+    @Deprecated
+    public static final String PAYARA6_WEBAPP_600_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN";
+    @Deprecated
+    public static final String PAYARA6_WEBAPP_600_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-web-app_6_0-0.dtd";
+    @Deprecated
     public static final String PAYARA_WEBAPP_610_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN";
+    @Deprecated
     public static final String PAYARA_WEBAPP_610_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-web-app_6_1-0.dtd";
+    public static final String PAYARA7_WEBAPP_611_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Patch 1//EN";
+    public static final String PAYARA7_WEBAPP_611_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd";
 
-    public static final String PAYARA_APPCLIENT_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN";
-    public static final String PAYARA_APPCLIENT_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application-client_10-0.dtd";
+    @Deprecated
+    public static final String PAYARA6_APPCLIENT_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN";
+    @Deprecated
+    public static final String PAYARA6_APPCLIENT_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application-client_10-0.dtd";
+    @Deprecated
     public static final String PAYARA_APPCLIENT_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN";
+    @Deprecated
     public static final String PAYARA_APPCLIENT_110_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client_11-0.dtd";
+    public static final String PAYARA7_APPCLIENT_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Patch 1//EN";
+    public static final String PAYARA7_APPCLIENT_111_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd";
 
-    public static final String PAYARA_APPLICATION_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN";
-    public static final String PAYARA_APPLICATION_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application_10-0.dtd";
+    @Deprecated
+    public static final String PAYARA6_APPLICATION_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN";
+    @Deprecated
+    public static final String PAYARA6_APPLICATION_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application_10-0.dtd";
+    @Deprecated
     public static final String PAYARA_APPLICATION_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN";
+    @Deprecated
     public static final String PAYARA_APPLICATION_110_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd";
+    public static final String PAYARA7_APPLICATION_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Patch 1//EN";
+    public static final String PAYARA7_APPLICATION_111_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application_11-1.dtd";
 
+    @Deprecated
+    public static final String PAYARA6_EJBJAR_400_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN";
+    @Deprecated
+    public static final String PAYARA6_EJBJAR_400_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-ejb-jar_4_0-0.dtd";
+    @Deprecated
     public static final String PAYARA_EJBJAR_400_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN";
+    @Deprecated
     public static final String PAYARA_EJBJAR_400_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd";
-    
+    public static final String PAYARA7_EJBJAR_401_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0 Patch 1//EN";
+    public static final String PAYARA7_EJBJAR_401_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd";
+
 }
 
 // END OF IASRI 4661135

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
@@ -281,20 +281,20 @@ public final class DTDRegistry {
     public static final String PAYARA_WEBAPP_600_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN";
     public static final String PAYARA_WEBAPP_600_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-web-app_6_0-0.dtd";
     public static final String PAYARA_WEBAPP_610_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN";
-    public static final String PAYARA_WEBAPP_610_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_6_1-0.dtd";
+    public static final String PAYARA_WEBAPP_610_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-web-app_6_1-0.dtd";
 
     public static final String PAYARA_APPCLIENT_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN";
     public static final String PAYARA_APPCLIENT_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application-client_10-0.dtd";
     public static final String PAYARA_APPCLIENT_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN";
-    public static final String PAYARA_APPCLIENT_110_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application-client_11-0.dtd";
+    public static final String PAYARA_APPCLIENT_110_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client_11-0.dtd";
 
     public static final String PAYARA_APPLICATION_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN";
     public static final String PAYARA_APPLICATION_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application_10-0.dtd";
     public static final String PAYARA_APPLICATION_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN";
-    public static final String PAYARA_APPLICATION_110_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application_11-0.dtd";
+    public static final String PAYARA_APPLICATION_110_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd";
 
     public static final String PAYARA_EJBJAR_400_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN";
-    public static final String PAYARA_EJBJAR_400_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-ejb-jar_4_0-0.dtd";
+    public static final String PAYARA_EJBJAR_400_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd";
     
 }
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
@@ -282,46 +282,46 @@ public final class DTDRegistry {
     @Deprecated
     public static final String PAYARA6_WEBAPP_600_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN";
     @Deprecated
-    public static final String PAYARA6_WEBAPP_600_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-web-app_6_0-0.dtd";
+    public static final String PAYARA6_WEBAPP_600_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-web-app_6_0-0.dtd";
     @Deprecated
     public static final String PAYARA_WEBAPP_610_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN";
     @Deprecated
-    public static final String PAYARA_WEBAPP_610_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-web-app_6_1-0.dtd";
+    public static final String PAYARA_WEBAPP_610_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-web-app_6_1-0.dtd";
     public static final String PAYARA7_WEBAPP_611_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN";
-    public static final String PAYARA7_WEBAPP_611_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd";
+    public static final String PAYARA7_WEBAPP_611_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd";
 
     @Deprecated
     public static final String PAYARA6_APPCLIENT_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN";
     @Deprecated
-    public static final String PAYARA6_APPCLIENT_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application-client_10-0.dtd";
+    public static final String PAYARA6_APPCLIENT_100_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client_10-0.dtd";
     @Deprecated
     public static final String PAYARA_APPCLIENT_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN";
     @Deprecated
-    public static final String PAYARA_APPCLIENT_110_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client_11-0.dtd";
+    public static final String PAYARA_APPCLIENT_110_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client_11-0.dtd";
     public static final String PAYARA7_APPCLIENT_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Revision 1//EN";
-    public static final String PAYARA7_APPCLIENT_111_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd";
+    public static final String PAYARA7_APPCLIENT_111_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd";
 
     @Deprecated
     public static final String PAYARA6_APPLICATION_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN";
     @Deprecated
-    public static final String PAYARA6_APPLICATION_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application_10-0.dtd";
+    public static final String PAYARA6_APPLICATION_100_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application_10-0.dtd";
     @Deprecated
     public static final String PAYARA_APPLICATION_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN";
     @Deprecated
-    public static final String PAYARA_APPLICATION_110_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd";
+    public static final String PAYARA_APPLICATION_110_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_11-0.dtd";
     public static final String PAYARA7_APPLICATION_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Revision 1//EN";
-    public static final String PAYARA7_APPLICATION_111_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application_11-1.dtd";
+    public static final String PAYARA7_APPLICATION_111_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd";
 
     @Deprecated
     public static final String PAYARA6_EJBJAR_400_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN";
     @Deprecated
-    public static final String PAYARA6_EJBJAR_400_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-ejb-jar_4_0-0.dtd";
+    public static final String PAYARA6_EJBJAR_400_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-ejb-jar_4_0-0.dtd";
     @Deprecated
     public static final String PAYARA_EJBJAR_400_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN";
     @Deprecated
-    public static final String PAYARA_EJBJAR_400_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd";
+    public static final String PAYARA_EJBJAR_400_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-ejb-jar_4_0-0.dtd";
     public static final String PAYARA7_EJBJAR_401_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0 Revision 1//EN";
-    public static final String PAYARA7_EJBJAR_401_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd";
+    public static final String PAYARA7_EJBJAR_401_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-ejb-jar_4_0-1.dtd";
 
 }
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
@@ -278,12 +278,18 @@ public final class DTDRegistry {
     public static final String PAYARA_WEBAPP_4_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 4 Servlet 3.0//EN";
     public static final String PAYARA_WEBAPP_4_DTD_SYSTEM_ID = "https://docs.payara.fish/schemas/payara-web-app_4.dtd";
 
+    public static final String PAYARA_WEBAPP_600_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN";
+    public static final String PAYARA_WEBAPP_600_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-web-app_6_0-0.dtd";
     public static final String PAYARA_WEBAPP_610_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN";
     public static final String PAYARA_WEBAPP_610_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_6_1-0.dtd";
 
+    public static final String PAYARA_APPCLIENT_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN";
+    public static final String PAYARA_APPCLIENT_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application-client_10-0.dtd";
     public static final String PAYARA_APPCLIENT_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN";
     public static final String PAYARA_APPCLIENT_110_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application-client_11-0.dtd";
 
+    public static final String PAYARA_APPLICATION_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN";
+    public static final String PAYARA_APPLICATION_100_DTD_SYSTEM_ID = "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application_10-0.dtd";
     public static final String PAYARA_APPLICATION_110_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN";
     public static final String PAYARA_APPLICATION_110_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application_11-0.dtd";
 

--- a/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/PayaraAppClientRuntimeNode.java
+++ b/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/PayaraAppClientRuntimeNode.java
@@ -74,14 +74,14 @@ public class PayaraAppClientRuntimeNode extends AppClientRuntimeNode {
      * @return the DOCTYPE that should be written to the XML file
      */
     public String getDocType() {
-        return DTDRegistry.PAYARA_APPCLIENT_110_DTD_PUBLIC_ID;
+        return DTDRegistry.PAYARA7_APPCLIENT_111_DTD_PUBLIC_ID;
     }
 
     /**
      * @return the SystemID of the XML file
      */
     public String getSystemID() {
-        return DTDRegistry.PAYARA_APPCLIENT_110_DTD_SYSTEM_ID;
+        return DTDRegistry.PAYARA7_APPCLIENT_111_DTD_SYSTEM_ID;
     }
 
     /**
@@ -91,8 +91,9 @@ public class PayaraAppClientRuntimeNode extends AppClientRuntimeNode {
      * @return the doctype tag name
      */
     public static String registerBundle(Map publicIDToDTD) {
-        publicIDToDTD.put(DTDRegistry.PAYARA_APPCLIENT_100_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPCLIENT_100_DTD_SYSTEM_ID);
+        publicIDToDTD.put(DTDRegistry.PAYARA6_APPCLIENT_100_DTD_PUBLIC_ID, DTDRegistry.PAYARA6_APPCLIENT_100_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA_APPCLIENT_110_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPCLIENT_110_DTD_SYSTEM_ID);
+        publicIDToDTD.put(DTDRegistry.PAYARA7_APPCLIENT_111_DTD_PUBLIC_ID, DTDRegistry.PAYARA7_APPCLIENT_111_DTD_SYSTEM_ID);
         return RuntimeTagNames.PAYARA_APPCLIENT_RUNTIME_TAG;
     }
 }

--- a/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/PayaraAppClientRuntimeNode.java
+++ b/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/PayaraAppClientRuntimeNode.java
@@ -91,6 +91,7 @@ public class PayaraAppClientRuntimeNode extends AppClientRuntimeNode {
      * @return the doctype tag name
      */
     public static String registerBundle(Map publicIDToDTD) {
+        publicIDToDTD.put(DTDRegistry.PAYARA_APPCLIENT_100_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPCLIENT_100_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA_APPCLIENT_110_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPCLIENT_110_DTD_SYSTEM_ID);
         return RuntimeTagNames.PAYARA_APPCLIENT_RUNTIME_TAG;
     }

--- a/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/application/PayaraApplicationRuntimeNode.java
+++ b/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/application/PayaraApplicationRuntimeNode.java
@@ -88,6 +88,7 @@ public class PayaraApplicationRuntimeNode extends ApplicationRuntimeNode {
      * @return the doctype tag name
      */
     public static String registerBundle(Map publicIDToDTD) {
+        publicIDToDTD.put(DTDRegistry.PAYARA_APPLICATION_100_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPLICATION_100_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA_APPLICATION_110_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPLICATION_110_DTD_SYSTEM_ID);
         return RuntimeTagNames.PAYARA_APPLICATION_RUNTIME_TAG;
     }

--- a/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/application/PayaraApplicationRuntimeNode.java
+++ b/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/application/PayaraApplicationRuntimeNode.java
@@ -71,14 +71,14 @@ public class PayaraApplicationRuntimeNode extends ApplicationRuntimeNode {
      * @return the DOCTYPE that should be written to the XML file
      */
     public String getDocType() {
-        return DTDRegistry.PAYARA_APPLICATION_110_DTD_PUBLIC_ID;
+        return DTDRegistry.PAYARA7_APPLICATION_111_DTD_PUBLIC_ID;
     }
 
     /**
      * @return the SystemID of the XML file
      */
     public String getSystemID() {
-        return DTDRegistry.PAYARA_APPLICATION_110_DTD_SYSTEM_ID;
+        return DTDRegistry.PAYARA7_APPLICATION_111_DTD_SYSTEM_ID;
     }
 
     /**
@@ -88,8 +88,9 @@ public class PayaraApplicationRuntimeNode extends ApplicationRuntimeNode {
      * @return the doctype tag name
      */
     public static String registerBundle(Map publicIDToDTD) {
-        publicIDToDTD.put(DTDRegistry.PAYARA_APPLICATION_100_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPLICATION_100_DTD_SYSTEM_ID);
+        publicIDToDTD.put(DTDRegistry.PAYARA6_APPLICATION_100_DTD_PUBLIC_ID, DTDRegistry.PAYARA6_APPLICATION_100_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA_APPLICATION_110_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPLICATION_110_DTD_SYSTEM_ID);
+        publicIDToDTD.put(DTDRegistry.PAYARA7_APPLICATION_111_DTD_PUBLIC_ID, DTDRegistry.PAYARA7_APPLICATION_111_DTD_SYSTEM_ID);
         return RuntimeTagNames.PAYARA_APPLICATION_RUNTIME_TAG;
     }
 }

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client_10-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client_10-0.dtd
@@ -1,0 +1,559 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2012 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+        <!-- Portions Copyright 2026 Payara Foundation and/or its affiliates -->
+
+        <!--
+          XML DTD for Payara Application Server specific Jakarta EE Client Application
+          deployment descriptor. This is a companion DTD to application-client_10.xsd
+
+          It must include a DOCTYPE of the following form:
+
+          <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application-client_10-0.dtd">
+
+        -->
+
+        <!--
+        payara-application-client is the root element describing all the runtime bindings of a single application client
+        -->
+        <!ELEMENT payara-application-client (ejb-ref*, resource-ref*, resource-env-ref*, service-ref*,
+                message-destination-ref*, message-destination*, java-web-start-access?, version-identifier?)>
+
+        <!--
+        name of a resource reference.
+        -->
+        <!ELEMENT res-ref-name (#PCDATA)>
+
+        <!--
+        resource-env-ref holds all the runtime bindings of a resource env reference.
+        -->
+        <!ELEMENT resource-env-ref ( resource-env-ref-name, jndi-name )>
+
+        <!--
+        name of a resource env reference.
+        -->
+        <!ELEMENT resource-env-ref-name (#PCDATA)>
+
+        <!--
+        resource-ref holds the runtime bindings of a resource reference.
+        -->
+        <!ELEMENT resource-ref  ( res-ref-name, jndi-name,  default-resource-principal?)>
+
+        <!--
+        default-resource-principal specifies the default principal that the container
+        will use to access a resource.
+        -->
+        <!ELEMENT default-resource-principal ( name,  password)>
+
+        <!--
+        name element holds the user name
+        -->
+        <!ELEMENT name (#PCDATA)>
+
+        <!--
+        password element holds a password string.
+        -->
+        <!ELEMENT password (#PCDATA)>
+
+        <!--
+        ejb-ref element which binds an ejb reference to a jndi name.
+        -->
+        <!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+
+        <!--
+        ejb-ref-name locates the name of the ejb reference in the application.
+        -->
+        <!ELEMENT ejb-ref-name (#PCDATA)>
+
+        <!--
+        jndi name of the associated entity
+        -->
+        <!ELEMENT  jndi-name (#PCDATA)>
+
+        <!--
+        This node holds information about a logical message destination
+        -->
+        <!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+        <!--
+        This node holds the name of a logical message destination
+        -->
+        <!ELEMENT message-destination-name (#PCDATA)>
+
+        <!--
+        message-destination-ref is used to directly bind a message destination reference
+        to the jndi-name of a Queue,Topic, or some other physical destination. It should
+        only be used when the corresponding message destination reference does not
+        specify a message-destination-link to a logical message-destination.
+        -->
+        <!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+        <!--
+        name of a message-destination reference.
+        -->
+        <!ELEMENT message-destination-ref-name (#PCDATA)>
+
+        <!--
+        Specifies the name of a durable subscription associated with a message-driven bean's
+        destination.  Required for a Topic destination, if subscription-durability is set to
+        Durable (in ejb-jar.xml)
+        -->
+
+        <!--
+                      W E B   S E R V I C E S
+        -->
+        <!--
+        Runtime settings for a web service reference.  In the simplest case,
+        there is no runtime information required for a service ref.  Runtime info
+        is only needed in the following cases :
+         * to define the port that should be used to resolve a container-managed port
+         * to define default Stub/Call property settings for Stub objects
+         * to define the URL of a final WSDL document to be used instead of
+        the one packaged with a service-ref
+        -->
+        <!ELEMENT service-ref ( service-ref-name, port-info*, call-property*,
+                wsdl-override?, service-impl-class?, service-qname? )>
+
+        <!--
+        Coded name (relative to java:comp/env) for a service-reference
+        -->
+        <!ELEMENT service-ref-name ( #PCDATA )>
+
+        <!--
+        Information for a port within a service-reference.
+
+        Either service-endpoint-interface or wsdl-port or both
+        (service-endpoint-interface and wsdl-port) should be specified.
+
+        If both are specified, wsdl-port represents the
+        port the container should choose for container-managed port selection.
+
+        The same wsdl-port value must not appear in
+        more than one port-info entry within the same service-ref.
+
+        If a particular service-endpoint-interface is using container-managed port
+        selection, it must not appear in more than one port-info entry
+        within the same service-ref.
+
+        The optional message-security-binding element is used to customize the
+        port to provider binding; either by binding the port to a specific provider
+        or by providing a definition of the message security requirements to be
+        enforced by the provider.
+
+        -->
+        <!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+        <!--
+        Fully qualified name of service endpoint interface
+        -->
+        <!ELEMENT service-endpoint-interface ( #PCDATA )>
+        <!--
+        Port used in port-info.
+        -->
+        <!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+        <!--
+        JAXRPC property values that should be set on a stub before it's returned to
+        to the web service client.  The property names can be any properties supported
+        by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+        -->
+        <!ELEMENT stub-property ( name, value )>
+
+        <!--
+        JAXRPC property values that should be set on a Call object before it's
+        returned to the web service client.  The property names can be any
+        properties supported by the JAXRPC Call implementation.  See javadoc
+        for javax.xml.rpc.Call
+        -->
+        <!ELEMENT call-property ( name, value )>
+
+        <!--
+        This is a valid URL pointing to a final WSDL document. It is optional.
+        If specified, the WSDL document at this URL will be used during
+        deployment instead of the WSDL document associated with the
+        service-ref in the standard deployment descriptor.
+
+        Examples :
+
+          // available via HTTP
+          <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+          // in a file
+          <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+        -->
+        <!ELEMENT wsdl-override ( #PCDATA )>
+
+        <!--
+        Name of generated service implementation class. This is not set by the
+        deployer. It is derived during deployment.
+        -->
+        <!ELEMENT service-impl-class ( #PCDATA )>
+
+        <!--
+        The service-qname element declares the specific WSDL service
+        element that is being refered to.  It is not set by the deployer.
+        It is derived during deployment.
+        -->
+        <!ELEMENT service-qname (namespaceURI, localpart)>
+
+        <!--
+        The localpart element indicates the local part of a QNAME.
+        -->
+        <!ELEMENT localpart (#PCDATA)>
+
+        <!--
+        The namespaceURI element indicates a URI.
+        -->
+        <!ELEMENT namespaceURI (#PCDATA)>
+
+        <!--
+        This text nodes holds a value string.
+        -->
+        <!ELEMENT value (#PCDATA)>
+
+        <!--
+        The message-layer entity is used to define the value of the
+        auth-layer attribute of message-security-binding elements.
+
+        Used in: message-security-binding
+        -->
+        <!ENTITY % message-layer    "(SOAP)">
+
+        <!--
+        The message-security-binding element is used to customize the
+        webservice-endpoint or port to provider binding; either by binding the
+        webservice-endpoint or port to a specific provider or by providing a
+        definition of the message security requirements to be enforced by the
+        provider.
+
+        These elements are typically NOT created as a result of the
+        deployment of an application. They need only be created when the
+        deployer or system administrator chooses to customize the
+        webservice-endpoint or port to provider binding.
+
+        The optional (repeating) message-security sub-element is used
+        to accomplish the latter; in which case the specified
+        message-security requirements override any defined with the
+        provider.
+
+        The auth-layer attribute identifies the message layer at which the
+        message-security requirements are to be enforced.
+
+        The optional provider-id attribute identifies the provider-config
+        and thus the authentication provider that is to be used to satisfy
+        the application specific message security requirements. If a value for
+        the provider-id attribute is not specified, and a default
+        provider is defined for the message layer, then it is used.
+        if a value for the provider-id attribute is not specified, and a
+        default provider is not defined at the layer, the authentication
+        requirements defined in the message-security-binding are not
+        enforced.
+
+        Default:
+        Used in: webservice-endpoint, port-info
+        -->
+        <!ELEMENT message-security-binding ( message-security* )>
+        <!ATTLIST message-security-binding
+                auth-layer  %message-layer; #REQUIRED
+                provider-id CDATA           #IMPLIED >
+
+        <!--
+        The message-security element describes message security requirements
+        that pertain to the request and response messages of the containing
+        endpoint, or port
+
+        When contained within a webservice-endpoint this element describes
+        the message security requirements that pertain to the request and
+        response messages of the containing endpoint. When contained within a
+        port-info of a service-ref this element describes the message security
+        requirements of the port of the referenced service.
+
+        The one or more contained message elements define the methods or operations
+        of the containing application, endpoint, or referenced service to which
+        the message security requirements apply.
+
+        Multiple message-security elements occur within a containing
+        element when it is necessary to define different message
+        security requirements for different messages within the encompassing
+        context. In such circumstances, the peer elements should not overlap
+        in the messages they pertain to. If there is any overlap in the
+        identified messages, no message security requirements apply to
+        the messages for which more than one message-security element apply.
+
+        Also, no message security requirements apply to any messages of
+        the encompassing context that are not identified by a message element.
+
+        Default:
+        Used in: webservice-endpoint, and port-info
+        -->
+        <!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+        <!--
+        The message element identifies the methods or operations to which
+        the message security requirements apply.
+
+        The identified methods or operations are methods or operations of
+        the resource identified by the context in which the message-security
+        element is defined (e.g. the the resource identified by the
+        service-qname of the containing webservice-endpoint or service-ref).
+
+        An empty message element indicates that the security requirements
+        apply to all the methods or operations of the identified resource.
+
+        When operation-name is specified, the security
+        requirements defined in the containing message-security
+        element apply to all the operations of the endpoint
+        with the specified (and potentially overloaded) operation name.
+
+        Default:
+        Used in: message-security
+        -->
+        <!ELEMENT message ( java-method? | operation-name? )>
+
+        <!--
+        The java-method element is used to identify a method (or methods
+        in the case of an overloaded method-name) of the java class
+        indicated by the context in which the java-method is contained.
+
+        Default:
+        Used in: message
+        -->
+        <!ELEMENT java-method ( method-name, method-params? )>
+
+        <!--
+        The operation-name element is used to identify the WSDL name of an
+        operation of a web service.
+
+        Default:
+        Used in: message
+        -->
+        <!ELEMENT operation-name ( #PCDATA )>
+
+        <!--
+        The request-protection element describes the authentication requirements
+        that apply to a request.
+
+        The auth-source attribute defines a requirement for message layer
+        sender authentication (e.g. username password) or content authentication
+        (e.g. digital signature).
+
+        The auth-recipient attribute defines a requirement for message
+        layer authentication of the reciever of a message to its sender (e.g. by
+        XML encryption).
+
+        The before-content attribute value indicates that recipient
+        authentication (e.g. encryption) is to occur before any
+        content authentication (e.g. encrypt then sign) with respect
+        to the target of the containing auth-policy.
+
+        An absent request-protection element is the recommended shorthand
+        for a request-protection element with unspecified values for both the
+        auth-source and auth-recipient attributes.
+
+        Default:
+        Used in: message-security
+
+         * Expected evolution to support partial message protection:
+         *
+         * request-protection ( content-auth-policy* )
+         *
+         * If the request-protection element contains one or more
+         * content-auth-policy sub-elements, they define the authentication
+         * requirements to be applied to the identified request content. If multiple
+         * content-auth-policy sub-elements are defined, a request sender must
+         * satisfy the requirements independently, and in the specified order.
+         *
+         * The content-auth-policy element would be used to associate authentication
+         * requirements with the parts of the request or response object identified
+         * by the contained method-params or part-name-list sub-elements.
+         *
+         * The content-auth-policy element would be defined as follows:
+         *
+         * content-auth-policy ( method-params | part-name-list )
+         * ATTLIST content-auth-policy
+         *         auth-source (sender | content) #IMPLIED
+         *	   auth-recipient (before-content | after-content) #IMPLIED
+         *
+         * The part-name-list and part-name elements would be defined as follows:
+         *
+         * part-name-list ( part-name* )
+         * part-name ( #PCDATA )
+         *
+        -->
+        <!ELEMENT request-protection EMPTY >
+        <!ATTLIST request-protection
+                auth-source (sender | content) #IMPLIED
+                auth-recipient (before-content | after-content) #IMPLIED>
+
+        <!--
+        The response-protection element describes the authentication requirements
+        that apply to a response.
+
+        The auth-source attribute defines a requirement for message layer
+        sender authentication (e.g. username password) or content authentication
+        (e.g. digital signature).
+
+        The auth-recipient attribute defines a requirement for message
+        layer authentication of the reciever of a message to its sender (e.g. by
+        XML encryption).
+
+        The before-content attribute value indicates that recipient
+        authentication (e.g. encryption) is to occur before any
+        content authentication (e.g. encrypt then sign) with respect
+        to the target of the containing auth-policy.
+
+        An absent response-protection element is the recommended shorthand
+        for a request-protection element with unspecified values for both the
+        auth-source and auth-recipient attributes.
+
+        Default:
+        Used in: message-security
+
+         * Expected evolution to support partial message protection:
+         *
+         * response-protection ( content-auth-policy* )
+         *
+         * see request-protection element for more details
+         *
+        -->
+        <!ELEMENT response-protection EMPTY >
+        <!ATTLIST response-protection
+                auth-source (sender | content) #IMPLIED
+                auth-recipient (before-content | after-content) #IMPLIED>
+
+        <!--
+        The method-name element contains the name of a service method of a web service
+        implementation class.
+
+        Used in: java-method
+        -->
+        <!ELEMENT method-name (#PCDATA)>
+        <!--
+        The method-params element contains a list of the fully-qualified Java
+        type names of the method parameters.
+
+        Used in: java-method
+        -->
+        <!ELEMENT method-params (method-param*)>
+
+        <!--
+        The method-param element contains the fully-qualified Java type name
+        of a method parameter.
+
+        Used in: method-params
+        -->
+        <!ELEMENT method-param (#PCDATA)>
+
+        <!--
+                                    J A V A   W E B   S T A R T    A C C E S S
+        -->
+
+        <!--
+        The java-web-start-access element contains all information relevant to Java
+        Web Start access to the app client.
+
+        Note that all elements that support Java Web Start access appear below
+        the java-web-start-access definition alphabetically by tag name.
+
+        The context-root subelement allows the developer to specify what context root
+        will be used for addressing the app client via Java Web Start.  If absent, the
+        app server uses a default context root value.
+
+        The eligible subelement allows the developer to control whether this app client
+        should allow Java Web Start access.  If this value is false, then Java Web Start
+        will never be allowed access.  Default: true.
+
+        The vendor subelement allows the developer to specify the vendor name that Java
+        Web Start should display to the end-user as the app client is downloaded and launched.
+
+        The jnlp-doc subelement gives the developer a way to direct the generation of
+        the JNLP document describing the app client launch.
+
+        Used in: payara-application-client
+        -->
+        <!ELEMENT java-web-start-access (context-root?, eligible?, vendor?, jnlp-doc?)>
+
+        <!--
+        The context-root element allows the developer to specify the context root
+        with which Java Web Start should access the app client.  The app server
+        provides a default value if the developer omits this.
+
+        Used in: java-web-start-access
+        -->
+        <!ELEMENT context-root (#PCDATA)>
+
+        <!--
+        The eligible element allows the developer to indicate whether Java Web Start
+        access should ever be permitted to launch this app client.
+
+        Used in: java-web-start-access
+        -->
+        <!ELEMENT eligible (#PCDATA)>
+
+        <!--
+        The vendor element allows the developer to indicate what vendor name Java Web Start
+        should display in the splash screen as the app client is downloaded and/or launched.
+
+        Used in: java-web-start-access
+        -->
+        <!ELEMENT vendor (#PCDATA)>
+
+        <!--
+        The jnlp-doc element's href attribute refers to a JNLP file in the app
+        client or in the EAR which is merged with the generated JNLP to create the final
+        JNLP which is used to launch the app client.  This href must be a relative
+        URI.  Note that the path may instead be specified as the text value of the
+        jnlp-doc element. Using the text value is described in the published documentation
+        so we need to allow either.  Users should not specify both; if they do results
+        are unpredictable.
+
+        Used in: java-web-start-access
+        -->
+        <!ELEMENT jnlp-doc (#PCDATA)>
+        <!ATTLIST jnlp-doc
+                href CDATA #IMPLIED>
+
+        <!--
+        The version-identifier element contains the version information. The value is
+         retrieved at deployment.
+        -->
+        <!ELEMENT version-identifier (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client_11-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client_11-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client_11-0.dtd">
+  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client_11-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client_11-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application-client_11-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application-client_11-0.dtd">
+  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client_11-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_10-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_10-0.dtd
@@ -1,0 +1,575 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+    Portions Copyright 2026 Payara Foundation and/or its affiliates
+-->
+
+<!--
+  XML DTD for Payara Application Server specific Jakarta EE Application
+  deployment descriptor. This is a companion DTD to application_10.xsd
+
+  It must include a DOCTYPE of the following form:
+
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application_10-0.dtd">
+
+-->
+
+<!--
+This is the root element of the runtime descriptor document.
+-->
+<!ELEMENT payara-application (web*, pass-by-reference?, unique-id?, security-role-mapping*, realm?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, message-destination*, archive-name?, compatibility?, keep-state?, version-identifier?, classloading-delegate?, enable-implicit-cdi?, scanning-exclude*, scanning-include*, whitelist-package*, property*) >
+
+<!ELEMENT web (web-uri, context-root)>
+<!ELEMENT web-uri (#PCDATA)>
+<!ELEMENT context-root (#PCDATA)>
+
+<!-- Pass by Reference semantics:  EJB spec requires pass by value,
+     which will be the default mode of operation. This can be set
+     to true for non-compliant and possibly higher performance.
+     For a stand-alone, this can be set at this level. By setting
+     a similarly named element at payara-application, it can apply to
+     all the enclosed ejb modules. Allowed values are true and
+     false. Default will be false.
+ -->
+<!ELEMENT pass-by-reference (#PCDATA)>
+
+<!-- Automatically generated and updated at deployment/redeployment
+     Needs to be unqiue in the system.
+  -->
+<!ELEMENT unique-id (#PCDATA)>
+
+<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)>
+
+<!ELEMENT role-name (#PCDATA)>
+<!ELEMENT principal-name (#PCDATA)>
+<!ATTLIST principal-name class-name CDATA #IMPLIED>
+<!ELEMENT group-name (#PCDATA)>
+
+<!--
+  realm: Allows specifying an optional authentication realm name which will
+    be used to process all authentication requests associated with this
+    application. If this element is not specified (or if it is given but
+    does not match the name of a configured realm) then the default realm
+    set in the server instances security-service element will be used
+    instead.
+-->
+<!ELEMENT realm (#PCDATA)>
+
+<!--
+name of a resource reference.
+-->
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!--
+resource-env-ref holds all the runtime bindings of a resource env reference.
+-->
+<!ELEMENT resource-env-ref ( resource-env-ref-name, jndi-name )>
+
+<!--
+name of a resource env reference.
+-->
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!--
+resource-ref holds the runtime bindings of a resource reference.
+-->
+<!ELEMENT resource-ref  ( res-ref-name, jndi-name,  default-resource-principal?)>
+
+<!--
+default-resource-principal specifies the default principal that the container
+will use to access a resource.
+-->
+<!ELEMENT default-resource-principal ( name,  password)>
+
+<!--
+name element holds the user name
+-->
+<!ELEMENT name (#PCDATA)>
+
+<!--
+password element holds a password string.
+-->
+<!ELEMENT password (#PCDATA)>
+
+<!--
+ejb-ref element which binds an ejb reference to a jndi name.
+-->
+<!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+
+<!--
+ejb-ref-name locates the name of the ejb reference in the application.
+-->
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!--
+jndi name of the associated entity
+-->
+<!ELEMENT  jndi-name (#PCDATA)>
+
+<!--
+This node holds information about a logical message destination
+-->
+<!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+<!--
+This node holds the name of a logical message destination
+-->
+<!ELEMENT message-destination-name (#PCDATA)>
+
+<!--
+message-destination-ref is used to directly bind a message destination reference
+to the jndi-name of a Queue,Topic, or some other physical destination. It should
+only be used when the corresponding message destination reference does not
+specify a message-destination-link to a logical message-destination.
+-->
+<!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+<!--
+name of a message-destination reference.
+-->
+<!ELEMENT message-destination-ref-name (#PCDATA)>
+
+<!--
+                        W E B   S E R V I C E S
+-->
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+<!ELEMENT service-ref ( service-ref-name, port-info*, call-property*,
+                wsdl-override?, service-impl-class?, service-qname? )>
+
+<!--
+Coded name (relative to java:comp/env) for a service-reference
+-->
+<!ELEMENT service-ref-name ( #PCDATA )>
+
+<!--
+Information for a port within a service-reference.
+
+Either service-endpoint-interface or wsdl-port or both
+(service-endpoint-interface and wsdl-port) should be specified.
+
+If both are specified, wsdl-port represents the
+port the container should choose for container-managed port selection.
+
+The same wsdl-port value must not appear in
+more than one port-info entry within the same service-ref.
+
+If a particular service-endpoint-interface is using container-managed port
+selection, it must not appear in more than one port-info entry
+within the same service-ref.
+
+The optional message-security-binding element is used to customize the
+port to provider binding; either by binding the port to a specific provider
+or by providing a definition of the message security requirements to be
+enforced by the provider.
+
+-->
+<!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+<!--
+Fully qualified name of service endpoint interface
+-->
+<!ELEMENT service-endpoint-interface ( #PCDATA )>
+<!--
+Port used in port-info.
+-->
+<!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+<!--
+JAXRPC property values that should be set on a stub before it's returned to
+to the web service client.  The property names can be any properties supported
+by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+-->
+<!ELEMENT stub-property ( name, value )>
+
+<!--
+JAXRPC property values that should be set on a Call object before it's
+returned to the web service client.  The property names can be any
+properties supported by the JAXRPC Call implementation.  See javadoc
+for javax.xml.rpc.Call
+-->
+<!ELEMENT call-property ( name, value )>
+
+<!--
+This is a valid URL pointing to a final WSDL document. It is optional.
+If specified, the WSDL document at this URL will be used during
+deployment instead of the WSDL document associated with the
+service-ref in the standard deployment descriptor.
+
+Examples :
+
+  // available via HTTP
+  <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+  // in a file
+  <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+-->
+<!ELEMENT wsdl-override ( #PCDATA )>
+
+<!--
+Name of generated service implementation class. This is not set by the
+deployer. It is derived during deployment.
+-->
+<!ELEMENT service-impl-class ( #PCDATA )>
+
+<!--
+The service-qname element declares the specific WSDL service
+element that is being refered to.  It is not set by the deployer.
+It is derived during deployment.
+-->
+<!ELEMENT service-qname (namespaceURI, localpart)>
+
+<!--
+The localpart element indicates the local part of a QNAME.
+-->
+<!ELEMENT localpart (#PCDATA)>
+
+<!--
+The namespaceURI element indicates a URI.
+-->
+<!ELEMENT namespaceURI (#PCDATA)>
+
+<!--
+This text nodes holds a value string.
+-->
+<!ELEMENT value (#PCDATA)>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-binding elements.
+
+Used in: message-security-binding
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-binding element is used to customize the
+webservice-endpoint or port to provider binding; either by binding the
+webservice-endpoint or port to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+These elements are typically NOT created as a result of the
+deployment of an application. They need only be created when the
+deployer or system administrator chooses to customize the
+webservice-endpoint or port to provider binding.
+
+The optional (repeating) message-security sub-element is used
+to accomplish the latter; in which case the specified
+message-security requirements override any defined with the
+provider.
+
+The auth-layer attribute identifies the message layer at which the
+message-security requirements are to be enforced.
+
+The optional provider-id attribute identifies the provider-config
+and thus the authentication provider that is to be used to satisfy
+the application specific message security requirements. If a value for
+the provider-id attribute is not specified, and a default
+provider is defined for the message layer, then it is used.
+if a value for the provider-id attribute is not specified, and a
+default provider is not defined at the layer, the authentication
+requirements defined in the message-security-binding are not
+enforced.
+
+Default:
+Used in: webservice-endpoint, port-info
+-->
+<!ELEMENT message-security-binding ( message-security* )>
+<!ATTLIST message-security-binding
+          auth-layer  %message-layer; #REQUIRED
+          provider-id CDATA           #IMPLIED >
+
+<!--
+The message-security element describes message security requirements
+that pertain to the request and response messages of the containing
+endpoint, or port
+
+When contained within a webservice-endpoint this element describes
+the message security requirements that pertain to the request and
+response messages of the containing endpoint. When contained within a
+port-info of a service-ref this element describes the message security
+requirements of the port of the referenced service.
+
+The one or more contained message elements define the methods or operations
+of the containing application, endpoint, or referenced service to which
+the message security requirements apply.
+
+Multiple message-security elements occur within a containing
+element when it is necessary to define different message
+security requirements for different messages within the encompassing
+context. In such circumstances, the peer elements should not overlap
+in the messages they pertain to. If there is any overlap in the
+identified messages, no message security requirements apply to
+the messages for which more than one message-security element apply.
+
+Also, no message security requirements apply to any messages of
+the encompassing context that are not identified by a message element.
+
+Default:
+Used in: webservice-endpoint, and port-info
+-->
+<!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+<!--
+The message element identifies the methods or operations to which
+the message security requirements apply.
+
+The identified methods or operations are methods or operations of
+the resource identified by the context in which the message-security
+element is defined (e.g. the the resource identified by the
+service-qname of the containing webservice-endpoint or service-ref).
+
+An empty message element indicates that the security requirements
+apply to all the methods or operations of the identified resource.
+
+When operation-name is specified, the security
+requirements defined in the containing message-security
+element apply to all the operations of the endpoint
+with the specified (and potentially overloaded) operation name.
+
+Default:
+Used in: message-security
+-->
+<!ELEMENT message ( java-method? | operation-name? )>
+
+<!--
+The java-method element is used to identify a method (or methods
+in the case of an overloaded method-name) of the java class
+indicated by the context in which the java-method is contained.
+
+Default:
+Used in: message
+-->
+<!ELEMENT java-method ( method-name, method-params? )>
+
+<!--
+The operation-name element is used to identify the WSDL name of an
+operation of a web service.
+
+Default:
+Used in: message
+-->
+<!ELEMENT operation-name ( #PCDATA )>
+
+<!--
+The request-protection element describes the authentication requirements
+that apply to a request.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent request-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default:
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * request-protection ( content-auth-policy* )
+ *
+ * If the request-protection element contains one or more
+ * content-auth-policy sub-elements, they define the authentication
+ * requirements to be applied to the identified request content. If multiple
+ * content-auth-policy sub-elements are defined, a request sender must
+ * satisfy the requirements independently, and in the specified order.
+ *
+ * The content-auth-policy element would be used to associate authentication
+ * requirements with the parts of the request or response object identified
+ * by the contained method-params or part-name-list sub-elements.
+ *
+ * The content-auth-policy element would be defined as follows:
+*
+ * content-auth-policy ( method-params | part-name-list )
+ * ATTLIST content-auth-policy
+ *         auth-source (sender | content) #IMPLIED
+ *         auth-recipient (before-content | after-content) #IMPLIED
+ *
+ * The part-name-list and part-name elements would be defined as follows:
+ *
+ * part-name-list ( part-name* )
+ * part-name ( #PCDATA )
+ *
+-->
+<!ELEMENT request-protection EMPTY >
+<!ATTLIST request-protection
+          auth-source (sender | content) #IMPLIED
+          auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The response-protection element describes the authentication requirements
+that apply to a response.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent response-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default:
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * response-protection ( content-auth-policy* )
+ *
+ * see request-protection element for more details
+ *
+-->
+<!ELEMENT response-protection EMPTY >
+<!ATTLIST response-protection
+          auth-source (sender | content) #IMPLIED
+          auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The method-name element contains the name of a service method of a web service
+implementation class.
+
+Used in: java-method
+-->
+<!ELEMENT method-name (#PCDATA)>
+<!--
+The method-params element contains a list of the fully-qualified Java
+type names of the method parameters.
+
+Used in: java-method
+-->
+<!ELEMENT method-params (method-param*)>
+
+<!--
+The method-param element contains the fully-qualified Java type name
+of a method parameter.
+
+Used in: method-params
+-->
+<!ELEMENT method-param (#PCDATA)>
+
+
+<!--
+  The value of the archive-name element will be used to derive the default
+name of the app-name when app-name is not present in application.xml.
+  The default app name will be archive-name value minus the file extension.
+For example, if archive-name is foo.ear, the default app-name will be foo.
+-->
+<!ELEMENT archive-name (#PCDATA)>
+
+<!--
+Specifies the Enterprise Server release with which to be backward compatible
+in terms of JAR visibility requirements for applications.
+The current allowed value is v2, which refers to GlassFish version 2 or
+Enterprise Server version 9.1 or 9.1.1. The Java EE 6 platform specification
+imposes stricter requirements than Java EE 5 did on which JAR files can be
+visible to various modules within an EAR file. Setting this element to v2
+removes these Java EE 6 restrictions.
+-->
+<!ELEMENT compatibility (#PCDATA)>
+
+<!--
+The keep-state element indicates whether the state information should be
+preserved across redeployment.
+-->
+<!ELEMENT keep-state (#PCDATA)>
+
+<!--
+The version-identifier element contains the version information. The value is
+ retrieved at deployment.
+-->
+<!ELEMENT version-identifier (#PCDATA)>
+
+<!--
+Payara flag to delegate classloader to parent class or not
+-->
+<!ELEMENT classloading-delegate (#PCDATA)>
+
+<!--
+Payara flag to enable / disable implicit CDI for EAR file
+-->
+<!ELEMENT enable-implicit-cdi (#PCDATA)>
+
+<!--
+Payara flag to include / exclude specific JARs for CDI scanning inside EAR files
+-->
+<!ELEMENT scanning-exclude (#PCDATA)>
+<!ELEMENT scanning-include (#PCDATA)>
+
+<!--
+Payara flag to enable / specify whitelist for extreme ClassLoader isolation
+-->
+<!ELEMENT whitelist-package (#PCDATA)>
+
+<!--
+Syntax for supplying properties as name value pairs
+-->
+<!ELEMENT property (description?)>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!ELEMENT description (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_11-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_11-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd">
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_11-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_11-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_11-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application_11-0.dtd">
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-ejb-jar_4_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-ejb-jar_4_0-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-ejb-jar_4_0-0.dtd">
+  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-ejb-jar_4_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-ejb-jar_4_0-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd">
+  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-ejb-jar_4_0-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-web-app_6_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-web-app_6_0-0.dtd
@@ -1,0 +1,871 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+    
+
+    Portions Copyright 2026 Payara Foundation and/or its affiliates
+-->
+
+<!--
+  XML DTD for Payara Application Server specific Jakarta EE web
+  deployment descriptor. This is a companion DTD to web-app_6_0.xsd
+  and web-common_6_0.xsd.
+
+  It must include a DOCTYPE of the following form:
+
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-web-app_6_0-0.dtd">
+
+-->
+
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+
+<!-- root element for vendor specific web application (module) configuration -->
+<!ELEMENT payara-web-app (context-root?, security-role-mapping*, servlet*, idempotent-url-pattern*, session-config?,
+                       ejb-ref*, resource-ref*, resource-env-ref*,  service-ref*,
+                       message-destination-ref*, cache?, class-loader?,
+                       jsp-config?, locale-charset-info?, parameter-encoding?,
+                       property*, valve*, message-destination*, webservice-description*, scanning-exclude*, scanning-include*, whitelist-package*, keep-state?, version-identifier?, container-initializer-enabled?, jaxrs-roles-allowed-enabled?)>
+<!ATTLIST payara-web-app error-url CDATA ""
+                      httpservlet-security-provider CDATA #IMPLIED>
+
+<!--
+  Idempotent URL Patterns
+    url-pattern      URL Pattern of the idempotent requests
+    num-of-retries  Specifies the number of times the Load Balancer will retry a request that is idempotent.
+-->
+<!ELEMENT idempotent-url-pattern EMPTY>
+<!ATTLIST idempotent-url-pattern url-pattern CDATA #REQUIRED
+                                 num-of-retries CDATA "-1">
+
+<!-- 
+ Context Root for the web application when the war file is a standalone module.
+ When the war module is part of the Jakarta EE Application, use the application.xml
+-->
+<!ELEMENT context-root (#PCDATA)>
+
+<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)>
+<!ELEMENT role-name (#PCDATA)>
+
+<!ELEMENT principal-name (#PCDATA)>
+<!ATTLIST principal-name class-name CDATA #IMPLIED>
+<!ELEMENT group-name (#PCDATA)>
+
+<!ELEMENT servlet (servlet-name, principal-name?, webservice-endpoint*)>
+
+<!ELEMENT session-config (session-manager?, session-properties?, cookie-properties?)>
+
+<!ENTITY % persistence-type "(memory | file | custom | ha | s1ws60 | mmap | replicated)">
+
+<!ELEMENT session-manager (manager-properties?, store-properties?)>
+<!ATTLIST session-manager persistence-type CDATA "memory">
+
+<!ELEMENT manager-properties (property*)>
+<!ELEMENT store-properties (property*)>
+<!ELEMENT session-properties (property*)>
+<!ELEMENT cookie-properties (property*)>
+
+<!ELEMENT jndi-name (#PCDATA)>
+
+<!ELEMENT resource-env-ref (resource-env-ref-name, jndi-name)>
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!ELEMENT resource-ref (res-ref-name, jndi-name, default-resource-principal?)>
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!ELEMENT default-resource-principal ( name,  password)>
+
+<!--
+This node holds information about a logical message destination
+-->
+<!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+<!--
+This node holds the name of a logical message destination
+-->
+<!ELEMENT message-destination-name (#PCDATA)>
+
+<!--
+message-destination-ref is used to directly bind a message destination reference
+to the jndi-name of a Queue,Topic, or some other physical destination. It should
+only be used when the corresponding message destination reference does not
+specify a message-destination-link to a logical message-destination.
+-->
+<!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+<!--
+name of a message-destination reference.
+-->
+<!ELEMENT message-destination-ref-name (#PCDATA)>
+
+<!--
+This text nodes holds a name string.
+-->
+<!ELEMENT name (#PCDATA)>
+
+<!--
+This element holds password text.
+-->
+<!ELEMENT password (#PCDATA)>
+
+
+<!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!ENTITY % scope "(context.attribute | request.header  | request.parameter | 
+                   request.cookie  | request.attribute | session.attribute)">
+<!ENTITY % key-scope "(context.attribute | request.header | request.parameter | 
+                       request.cookie | session.id | session.attribute)">
+<!ENTITY % expr "(equals | greater | lesser | not-equals | in-range)">
+
+<!-- cache element configures the cache for web application. iAS 7.0 web container    
+     supports one such cache object per application: i.e. <cache> is a sub element    
+     of <ias-web-app>. A cache can have zero or more cache-mapping elements and
+     zero or more customizable cache-helper classes.
+                                                                                   
+        max-entries        Maximum number of entries this cache may hold. [4096]
+        timeout-in-seconds Default timeout for the cache entries in seconds. [30]
+        enabled            Is this cache enabled? [true]
+-->
+<!ELEMENT cache (cache-helper*, default-helper?, property*, cache-mapping*)>
+<!ATTLIST cache  max-entries         CDATA     "4096"
+                 timeout-in-seconds  CDATA     "30"
+                 enabled             %boolean; "true">
+
+<!-- cache-helper specifies customizable class which implements CacheHelper interface. 
+
+     name                     Unique name for the helper class; this is referenced in
+                              the cache-mapping elements (see below).
+                              "default" is reserved for the built-in default helper.
+     class-name               Fully qualified class name of the cache-helper; this class
+                              must extend the com.sun.appserv.web.CacheHelper class.
+-->
+<!ELEMENT cache-helper (property*)>
+<!ATTLIST cache-helper name CDATA #REQUIRED
+                       class-name CDATA #REQUIRED>
+
+<!-- 
+Default, built-in cache-helper properties
+-->
+<!ELEMENT default-helper (property*)>
+
+<!-- 
+cache-mapping element defines what to be cached, the key to be used, any other   
+constraints to be applied and a customizable cache-helper to programmatically
+hook this information.
+-->
+<!ELEMENT cache-mapping ((servlet-name | url-pattern), 
+                        (cache-helper-ref |
+                        (dispatcher*, timeout?, refresh-field?, http-method*, key-field*, constraint-field*)))>
+
+<!-- 
+servlet-name element defines a named servlet to which this caching is enabled.
+the specified name must be present in the web application deployment descriptor
+(web.xml)
+-->
+<!ELEMENT servlet-name (#PCDATA)>
+
+<!-- 
+url-pattern element specifies the url pattern to which caching is to be enabled.
+See Servlet 2.3 specification section SRV. 11.2 for the applicable patterns.
+-->
+<!ELEMENT url-pattern  (#PCDATA)>
+
+<!-- 
+cache-helper-ref s a reference to the cache-helper used by this cache-mapping 
+-->
+<!ELEMENT cache-helper-ref (#PCDATA)>
+
+<!-- 
+Specifies the RequestDispatcher methods for which caching is to be
+enabled on the target resource. Valid values are REQUEST, FORWARD, INCLUDE,
+and ERROR (default: REQUEST).
+See SRV.6.2.5 of the Servlet 2.4 Specification for more information.
+-->
+<!ELEMENT dispatcher (#PCDATA)>
+
+<!-- 
+timeout element defines the cache timeout in seconds applicable for this mapping.
+default is to use cache object's timeout. The timeout value is specified statically
+ere (e.g. <timeout> 60 </timeout> or dynamically via fields in the relevant scope.
+
+   name             Name of the field where this timeout could be found
+   scope            Scope of the field. default scope is request attribute.
+-->
+<!ELEMENT timeout (#PCDATA)>
+<!ATTLIST timeout  name  CDATA  #IMPLIED
+                   scope %scope; 'request.attribute'>
+
+<!-- 
+http-method specifies HTTP method eligible for caching default is GET. 
+-->
+<!ELEMENT http-method (#PCDATA)>
+
+<!-- 
+specifies the request parameter name that triggers refresh. the cached entry 
+is refreshed when there such a request parameter is set to "true"
+example:
+<cache-mapping> 
+    <url-pattern> /quote </url-pattern> 
+    <refresh-field name="refresh" scope="request.parameter"/> 
+</cache-mapping> 
+-->
+<!ELEMENT refresh-field EMPTY>
+<!ATTLIST refresh-field name  CDATA       #REQUIRED
+                        scope %key-scope; 'request.parameter'>
+<!-- 
+key-field specifies a component of the key; container looks for the named 
+field in the given scope to access the cached entry. Default is to use
+the Servlet Path (the path section that corresponds to the servlet mapping 
+which activated this request). See Servlet 2.3 specification section SRV 4.4 
+on Servlet Path.
+
+  name             Name of the field to look for in the given scope
+  scope            Scope of the field. default scope is request parameter.
+-->
+<!ELEMENT key-field EMPTY>
+<!ATTLIST key-field name  CDATA       #REQUIRED
+                    scope %key-scope; 'request.parameter'>
+
+<!-- 
+constraint-field specifies a field whose value is used as a cacheability constraint.
+  
+  name                     Name of the field to look for in the given scope
+  scope                    Scope of the field. Default scope is request parameter.
+  cache-on-match           Should this constraint check pass, is the response cacheable?
+                           Default is true (i.e. cache the response on success match). 
+                           Useful to turn off caching when there is an attribute in the 
+                           scope (e.g. don't cache when there is an attribute called UID 
+                           in the session.attribute scope).
+  cache-on-match-failure   Should the constraint check fail, is response not cacheable?
+                           Default is false (i.e. a failure in enforcing the constraint
+                           would negate caching). Useful to turn on caching when the 
+                           an an attribute is not present (e.g. turn on caching 
+                           when there is no session or session attribute called UID).
+
+  Example 1: don't cache when there is a session attribute
+  <constraint-field name="UID" scope="session.attribute" cache-on-match="false">
+
+  Example 2: do cache only when there is no session attribute
+  <constraint-field name="UID" scope="session.attribute" 
+                    cache-on-match-failure="false">
+-->
+<!ELEMENT constraint-field (constraint-field-value*)>
+<!ATTLIST constraint-field  name                    CDATA      #REQUIRED
+                            scope                   %scope;    'request.parameter'
+                            cache-on-match          %boolean;  'true'
+                            cache-on-match-failure  %boolean;  'false'>
+
+<!-- 
+value element specifies the applicable value and a matching expression for a constraint-field
+  match-expr            Expression used to match the value. Default is 'equals'.
+
+  Example 1: cache when the category matches with any value other than a specific value
+  <constraint-field name="category" scope="request.parameter>
+    <value match-expr="equals" cache-on-match-failure="true">
+         bogus
+    </value>
+  </constraint-field>
+-->
+<!ELEMENT constraint-field-value (#PCDATA)>
+<!ATTLIST constraint-field-value 	match-expr              %expr;    'equals'
+                			cache-on-match          %boolean;  'true'
+                			cache-on-match-failure  %boolean;  'false'>
+
+<!--
+  The class-loader element allows developers to customize the behaviour
+  of their web application's classloader.
+
+  attributes
+    extra-class-path          List of comma-separated JAR files to be
+                              added to the web application's class path
+    delegate                  If set to false, the delegation behavior
+                              of the web application's classloader complies
+                              with the Servlet 2.3 specification,
+                              section 9.7.2, and gives preference to classes
+                              and resources within the WAR file or the
+                              extra-class-path over those higher up in the
+                              classloader hierarchy, unless those classes or
+                              resources are part of the Jakarta EE platform.
+                              If set to its default value of true, classes
+                              and resources residing in container-wide library
+                              JAR files are loaded in preference to classes
+                              and resources packaged within the WAR file or
+                              specified on the extra-class-path.
+    dynamic-reload-interval   Not supported. Included for backward
+                              compatibility with previous Sun Java System
+                              Web Server versions
+-->
+<!ELEMENT class-loader (property*)>
+<!ATTLIST class-loader extra-class-path CDATA  #IMPLIED
+                       delegate %boolean; 'true'
+                       dynamic-reload-interval CDATA #IMPLIED >
+
+<!ELEMENT jsp-config (property*)>
+
+<!ELEMENT locale-charset-info (locale-charset-map+, parameter-encoding?)>
+<!ATTLIST locale-charset-info default-locale CDATA #IMPLIED>
+
+<!ELEMENT locale-charset-map (description?)>
+<!ATTLIST locale-charset-map locale  CDATA  #REQUIRED
+                             agent   CDATA  #IMPLIED
+                             charset CDATA  #REQUIRED>
+
+<!ELEMENT parameter-encoding EMPTY>
+<!ATTLIST parameter-encoding form-hint-field CDATA #IMPLIED
+			     default-charset CDATA #IMPLIED>
+
+<!-- 
+Syntax for supplying properties as name value pairs 
+-->
+<!ELEMENT property (description?)>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!--
+This text nodes holds a value string.
+-->
+<!ELEMENT value (#PCDATA)>
+
+<!ELEMENT valve (description?, property*)>
+<!ATTLIST valve name        CDATA  #REQUIRED
+                class-name  CDATA  #REQUIRED>
+
+<!--
+  					W E B   S E R V I C E S 
+-->
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+<!ELEMENT service-ref ( service-ref-name, port-info*, call-property*, wsdl-override?, service-impl-class?, service-qname? )>
+
+<!--
+Coded name (relative to java:comp/env) for a service-reference
+-->
+<!ELEMENT service-ref-name ( #PCDATA )>
+
+<!-- 
+Information for a port within a service-reference.
+
+Either service-endpoint-interface or wsdl-port or both
+(service-endpoint-interface and wsdl-port) should be specified.  
+
+If both are specified, wsdl-port represents the
+port the container should choose for container-managed port selection.
+
+The same wsdl-port value must not appear in
+more than one port-info entry within the same service-ref.
+
+If a particular service-endpoint-interface is using container-managed port
+selection, it must not appear in more than one port-info entry
+within the same service-ref.
+
+The optional message-security-binding element is used to customize the
+port to provider binding; either by binding the port to a specific provider
+or by providing a definition of the message security requirements to be
+enforced by the provider.
+
+-->
+<!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+<!--
+Fully qualified name of service endpoint interface
+-->
+<!ELEMENT service-endpoint-interface ( #PCDATA )>
+<!-- 
+Port used in port-info.  
+-->
+<!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+<!-- 
+JAXRPC property values that should be set on a stub before it's returned to 
+to the web service client.  The property names can be any properties supported
+by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+-->
+<!ELEMENT stub-property ( name, value )>
+
+<!-- 
+JAXRPC property values that should be set on a Call object before it's 
+returned to the web service client.  The property names can be any 
+properties supported by the JAXRPC Call implementation.  See javadoc
+for javax.xml.rpc.Call
+-->
+<!ELEMENT call-property ( name, value )>
+
+<!--
+This is a valid URL pointing to a final WSDL document. It is optional.
+If specified, the WSDL document at this URL will be used during
+deployment instead of the WSDL document associated with the
+service-ref in the standard deployment descriptor.
+
+Examples :
+
+  // available via HTTP
+  <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+  // in a file
+  <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+-->
+<!ELEMENT wsdl-override ( #PCDATA )>
+
+<!--
+Name of generated service implementation class. This is not set by the 
+deployer. It is derived during deployment.
+-->
+<!ELEMENT service-impl-class ( #PCDATA )>
+
+<!-- 
+The service-qname element declares the specific WSDL service
+element that is being refered to.  It is not set by the deployer.
+It is derived during deployment.
+-->
+<!ELEMENT service-qname (namespaceURI, localpart)>
+
+<!-- 
+Runtime information about a web service.  
+
+wsdl-publish-location is optionally used to specify 
+where the final wsdl and any dependent files should be stored.  This location
+resides on the file system from which deployment is initiated.
+
+-->
+<!ELEMENT webservice-description ( webservice-description-name, wsdl-publish-location? )>
+
+<!--
+Unique name of a webservice within a module
+-->
+<!ELEMENT webservice-description-name ( #PCDATA )>
+
+<!--
+file: URL of a directory to which a web-service-description's wsdl should be
+published during deployment.  Any required files will be published to this
+directory, preserving their location relative to the module-specific
+wsdl directory(META-INF/wsdl or WEB-INF/wsdl).
+
+Example :
+
+  For an ejb.jar whose webservices.xml wsdl-file element contains
+    META-INF/wsdl/a/Foo.wsdl 
+
+  <wsdl-publish-location>file:/home/user1/publish
+  </wsdl-publish-location>
+
+  The final wsdl will be stored in /home/user1/publish/a/Foo.wsdl
+
+-->
+<!ELEMENT wsdl-publish-location ( #PCDATA )>
+
+<!--
+Information about a web service endpoint.  
+
+The optional message-security-binding element is used to customize the
+webservice-endpoint to provider binding; either by binding the
+webservice-endpoint to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+When login-config is specified, a default message-security provider
+is not applied to the endpoint.
+-->
+<!ELEMENT webservice-endpoint ( port-component-name, endpoint-address-uri?, (login-config | message-security-binding)?, transport-guarantee?, service-qname?, tie-class?, servlet-impl-class?, debugging-enabled? )>
+
+<!--
+Unique name of a port component within a module
+-->
+<!ELEMENT port-component-name ( #PCDATA )>
+
+<!--
+Relative path combined with web server root to form fully qualified
+endpoint address for a web service endpoint.  For servlet endpoints, this
+value is relative to the servlet's web application context root.  In
+all cases, this value must be a fixed pattern(i.e. no "*" allowed).
+If the web service endpoint is a servlet that only implements a single
+endpoint has only one url-pattern, it is not necessary to set 
+this value since the container can derive it from web.xml.
+-->
+<!ELEMENT endpoint-address-uri ( #PCDATA )>
+
+<!--
+The name of tie implementation class for a port-component.  This is
+not specified by the deployer.  It is derived during deployment.
+-->
+<!ELEMENT tie-class (#PCDATA)>
+
+<!-- 
+Optional authentication configuration for an EJB web service endpoint.
+Not needed for servet web service endpoints.  Their security configuration
+is contained in the standard web application descriptor.
+-->
+<!ELEMENT login-config ( auth-method )>
+
+<!--
+The auth-method element is used to configure the authentication
+mechanism for the web application. As a prerequisite to gaining access
+to any web resources which are protected by an authorization
+constraint, a user must have authenticated using the configured
+mechanism.
+-->
+
+<!ELEMENT auth-method (#PCDATA)>
+
+<!--
+Name of application-written servlet impl class contained in deployed war.
+This is not set by the deployer.  It is derived by the container
+during deployment.
+-->
+<!ELEMENT servlet-impl-class (#PCDATA)>
+
+<!--
+Specify whether or not the debugging servlet should be enabled for this 
+Web Service endpoint. 
+
+Supported values : "true" to debug the endpoint
+-->
+<!ELEMENT debugging-enabled (#PCDATA)>
+
+<!--
+The transport-guarantee element specifies that the communication
+between client and server should be NONE, INTEGRAL, or
+CONFIDENTIAL. NONE means that the application does not require any
+transport guarantees. A value of INTEGRAL means that the application
+requires that the data sent between the client and server be sent in
+such a way that it can't be changed in transit. CONFIDENTIAL means
+that the application requires that the data be transmitted in a
+fashion that prevents other entities from observing the contents of
+the transmission. In most cases, the presence of the INTEGRAL or
+CONFIDENTIAL flag will indicate that the use of SSL is required.
+-->
+
+<!ELEMENT transport-guarantee (#PCDATA)>
+
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+
+<!--
+The localpart element indicates the local part of a QNAME.
+-->
+<!ELEMENT localpart (#PCDATA)>
+
+<!--
+The namespaceURI element indicates a URI.
+-->
+<!ELEMENT namespaceURI (#PCDATA)>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-binding elements.
+
+Used in: message-security-binding
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-binding element is used to customize the
+webservice-endpoint or port to provider binding; either by binding the
+webservice-endpoint or port to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+These elements are typically NOT created as a result of the
+deployment of an application. They need only be created when the
+deployer or system administrator chooses to customize the 
+webservice-endpoint or port to provider binding.
+
+The optional (repeating) message-security sub-element is used 
+to accomplish the latter; in which case the specified 
+message-security requirements override any defined with the
+provider.
+
+The auth-layer attribute identifies the message layer at which the
+message-security requirements are to be enforced.
+
+The optional provider-id attribute identifies the provider-config 
+and thus the authentication provider that is to be used to satisfy 
+the application specific message security requirements. If a value for 
+the provider-id attribute is not specified, and a default
+provider is defined for the message layer, then it is used. 
+if a value for the provider-id attribute is not specified, and a
+default provider is not defined at the layer, the authentication
+requirements defined in the message-security-binding are not
+enforced. 
+ 
+Default:
+Used in: webservice-endpoint, port-info
+-->
+<!ELEMENT message-security-binding ( message-security* )>
+<!ATTLIST message-security-binding
+          auth-layer  %message-layer; #REQUIRED
+          provider-id CDATA           #IMPLIED >
+
+<!--
+The message-security element describes message security requirements
+that pertain to the request and response messages of the containing 
+endpoint, or port
+
+When contained within a webservice-endpoint this element describes 
+the message security requirements that pertain to the request and 
+response messages of the containing endpoint. When contained within a 
+port-info of a service-ref this element describes the message security
+requirements of the port of the referenced service.
+
+The one or more contained message elements define the methods or operations
+of the containing application, endpoint, or referenced service to which 
+the message security requirements apply.
+
+Multiple message-security elements occur within a containing
+element when it is necessary to define different message
+security requirements for different messages within the encompassing
+context. In such circumstances, the peer elements should not overlap
+in the messages they pertain to. If there is any overlap in the
+identified messages, no message security requirements apply to
+the messages for which more than one message-security element apply.
+
+Also, no message security requirements apply to any messages of
+the encompassing context that are not identified by a message element. 
+ 
+Default:
+Used in: webservice-endpoint, and port-info
+-->
+<!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+<!--
+The message element identifies the methods or operations to which
+the message security requirements apply.
+
+The identified methods or operations are methods or operations of
+the resource identified by the context in which the message-security
+element is defined (e.g. the the resource identified by the
+service-qname of the containing webservice-endpoint or service-ref).
+
+An empty message element indicates that the security requirements
+apply to all the methods or operations of the identified resource.
+
+When operation-name is specified, the security
+requirements defined in the containing message-security 
+element apply to all the operations of the endpoint 
+with the specified (and potentially overloaded) operation name.
+
+Default: 
+Used in: message-security
+-->
+<!ELEMENT message ( java-method? | operation-name? )>
+
+<!--
+The java-method element is used to identify a method (or methods
+in the case of an overloaded method-name) of the java class 
+indicated by the context in which the java-method is contained.
+
+Default: 
+Used in: message
+-->
+<!ELEMENT java-method ( method-name, method-params? )>
+
+<!--
+The operation-name element is used to identify the WSDL name of an
+operation of a web service.
+
+Default: 
+Used in: message
+-->
+<!ELEMENT operation-name ( #PCDATA )>
+
+<!--
+The request-protection element describes the authentication requirements
+that apply to a request.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent request-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default: 
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * request-protection ( content-auth-policy* )
+ *
+ * If the request-protection element contains one or more
+ * content-auth-policy sub-elements, they define the authentication
+ * requirements to be applied to the identified request content. If multiple
+ * content-auth-policy sub-elements are defined, a request sender must
+ * satisfy the requirements independently, and in the specified order.  
+ *
+ * The content-auth-policy element would be used to associate authentication
+ * requirements with the parts of the request or response object identified
+ * by the contained method-params or part-name-list sub-elements.
+ *
+ * The content-auth-policy element would be defined as follows:
+ * 
+ * content-auth-policy ( method-params | part-name-list )
+ * ATTLIST content-auth-policy 
+ *         auth-source (sender | content) #IMPLIED
+ *	   auth-recipient (before-content | after-content) #IMPLIED
+ * 
+ * The part-name-list and part-name elements would be defined as follows:
+ *
+ * part-name-list ( part-name* )
+ * part-name ( #PCDATA )
+ *
+-->
+<!ELEMENT request-protection EMPTY >
+<!ATTLIST request-protection
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The response-protection element describes the authentication requirements
+that apply to a response.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent response-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default: 
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * response-protection ( content-auth-policy* )
+ *
+ * see request-protection element for more details
+ *
+-->
+<!ELEMENT response-protection EMPTY >
+<!ATTLIST response-protection
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The method-name element contains the name of a service method of a web service
+implementation class.
+
+Used in: java-method
+-->
+<!ELEMENT method-name (#PCDATA)>
+<!--
+The method-params element contains a list of the fully-qualified Java
+type names of the method parameters.
+
+Used in: java-method
+-->
+<!ELEMENT method-params (method-param*)>
+
+<!--
+The method-param element contains the fully-qualified Java type name
+of a method parameter.
+
+Used in: method-params
+-->
+<!ELEMENT method-param (#PCDATA)>
+
+<!--
+Payara flag to include / exclude specific JARs for CDI scanning inside EAR files
+-->
+<!ELEMENT scanning-exclude (#PCDATA)>
+<!ELEMENT scanning-include (#PCDATA)>
+
+<!--
+Payara flag to enable / specify whitelist for extreme ClassLoader isolation
+-->
+<!ELEMENT whitelist-package (#PCDATA)>
+
+<!--
+Payara element to ignore the default support for the RolesAllowed annotation on JAX-RS resources.
+When this is disabled, RolesAllowed can still be activated by other means, e.g. by the Jersey
+specific method. 
+-->
+<!ELEMENT jaxrs-roles-allowed-enabled (#PCDATA)>
+
+<!--
+The keep-state element indicates whether the state information should be
+preserved across redeployment.
+-->
+<!ELEMENT keep-state (#PCDATA)>
+
+<!--
+The version-identifier element contains the version information. The value is
+ retrieved at deployment.
+-->
+<!ELEMENT version-identifier (#PCDATA)>
+
+<!--
+Payara element to ignore servlet initializers
+-->
+<!ELEMENT container-initializer-enabled (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-web-app_6_1-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-web-app_6_1-0.dtd
@@ -49,7 +49,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_6_1-0.dtd">
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-web-app_6_1-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-web-app_6_1-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-web-app_6_1-0.dtd
@@ -49,7 +49,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-web-app_6_1-0.dtd">
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-web-app_6_1-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client-container_1_4-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client-container_1_4-0.dtd
@@ -1,0 +1,291 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<!--  Portions Copyright 2022-2026 Payara Foundation and/or its affiliates -->
+
+
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+<!ENTITY % severity "(FINEST|FINER|FINE|CONFIG|INFO|WARNING|SEVERE|ALERT|FATAL)">
+
+<!-- Payara Application client container configuration
+    send-password   Specifies whether client authentication credentials should 
+                    be sent to the server. Without credential all accesses to 
+                    protected EJBs will result in exceptions.
+   message-security-config: Optional list of layer specific lists of
+     configured message security providers.
+-->
+<!ELEMENT client-container (target-server+, auth-realm?, client-credential?, log-service?, message-security-config*, property*)>
+<!ATTLIST client-container send-password %boolean; "true"> 
+
+<!-- Target server's IIOP listener configuration 
+    name        Application server instance name 
+    address     ip address or hostname (resolvable by DNS) of the ORB
+    port        port number of the ORB
+-->
+<!ELEMENT target-server (description?, security?)>
+<!ATTLIST target-server name             CDATA     #REQUIRED
+                        address          CDATA     #REQUIRED
+                        port             CDATA     #REQUIRED>
+                                                  
+<!ELEMENT description (#PCDATA)>
+
+<!-- Default client credentials that will be sent to server. If this element 
+     is present, then it will be automatically sent to the server, without
+     prompting the user for usename and password on the client side. 
+     user-name  User name credential   
+     password   Password credential
+     realm      The realm (specified by name) where credentials are to be 
+                resolved.
+ -->
+<!ELEMENT client-credential (property*)>
+<!ATTLIST client-credential user-name CDATA   #REQUIRED
+                            password  CDATA   #REQUIRED
+                            realm     CDATA   #IMPLIED>
+                                
+<!-- Logging service configuration. 
+
+     file   By default log file will be at $APPCLIENT_ROOT/logs/client.log
+            Can use this attribute to specify an alternate location.
+     level  sets the base level of severity. Messages at or above this 
+            setting get logged into the log file.
+ -->
+<!ELEMENT log-service (property*)>
+<!ATTLIST log-service  file                      CDATA      #IMPLIED
+                       level                     %severity; "SEVERE">
+
+<!-- SSL security  configuration for IIOP/SSL communication with 
+     the target-server.
+ -->
+<!ELEMENT security (ssl, cert-db)>
+
+<!-- Define SSL processing parameters
+
+     cert-nickname nickname of the server certificate in the certificate database 
+                   or the PKCS#11 token. In the certificate, the name format is
+                   tokenname:nickname. Including the tokenname: part of the name 
+                   in this attribute is optional.
+
+    ssl3-tls-ciphers (optional) A space-separated list of the SSL3 ciphers used, with
+                     the prefix + to enable or - to disable, for example
+                     +SSL_RSA_WITH_RC4_128_MD5.
+                     Allowed SSL3/TLS values are SSL_RSA_WITH_RC4_128_MD5,
+                     SSL_RSA_WITH_3DES_EDE_CBC_SHA, SSL_RSA_WITH_DES_CBC_SHA,
+                     SSL_RSA_EXPORT_WITH_RC4_40_MD5, SSL_RSA_WITH_NULL_MD5,
+                     SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_NULL_SHA
+
+    tls-rollback-enabled  (optional) Determines whether TLS rollback is enabled. TLS 
+                          rollback should be enabled for Microsoft Internet Explorer 
+                          5.0 and 5.5. 
+
+    client-auth-enabled   (optional) Determines whether client authentication is
+                          performed on every request, independent of ACL-based access 
+                          control.
+--> 
+<!ELEMENT ssl EMPTY>
+<!ATTLIST ssl cert-nickname        CDATA    #IMPLIED
+              ssl3-tls-ciphers     CDATA    #IMPLIED
+              tls-rollback-enabled CDATA    "true">
+
+<!-- Location and password to read the Certificate Database. iAS
+     (actually NSS) will provide utilities with which a certificate 
+     database can be created.
+
+     path     Specifies the absolute path where the cert database (cert7.db) 
+              is stored. 
+     password needed to open and read a cert database
+ -->
+<!ELEMENT cert-db EMPTY>
+<!ATTLIST cert-db path       CDATA #REQUIRED
+                  password   CDATA #REQUIRED>
+
+<!-- JAAS is available on Application Client Container. 
+     Optional configuration for JAAS authentication realm.
+     
+     name       defines the name of this realm
+     classname  defines the java class which implements this realm
+ -->
+<!ELEMENT auth-realm (property*)>
+<!ATTLIST auth-realm name            CDATA   #REQUIRED
+                     classname       CDATA   #REQUIRED>
+               
+<!-- Syntax for supplying properties as name value pairs -->
+<!ELEMENT property EMPTY>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-config elements.
+
+Used in: message-security-config
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-config element defines the message layer
+specific provider configurations of the application server.
+
+All of the providers within a message-security-config element
+must be able to perform authentication processing at
+the message layer defined by the value of the auth-layer 
+attribute. 
+
+The default-provider attribute may be used to identify 
+the server provider to be invoked for any application 
+for which a specific server provider has not been bound.
+
+The default-client-provider attribute may be used to identify 
+the client provider to be invoked for any application 
+for which a specific client provider has not been bound.
+
+At most one (non-null) default server provider and at most one
+(non-null) default client provider may be identified 
+among all the same layer message-security-config elements. 
+
+When a default provider of a type is not defined for a message 
+layer, the container will only invoke a provider of the type
+(at the layer) for those applications for which a specific
+provider has been bound.
+
+Default: 
+Used in: security-service
+-->
+<!ELEMENT message-security-config ( provider-config+ )>
+<!ATTLIST message-security-config 
+          auth-layer %message-layer; #REQUIRED
+	  default-provider        CDATA #IMPLIED
+	  default-client-provider CDATA #IMPLIED>
+
+<!--
+The provider-config element defines the configuration of
+an authentication provider.
+
+The provider-id attibute contains an identifier that can be used to
+reference the provider-config.
+
+The request-policy and response-policy sub-elements define
+the authentication policy requirements associated 
+with the request and response processing performed by the
+authentication provider (respectively).
+
+the provider-type attribute defines whether the provider is a client
+authentication provider or a server authentication provider.
+
+The class-name attribute defines the java implementation class of the 
+provider. Client authentication providers must implement the 
+com.sun.enterprise.security.jauth.ClientAuthModule interface. Server-side
+providers must implement the com.sun.enterprise.security.jauth.ServerAuthModule
+interface. A provider may implement both interfaces, but it must implement
+the interface corresponding to its provider type.
+
+The optional list of property elements may be used to configure provider
+specific property values. These values will be passed to the provider
+when its initialize method is called.
+
+A provider-config with no contained request-policy or response-policy
+sub-elements, is a null provider. The container will not instantiate
+or invoke the methods of a null provider, and as such the implementation
+class of a null provider need not exist.
+
+Default: 
+Used in: message-security-config
+-->
+<!ELEMENT provider-config ( request-policy?, response-policy?, property* )>
+<!ATTLIST provider-config
+          provider-id CDATA                   #REQUIRED
+	  provider-type  (client | server | client-server) #REQUIRED
+          class-name      CDATA            #REQUIRED>
+
+<!--
+The request-policy element is used to define the authentication policy 
+requirements associated with the request processing performed by an 
+authentication provider (i.e. when a client provider's 
+ClientAuthModule.initiateRequest method is called or when a
+server provider's ServerAuthModule.validateRequest is called).
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+Default: 
+Used in: provider-config
+-->
+<!ELEMENT request-policy EMPTY >
+<!ATTLIST request-policy 
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+<!--
+The response-policy element is used to define the authentication policy 
+requirements associated with the response processing performed by an 
+authentication provider (i.e. when a client provider's 
+ClientAuthModule.validateResponse method is called or when a
+server provider's ServerAuthModule.secureResponse method is called).
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+Default: 
+Used in: provider-config
+-->
+<!ELEMENT response-policy EMPTY >
+<!ATTLIST response-policy 
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client_10-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client_10-0.dtd
@@ -47,7 +47,7 @@
 
           It must include a DOCTYPE of the following form:
 
-          <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application-client_10-0.dtd">
+          <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client_10-0.dtd">
 
         -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client_10-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application-client_10-0.dtd
@@ -47,7 +47,7 @@
 
           It must include a DOCTYPE of the following form:
 
-          <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application-client_10-0.dtd">
+          <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application-client_10-0.dtd">
 
         -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application_10-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application_10-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application_10-0.dtd">
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application_10-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application_10-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application_10-0.dtd
@@ -1,0 +1,575 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+    Portions Copyright 2026 Payara Foundation and/or its affiliates
+-->
+
+<!--
+  XML DTD for Payara Application Server specific Jakarta EE Application
+  deployment descriptor. This is a companion DTD to application_10.xsd
+
+  It must include a DOCTYPE of the following form:
+
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application_10-0.dtd">
+
+-->
+
+<!--
+This is the root element of the runtime descriptor document.
+-->
+<!ELEMENT payara-application (web*, pass-by-reference?, unique-id?, security-role-mapping*, realm?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, message-destination*, archive-name?, compatibility?, keep-state?, version-identifier?, classloading-delegate?, enable-implicit-cdi?, scanning-exclude*, scanning-include*, whitelist-package*, property*) >
+
+<!ELEMENT web (web-uri, context-root)>
+<!ELEMENT web-uri (#PCDATA)>
+<!ELEMENT context-root (#PCDATA)>
+
+<!-- Pass by Reference semantics:  EJB spec requires pass by value,
+     which will be the default mode of operation. This can be set
+     to true for non-compliant and possibly higher performance.
+     For a stand-alone, this can be set at this level. By setting
+     a similarly named element at payara-application, it can apply to
+     all the enclosed ejb modules. Allowed values are true and
+     false. Default will be false.
+ -->
+<!ELEMENT pass-by-reference (#PCDATA)>
+
+<!-- Automatically generated and updated at deployment/redeployment
+     Needs to be unqiue in the system.
+  -->
+<!ELEMENT unique-id (#PCDATA)>
+
+<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)>
+
+<!ELEMENT role-name (#PCDATA)>
+<!ELEMENT principal-name (#PCDATA)>
+<!ATTLIST principal-name class-name CDATA #IMPLIED>
+<!ELEMENT group-name (#PCDATA)>
+
+<!--
+  realm: Allows specifying an optional authentication realm name which will
+    be used to process all authentication requests associated with this
+    application. If this element is not specified (or if it is given but
+    does not match the name of a configured realm) then the default realm
+    set in the server instances security-service element will be used
+    instead.
+-->
+<!ELEMENT realm (#PCDATA)>
+
+<!--
+name of a resource reference.
+-->
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!--
+resource-env-ref holds all the runtime bindings of a resource env reference.
+-->
+<!ELEMENT resource-env-ref ( resource-env-ref-name, jndi-name )>
+
+<!--
+name of a resource env reference.
+-->
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!--
+resource-ref holds the runtime bindings of a resource reference.
+-->
+<!ELEMENT resource-ref  ( res-ref-name, jndi-name,  default-resource-principal?)>
+
+<!--
+default-resource-principal specifies the default principal that the container
+will use to access a resource.
+-->
+<!ELEMENT default-resource-principal ( name,  password)>
+
+<!--
+name element holds the user name
+-->
+<!ELEMENT name (#PCDATA)>
+
+<!--
+password element holds a password string.
+-->
+<!ELEMENT password (#PCDATA)>
+
+<!--
+ejb-ref element which binds an ejb reference to a jndi name.
+-->
+<!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+
+<!--
+ejb-ref-name locates the name of the ejb reference in the application.
+-->
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!--
+jndi name of the associated entity
+-->
+<!ELEMENT  jndi-name (#PCDATA)>
+
+<!--
+This node holds information about a logical message destination
+-->
+<!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+<!--
+This node holds the name of a logical message destination
+-->
+<!ELEMENT message-destination-name (#PCDATA)>
+
+<!--
+message-destination-ref is used to directly bind a message destination reference
+to the jndi-name of a Queue,Topic, or some other physical destination. It should
+only be used when the corresponding message destination reference does not
+specify a message-destination-link to a logical message-destination.
+-->
+<!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+<!--
+name of a message-destination reference.
+-->
+<!ELEMENT message-destination-ref-name (#PCDATA)>
+
+<!--
+                        W E B   S E R V I C E S
+-->
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+<!ELEMENT service-ref ( service-ref-name, port-info*, call-property*,
+                wsdl-override?, service-impl-class?, service-qname? )>
+
+<!--
+Coded name (relative to java:comp/env) for a service-reference
+-->
+<!ELEMENT service-ref-name ( #PCDATA )>
+
+<!--
+Information for a port within a service-reference.
+
+Either service-endpoint-interface or wsdl-port or both
+(service-endpoint-interface and wsdl-port) should be specified.
+
+If both are specified, wsdl-port represents the
+port the container should choose for container-managed port selection.
+
+The same wsdl-port value must not appear in
+more than one port-info entry within the same service-ref.
+
+If a particular service-endpoint-interface is using container-managed port
+selection, it must not appear in more than one port-info entry
+within the same service-ref.
+
+The optional message-security-binding element is used to customize the
+port to provider binding; either by binding the port to a specific provider
+or by providing a definition of the message security requirements to be
+enforced by the provider.
+
+-->
+<!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+<!--
+Fully qualified name of service endpoint interface
+-->
+<!ELEMENT service-endpoint-interface ( #PCDATA )>
+<!--
+Port used in port-info.
+-->
+<!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+<!--
+JAXRPC property values that should be set on a stub before it's returned to
+to the web service client.  The property names can be any properties supported
+by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+-->
+<!ELEMENT stub-property ( name, value )>
+
+<!--
+JAXRPC property values that should be set on a Call object before it's
+returned to the web service client.  The property names can be any
+properties supported by the JAXRPC Call implementation.  See javadoc
+for javax.xml.rpc.Call
+-->
+<!ELEMENT call-property ( name, value )>
+
+<!--
+This is a valid URL pointing to a final WSDL document. It is optional.
+If specified, the WSDL document at this URL will be used during
+deployment instead of the WSDL document associated with the
+service-ref in the standard deployment descriptor.
+
+Examples :
+
+  // available via HTTP
+  <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+  // in a file
+  <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+-->
+<!ELEMENT wsdl-override ( #PCDATA )>
+
+<!--
+Name of generated service implementation class. This is not set by the
+deployer. It is derived during deployment.
+-->
+<!ELEMENT service-impl-class ( #PCDATA )>
+
+<!--
+The service-qname element declares the specific WSDL service
+element that is being refered to.  It is not set by the deployer.
+It is derived during deployment.
+-->
+<!ELEMENT service-qname (namespaceURI, localpart)>
+
+<!--
+The localpart element indicates the local part of a QNAME.
+-->
+<!ELEMENT localpart (#PCDATA)>
+
+<!--
+The namespaceURI element indicates a URI.
+-->
+<!ELEMENT namespaceURI (#PCDATA)>
+
+<!--
+This text nodes holds a value string.
+-->
+<!ELEMENT value (#PCDATA)>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-binding elements.
+
+Used in: message-security-binding
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-binding element is used to customize the
+webservice-endpoint or port to provider binding; either by binding the
+webservice-endpoint or port to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+These elements are typically NOT created as a result of the
+deployment of an application. They need only be created when the
+deployer or system administrator chooses to customize the
+webservice-endpoint or port to provider binding.
+
+The optional (repeating) message-security sub-element is used
+to accomplish the latter; in which case the specified
+message-security requirements override any defined with the
+provider.
+
+The auth-layer attribute identifies the message layer at which the
+message-security requirements are to be enforced.
+
+The optional provider-id attribute identifies the provider-config
+and thus the authentication provider that is to be used to satisfy
+the application specific message security requirements. If a value for
+the provider-id attribute is not specified, and a default
+provider is defined for the message layer, then it is used.
+if a value for the provider-id attribute is not specified, and a
+default provider is not defined at the layer, the authentication
+requirements defined in the message-security-binding are not
+enforced.
+
+Default:
+Used in: webservice-endpoint, port-info
+-->
+<!ELEMENT message-security-binding ( message-security* )>
+<!ATTLIST message-security-binding
+          auth-layer  %message-layer; #REQUIRED
+          provider-id CDATA           #IMPLIED >
+
+<!--
+The message-security element describes message security requirements
+that pertain to the request and response messages of the containing
+endpoint, or port
+
+When contained within a webservice-endpoint this element describes
+the message security requirements that pertain to the request and
+response messages of the containing endpoint. When contained within a
+port-info of a service-ref this element describes the message security
+requirements of the port of the referenced service.
+
+The one or more contained message elements define the methods or operations
+of the containing application, endpoint, or referenced service to which
+the message security requirements apply.
+
+Multiple message-security elements occur within a containing
+element when it is necessary to define different message
+security requirements for different messages within the encompassing
+context. In such circumstances, the peer elements should not overlap
+in the messages they pertain to. If there is any overlap in the
+identified messages, no message security requirements apply to
+the messages for which more than one message-security element apply.
+
+Also, no message security requirements apply to any messages of
+the encompassing context that are not identified by a message element.
+
+Default:
+Used in: webservice-endpoint, and port-info
+-->
+<!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+<!--
+The message element identifies the methods or operations to which
+the message security requirements apply.
+
+The identified methods or operations are methods or operations of
+the resource identified by the context in which the message-security
+element is defined (e.g. the the resource identified by the
+service-qname of the containing webservice-endpoint or service-ref).
+
+An empty message element indicates that the security requirements
+apply to all the methods or operations of the identified resource.
+
+When operation-name is specified, the security
+requirements defined in the containing message-security
+element apply to all the operations of the endpoint
+with the specified (and potentially overloaded) operation name.
+
+Default:
+Used in: message-security
+-->
+<!ELEMENT message ( java-method? | operation-name? )>
+
+<!--
+The java-method element is used to identify a method (or methods
+in the case of an overloaded method-name) of the java class
+indicated by the context in which the java-method is contained.
+
+Default:
+Used in: message
+-->
+<!ELEMENT java-method ( method-name, method-params? )>
+
+<!--
+The operation-name element is used to identify the WSDL name of an
+operation of a web service.
+
+Default:
+Used in: message
+-->
+<!ELEMENT operation-name ( #PCDATA )>
+
+<!--
+The request-protection element describes the authentication requirements
+that apply to a request.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent request-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default:
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * request-protection ( content-auth-policy* )
+ *
+ * If the request-protection element contains one or more
+ * content-auth-policy sub-elements, they define the authentication
+ * requirements to be applied to the identified request content. If multiple
+ * content-auth-policy sub-elements are defined, a request sender must
+ * satisfy the requirements independently, and in the specified order.
+ *
+ * The content-auth-policy element would be used to associate authentication
+ * requirements with the parts of the request or response object identified
+ * by the contained method-params or part-name-list sub-elements.
+ *
+ * The content-auth-policy element would be defined as follows:
+*
+ * content-auth-policy ( method-params | part-name-list )
+ * ATTLIST content-auth-policy
+ *         auth-source (sender | content) #IMPLIED
+ *         auth-recipient (before-content | after-content) #IMPLIED
+ *
+ * The part-name-list and part-name elements would be defined as follows:
+ *
+ * part-name-list ( part-name* )
+ * part-name ( #PCDATA )
+ *
+-->
+<!ELEMENT request-protection EMPTY >
+<!ATTLIST request-protection
+          auth-source (sender | content) #IMPLIED
+          auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The response-protection element describes the authentication requirements
+that apply to a response.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent response-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default:
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * response-protection ( content-auth-policy* )
+ *
+ * see request-protection element for more details
+ *
+-->
+<!ELEMENT response-protection EMPTY >
+<!ATTLIST response-protection
+          auth-source (sender | content) #IMPLIED
+          auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The method-name element contains the name of a service method of a web service
+implementation class.
+
+Used in: java-method
+-->
+<!ELEMENT method-name (#PCDATA)>
+<!--
+The method-params element contains a list of the fully-qualified Java
+type names of the method parameters.
+
+Used in: java-method
+-->
+<!ELEMENT method-params (method-param*)>
+
+<!--
+The method-param element contains the fully-qualified Java type name
+of a method parameter.
+
+Used in: method-params
+-->
+<!ELEMENT method-param (#PCDATA)>
+
+
+<!--
+  The value of the archive-name element will be used to derive the default
+name of the app-name when app-name is not present in application.xml.
+  The default app name will be archive-name value minus the file extension.
+For example, if archive-name is foo.ear, the default app-name will be foo.
+-->
+<!ELEMENT archive-name (#PCDATA)>
+
+<!--
+Specifies the Enterprise Server release with which to be backward compatible
+in terms of JAR visibility requirements for applications.
+The current allowed value is v2, which refers to GlassFish version 2 or
+Enterprise Server version 9.1 or 9.1.1. The Java EE 6 platform specification
+imposes stricter requirements than Java EE 5 did on which JAR files can be
+visible to various modules within an EAR file. Setting this element to v2
+removes these Java EE 6 restrictions.
+-->
+<!ELEMENT compatibility (#PCDATA)>
+
+<!--
+The keep-state element indicates whether the state information should be
+preserved across redeployment.
+-->
+<!ELEMENT keep-state (#PCDATA)>
+
+<!--
+The version-identifier element contains the version information. The value is
+ retrieved at deployment.
+-->
+<!ELEMENT version-identifier (#PCDATA)>
+
+<!--
+Payara flag to delegate classloader to parent class or not
+-->
+<!ELEMENT classloading-delegate (#PCDATA)>
+
+<!--
+Payara flag to enable / disable implicit CDI for EAR file
+-->
+<!ELEMENT enable-implicit-cdi (#PCDATA)>
+
+<!--
+Payara flag to include / exclude specific JARs for CDI scanning inside EAR files
+-->
+<!ELEMENT scanning-exclude (#PCDATA)>
+<!ELEMENT scanning-include (#PCDATA)>
+
+<!--
+Payara flag to enable / specify whitelist for extreme ClassLoader isolation
+-->
+<!ELEMENT whitelist-package (#PCDATA)>
+
+<!--
+Syntax for supplying properties as name value pairs
+-->
+<!ELEMENT property (description?)>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!ELEMENT description (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-ejb-jar_4_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-ejb-jar_4_0-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-ejb-jar_4_0-0.dtd">
+  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-ejb-jar_4_0-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-ejb-jar_4_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-ejb-jar_4_0-0.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd">
+  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-ejb-jar_4_0-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-web-app_6_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-web-app_6_0-0.dtd
@@ -49,7 +49,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-web-app_6_0-0.dtd">
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-web-app_6_0-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-web-app_6_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-web-app_6_0-0.dtd
@@ -49,7 +49,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-web-app_6_0-0.dtd">
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-web-app_6_0-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client-container_1_4-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client-container_1_4-1.dtd
@@ -1,0 +1,291 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<!--  Portions Copyright 2022-2026 Payara Foundation and/or its affiliates -->
+
+
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+<!ENTITY % severity "(FINEST|FINER|FINE|CONFIG|INFO|WARNING|SEVERE|ALERT|FATAL)">
+
+<!-- Payara Application client container configuration
+    send-password   Specifies whether client authentication credentials should 
+                    be sent to the server. Without credential all accesses to 
+                    protected EJBs will result in exceptions.
+   message-security-config: Optional list of layer specific lists of
+     configured message security providers.
+-->
+<!ELEMENT client-container (target-server+, auth-realm?, client-credential?, log-service?, message-security-config*, property*)>
+<!ATTLIST client-container send-password %boolean; "true"> 
+
+<!-- Target server's IIOP listener configuration 
+    name        Application server instance name 
+    address     ip address or hostname (resolvable by DNS) of the ORB
+    port        port number of the ORB
+-->
+<!ELEMENT target-server (description?, security?)>
+<!ATTLIST target-server name             CDATA     #REQUIRED
+                        address          CDATA     #REQUIRED
+                        port             CDATA     #REQUIRED>
+                                                  
+<!ELEMENT description (#PCDATA)>
+
+<!-- Default client credentials that will be sent to server. If this element 
+     is present, then it will be automatically sent to the server, without
+     prompting the user for usename and password on the client side. 
+     user-name  User name credential   
+     password   Password credential
+     realm      The realm (specified by name) where credentials are to be 
+                resolved.
+ -->
+<!ELEMENT client-credential (property*)>
+<!ATTLIST client-credential user-name CDATA   #REQUIRED
+                            password  CDATA   #REQUIRED
+                            realm     CDATA   #IMPLIED>
+                                
+<!-- Logging service configuration. 
+
+     file   By default log file will be at $APPCLIENT_ROOT/logs/client.log
+            Can use this attribute to specify an alternate location.
+     level  sets the base level of severity. Messages at or above this 
+            setting get logged into the log file.
+ -->
+<!ELEMENT log-service (property*)>
+<!ATTLIST log-service  file                      CDATA      #IMPLIED
+                       level                     %severity; "SEVERE">
+
+<!-- SSL security  configuration for IIOP/SSL communication with 
+     the target-server.
+ -->
+<!ELEMENT security (ssl, cert-db)>
+
+<!-- Define SSL processing parameters
+
+     cert-nickname nickname of the server certificate in the certificate database 
+                   or the PKCS#11 token. In the certificate, the name format is
+                   tokenname:nickname. Including the tokenname: part of the name 
+                   in this attribute is optional.
+
+    ssl3-tls-ciphers (optional) A space-separated list of the SSL3 ciphers used, with
+                     the prefix + to enable or - to disable, for example
+                     +SSL_RSA_WITH_RC4_128_MD5.
+                     Allowed SSL3/TLS values are SSL_RSA_WITH_RC4_128_MD5,
+                     SSL_RSA_WITH_3DES_EDE_CBC_SHA, SSL_RSA_WITH_DES_CBC_SHA,
+                     SSL_RSA_EXPORT_WITH_RC4_40_MD5, SSL_RSA_WITH_NULL_MD5,
+                     SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_NULL_SHA
+
+    tls-rollback-enabled  (optional) Determines whether TLS rollback is enabled. TLS 
+                          rollback should be enabled for Microsoft Internet Explorer 
+                          5.0 and 5.5. 
+
+    client-auth-enabled   (optional) Determines whether client authentication is
+                          performed on every request, independent of ACL-based access 
+                          control.
+--> 
+<!ELEMENT ssl EMPTY>
+<!ATTLIST ssl cert-nickname        CDATA    #IMPLIED
+              ssl3-tls-ciphers     CDATA    #IMPLIED
+              tls-rollback-enabled CDATA    "true">
+
+<!-- Location and password to read the Certificate Database. iAS
+     (actually NSS) will provide utilities with which a certificate 
+     database can be created.
+
+     path     Specifies the absolute path where the cert database (cert7.db) 
+              is stored. 
+     password needed to open and read a cert database
+ -->
+<!ELEMENT cert-db EMPTY>
+<!ATTLIST cert-db path       CDATA #REQUIRED
+                  password   CDATA #REQUIRED>
+
+<!-- JAAS is available on Application Client Container. 
+     Optional configuration for JAAS authentication realm.
+     
+     name       defines the name of this realm
+     classname  defines the java class which implements this realm
+ -->
+<!ELEMENT auth-realm (property*)>
+<!ATTLIST auth-realm name            CDATA   #REQUIRED
+                     classname       CDATA   #REQUIRED>
+               
+<!-- Syntax for supplying properties as name value pairs -->
+<!ELEMENT property EMPTY>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-config elements.
+
+Used in: message-security-config
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-config element defines the message layer
+specific provider configurations of the application server.
+
+All of the providers within a message-security-config element
+must be able to perform authentication processing at
+the message layer defined by the value of the auth-layer 
+attribute. 
+
+The default-provider attribute may be used to identify 
+the server provider to be invoked for any application 
+for which a specific server provider has not been bound.
+
+The default-client-provider attribute may be used to identify 
+the client provider to be invoked for any application 
+for which a specific client provider has not been bound.
+
+At most one (non-null) default server provider and at most one
+(non-null) default client provider may be identified 
+among all the same layer message-security-config elements. 
+
+When a default provider of a type is not defined for a message 
+layer, the container will only invoke a provider of the type
+(at the layer) for those applications for which a specific
+provider has been bound.
+
+Default: 
+Used in: security-service
+-->
+<!ELEMENT message-security-config ( provider-config+ )>
+<!ATTLIST message-security-config 
+          auth-layer %message-layer; #REQUIRED
+	  default-provider        CDATA #IMPLIED
+	  default-client-provider CDATA #IMPLIED>
+
+<!--
+The provider-config element defines the configuration of
+an authentication provider.
+
+The provider-id attibute contains an identifier that can be used to
+reference the provider-config.
+
+The request-policy and response-policy sub-elements define
+the authentication policy requirements associated 
+with the request and response processing performed by the
+authentication provider (respectively).
+
+the provider-type attribute defines whether the provider is a client
+authentication provider or a server authentication provider.
+
+The class-name attribute defines the java implementation class of the 
+provider. Client authentication providers must implement the 
+com.sun.enterprise.security.jauth.ClientAuthModule interface. Server-side
+providers must implement the com.sun.enterprise.security.jauth.ServerAuthModule
+interface. A provider may implement both interfaces, but it must implement
+the interface corresponding to its provider type.
+
+The optional list of property elements may be used to configure provider
+specific property values. These values will be passed to the provider
+when its initialize method is called.
+
+A provider-config with no contained request-policy or response-policy
+sub-elements, is a null provider. The container will not instantiate
+or invoke the methods of a null provider, and as such the implementation
+class of a null provider need not exist.
+
+Default: 
+Used in: message-security-config
+-->
+<!ELEMENT provider-config ( request-policy?, response-policy?, property* )>
+<!ATTLIST provider-config
+          provider-id CDATA                   #REQUIRED
+	  provider-type  (client | server | client-server) #REQUIRED
+          class-name      CDATA            #REQUIRED>
+
+<!--
+The request-policy element is used to define the authentication policy 
+requirements associated with the request processing performed by an 
+authentication provider (i.e. when a client provider's 
+ClientAuthModule.initiateRequest method is called or when a
+server provider's ServerAuthModule.validateRequest is called).
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+Default: 
+Used in: provider-config
+-->
+<!ELEMENT request-policy EMPTY >
+<!ATTLIST request-policy 
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+<!--
+The response-policy element is used to define the authentication policy 
+requirements associated with the response processing performed by an 
+authentication provider (i.e. when a client provider's 
+ClientAuthModule.validateResponse method is called or when a
+server provider's ServerAuthModule.secureResponse method is called).
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+Default: 
+Used in: provider-config
+-->
+<!ELEMENT response-policy EMPTY >
+<!ATTLIST response-policy 
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd
@@ -2,7 +2,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -38,59 +38,24 @@
     only if the new code is made subject to such option by the copyright
     holder.
 
-    Portions Copyright 2026 Payara Foundation and/or its affiliates
 -->
+<!-- Portions Copyright 2026 Payara Foundation and/or its affiliates -->
 
 <!--
-  XML DTD for Payara Application Server specific Jakarta EE Application
-  deployment descriptor. This is a companion DTD to application_10.xsd
+  XML DTD for Payara Application Server specific Jakarta EE Client Application
+  deployment descriptor. This is a companion DTD to application-client_11.xsd
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara-application_10-0.dtd">
+  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd">
 
 -->
 
 <!--
-This is the root element of the runtime descriptor document.
+payara-application-client is the root element describing all the runtime bindings of a single application client
 -->
-<!ELEMENT payara-application (web*, pass-by-reference?, unique-id?, security-role-mapping*, realm?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, message-destination*, archive-name?, compatibility?, keep-state?, version-identifier?, classloading-delegate?, enable-implicit-cdi?, scanning-exclude*, scanning-include*, whitelist-package*, property*) >
-
-<!ELEMENT web (web-uri, context-root)>
-<!ELEMENT web-uri (#PCDATA)>
-<!ELEMENT context-root (#PCDATA)>
-
-<!-- Pass by Reference semantics:  EJB spec requires pass by value,
-     which will be the default mode of operation. This can be set
-     to true for non-compliant and possibly higher performance.
-     For a stand-alone, this can be set at this level. By setting
-     a similarly named element at payara-application, it can apply to
-     all the enclosed ejb modules. Allowed values are true and
-     false. Default will be false.
- -->
-<!ELEMENT pass-by-reference (#PCDATA)>
-
-<!-- Automatically generated and updated at deployment/redeployment
-     Needs to be unqiue in the system.
-  -->
-<!ELEMENT unique-id (#PCDATA)>
-
-<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)>
-
-<!ELEMENT role-name (#PCDATA)>
-<!ELEMENT principal-name (#PCDATA)>
-<!ATTLIST principal-name class-name CDATA #IMPLIED>
-<!ELEMENT group-name (#PCDATA)>
-
-<!--
-  realm: Allows specifying an optional authentication realm name which will
-    be used to process all authentication requests associated with this
-    application. If this element is not specified (or if it is given but
-    does not match the name of a configured realm) then the default realm
-    set in the server instances security-service element will be used
-    instead.
--->
-<!ELEMENT realm (#PCDATA)>
+<!ELEMENT payara-application-client (ejb-ref*, resource-ref*, resource-env-ref*, service-ref*,
+	message-destination-ref*, message-destination*, java-web-start-access?, version-identifier?)>
 
 <!--
 name of a resource reference.
@@ -167,7 +132,13 @@ name of a message-destination reference.
 <!ELEMENT message-destination-ref-name (#PCDATA)>
 
 <!--
-                        W E B   S E R V I C E S
+Specifies the name of a durable subscription associated with a message-driven bean's
+destination.  Required for a Topic destination, if subscription-durability is set to
+Durable (in ejb-jar.xml)
+-->
+
+<!--
+  			W E B   S E R V I C E S
 -->
 <!--
 Runtime settings for a web service reference.  In the simplest case,
@@ -179,7 +150,7 @@ is only needed in the following cases :
 the one packaged with a service-ref
 -->
 <!ELEMENT service-ref ( service-ref-name, port-info*, call-property*,
-                wsdl-override?, service-impl-class?, service-qname? )>
+		wsdl-override?, service-impl-class?, service-qname? )>
 
 <!--
 Coded name (relative to java:comp/env) for a service-reference
@@ -436,11 +407,11 @@ Used in: message-security
  * by the contained method-params or part-name-list sub-elements.
  *
  * The content-auth-policy element would be defined as follows:
-*
+ *
  * content-auth-policy ( method-params | part-name-list )
  * ATTLIST content-auth-policy
  *         auth-source (sender | content) #IMPLIED
- *         auth-recipient (before-content | after-content) #IMPLIED
+ *	   auth-recipient (before-content | after-content) #IMPLIED
  *
  * The part-name-list and part-name elements would be defined as follows:
  *
@@ -451,7 +422,7 @@ Used in: message-security
 <!ELEMENT request-protection EMPTY >
 <!ATTLIST request-protection
           auth-source (sender | content) #IMPLIED
-          auth-recipient (before-content | after-content) #IMPLIED>
+	  auth-recipient (before-content | after-content) #IMPLIED>
 
 <!--
 The response-protection element describes the authentication requirements
@@ -487,7 +458,7 @@ Used in: message-security
 <!ELEMENT response-protection EMPTY >
 <!ATTLIST response-protection
           auth-source (sender | content) #IMPLIED
-          auth-recipient (before-content | after-content) #IMPLIED>
+	  auth-recipient (before-content | after-content) #IMPLIED>
 
 <!--
 The method-name element contains the name of a service method of a web service
@@ -512,64 +483,77 @@ Used in: method-params
 -->
 <!ELEMENT method-param (#PCDATA)>
 
+<!--
+                            J A V A   W E B   S T A R T    A C C E S S
+-->
 
 <!--
-  The value of the archive-name element will be used to derive the default
-name of the app-name when app-name is not present in application.xml.
-  The default app name will be archive-name value minus the file extension.
-For example, if archive-name is foo.ear, the default app-name will be foo.
+The java-web-start-access element contains all information relevant to Java
+Web Start access to the app client.
+
+Note that all elements that support Java Web Start access appear below
+the java-web-start-access definition alphabetically by tag name.
+
+The context-root subelement allows the developer to specify what context root
+will be used for addressing the app client via Java Web Start.  If absent, the
+app server uses a default context root value.
+
+The eligible subelement allows the developer to control whether this app client
+should allow Java Web Start access.  If this value is false, then Java Web Start
+will never be allowed access.  Default: true.
+
+The vendor subelement allows the developer to specify the vendor name that Java
+Web Start should display to the end-user as the app client is downloaded and launched.
+
+The jnlp-doc subelement gives the developer a way to direct the generation of
+the JNLP document describing the app client launch.
+
+Used in: payara-application-client
 -->
-<!ELEMENT archive-name (#PCDATA)>
+<!ELEMENT java-web-start-access (context-root?, eligible?, vendor?, jnlp-doc?)>
 
 <!--
-Specifies the Enterprise Server release with which to be backward compatible
-in terms of JAR visibility requirements for applications.
-The current allowed value is v2, which refers to GlassFish version 2 or
-Enterprise Server version 9.1 or 9.1.1. The Java EE 6 platform specification
-imposes stricter requirements than Java EE 5 did on which JAR files can be
-visible to various modules within an EAR file. Setting this element to v2
-removes these Java EE 6 restrictions.
+The context-root element allows the developer to specify the context root
+with which Java Web Start should access the app client.  The app server
+provides a default value if the developer omits this.
+
+Used in: java-web-start-access
 -->
-<!ELEMENT compatibility (#PCDATA)>
+<!ELEMENT context-root (#PCDATA)>
 
 <!--
-The keep-state element indicates whether the state information should be
-preserved across redeployment.
+The eligible element allows the developer to indicate whether Java Web Start
+access should ever be permitted to launch this app client.
+
+Used in: java-web-start-access
 -->
-<!ELEMENT keep-state (#PCDATA)>
+<!ELEMENT eligible (#PCDATA)>
+
+<!--
+The vendor element allows the developer to indicate what vendor name Java Web Start
+should display in the splash screen as the app client is downloaded and/or launched.
+
+Used in: java-web-start-access
+-->
+<!ELEMENT vendor (#PCDATA)>
+
+<!--
+The jnlp-doc element's href attribute refers to a JNLP file in the app
+client or in the EAR which is merged with the generated JNLP to create the final
+JNLP which is used to launch the app client.  This href must be a relative
+URI.  Note that the path may instead be specified as the text value of the
+jnlp-doc element. Using the text value is described in the published documentation 
+so we need to allow either.  Users should not specify both; if they do results 
+are unpredictable.
+
+Used in: java-web-start-access
+-->
+<!ELEMENT jnlp-doc (#PCDATA)>
+<!ATTLIST jnlp-doc 
+          href CDATA #IMPLIED>
 
 <!--
 The version-identifier element contains the version information. The value is
  retrieved at deployment.
 -->
 <!ELEMENT version-identifier (#PCDATA)>
-
-<!--
-Payara flag to delegate classloader to parent class or not
--->
-<!ELEMENT classloading-delegate (#PCDATA)>
-
-<!--
-Payara flag to enable / disable implicit CDI for EAR file
--->
-<!ELEMENT enable-implicit-cdi (#PCDATA)>
-
-<!--
-Payara flag to include / exclude specific JARs for CDI scanning inside EAR files
--->
-<!ELEMENT scanning-exclude (#PCDATA)>
-<!ELEMENT scanning-include (#PCDATA)>
-
-<!--
-Payara flag to enable / specify whitelist for extreme ClassLoader isolation
--->
-<!ELEMENT whitelist-package (#PCDATA)>
-
-<!--
-Syntax for supplying properties as name value pairs
--->
-<!ELEMENT property (description?)>
-<!ATTLIST property name  CDATA  #REQUIRED
-                   value CDATA  #REQUIRED>
-
-<!ELEMENT description (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd">
+  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Revision 1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd">
+  <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application_11-1.dtd">
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application_11-1.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application_11-1.dtd">
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Revision 1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd
@@ -1,0 +1,575 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+    Portions Copyright 2026 Payara Foundation and/or its affiliates
+-->
+
+<!--
+  XML DTD for Payara Application Server specific Jakarta EE Application
+  deployment descriptor. This is a companion DTD to application_11.xsd
+
+  It must include a DOCTYPE of the following form:
+
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application_11-1.dtd">
+
+-->
+
+<!--
+This is the root element of the runtime descriptor document.
+-->
+<!ELEMENT payara-application (web*, pass-by-reference?, unique-id?, security-role-mapping*, realm?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, message-destination*, archive-name?, compatibility?, keep-state?, version-identifier?, classloading-delegate?, enable-implicit-cdi?, scanning-exclude*, scanning-include*, whitelist-package*, property*) >
+
+<!ELEMENT web (web-uri, context-root)>
+<!ELEMENT web-uri (#PCDATA)>
+<!ELEMENT context-root (#PCDATA)>
+
+<!-- Pass by Reference semantics:  EJB spec requires pass by value,
+     which will be the default mode of operation. This can be set 
+     to true for non-compliant and possibly higher performance. 
+     For a stand-alone, this can be set at this level. By setting 
+     a similarly named element at payara-application, it can apply to
+     all the enclosed ejb modules. Allowed values are true and 
+     false. Default will be false.
+ -->
+<!ELEMENT pass-by-reference (#PCDATA)>
+
+<!-- Automatically generated and updated at deployment/redeployment 
+     Needs to be unqiue in the system.
+  -->
+<!ELEMENT unique-id (#PCDATA)>
+
+<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)>
+
+<!ELEMENT role-name (#PCDATA)>
+<!ELEMENT principal-name (#PCDATA)>
+<!ATTLIST principal-name class-name CDATA #IMPLIED>
+<!ELEMENT group-name (#PCDATA)>
+
+<!-- 
+  realm: Allows specifying an optional authentication realm name which will
+    be used to process all authentication requests associated with this
+    application. If this element is not specified (or if it is given but
+    does not match the name of a configured realm) then the default realm
+    set in the server instances security-service element will be used
+    instead.
+-->
+<!ELEMENT realm (#PCDATA)>
+
+<!--
+name of a resource reference.
+-->
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!--
+resource-env-ref holds all the runtime bindings of a resource env reference.
+-->
+<!ELEMENT resource-env-ref ( resource-env-ref-name, jndi-name )>
+
+<!--
+name of a resource env reference.
+-->
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!--
+resource-ref holds the runtime bindings of a resource reference.
+-->
+<!ELEMENT resource-ref  ( res-ref-name, jndi-name,  default-resource-principal?)>
+
+<!--
+default-resource-principal specifies the default principal that the container
+will use to access a resource.
+-->
+<!ELEMENT default-resource-principal ( name,  password)>
+
+<!--
+name element holds the user name
+-->
+<!ELEMENT name (#PCDATA)>
+
+<!--
+password element holds a password string.
+-->
+<!ELEMENT password (#PCDATA)>
+
+<!--
+ejb-ref element which binds an ejb reference to a jndi name.
+-->
+<!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+
+<!--
+ejb-ref-name locates the name of the ejb reference in the application.
+-->
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!--
+jndi name of the associated entity
+-->
+<!ELEMENT  jndi-name (#PCDATA)>
+
+<!--
+This node holds information about a logical message destination
+-->
+<!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+<!--
+This node holds the name of a logical message destination
+-->
+<!ELEMENT message-destination-name (#PCDATA)>
+
+<!--
+message-destination-ref is used to directly bind a message destination reference
+to the jndi-name of a Queue,Topic, or some other physical destination. It should
+only be used when the corresponding message destination reference does not
+specify a message-destination-link to a logical message-destination.
+-->
+<!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+<!--
+name of a message-destination reference.
+-->
+<!ELEMENT message-destination-ref-name (#PCDATA)>
+
+<!--
+                        W E B   S E R V I C E S
+-->
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+<!ELEMENT service-ref ( service-ref-name, port-info*, call-property*,
+                wsdl-override?, service-impl-class?, service-qname? )>
+
+<!--
+Coded name (relative to java:comp/env) for a service-reference
+-->
+<!ELEMENT service-ref-name ( #PCDATA )>
+
+<!--
+Information for a port within a service-reference.
+
+Either service-endpoint-interface or wsdl-port or both
+(service-endpoint-interface and wsdl-port) should be specified.
+
+If both are specified, wsdl-port represents the
+port the container should choose for container-managed port selection.
+
+The same wsdl-port value must not appear in
+more than one port-info entry within the same service-ref.
+
+If a particular service-endpoint-interface is using container-managed port
+selection, it must not appear in more than one port-info entry
+within the same service-ref.
+
+The optional message-security-binding element is used to customize the
+port to provider binding; either by binding the port to a specific provider
+or by providing a definition of the message security requirements to be
+enforced by the provider.
+
+-->
+<!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+<!--
+Fully qualified name of service endpoint interface
+-->
+<!ELEMENT service-endpoint-interface ( #PCDATA )>
+<!--
+Port used in port-info.
+-->
+<!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+<!--
+JAXRPC property values that should be set on a stub before it's returned to
+to the web service client.  The property names can be any properties supported
+by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+-->
+<!ELEMENT stub-property ( name, value )>
+
+<!--
+JAXRPC property values that should be set on a Call object before it's
+returned to the web service client.  The property names can be any
+properties supported by the JAXRPC Call implementation.  See javadoc
+for javax.xml.rpc.Call
+-->
+<!ELEMENT call-property ( name, value )>
+
+<!--
+This is a valid URL pointing to a final WSDL document. It is optional.
+If specified, the WSDL document at this URL will be used during
+deployment instead of the WSDL document associated with the
+service-ref in the standard deployment descriptor.
+
+Examples :
+
+  // available via HTTP
+  <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+  // in a file
+  <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+-->
+<!ELEMENT wsdl-override ( #PCDATA )>
+
+<!--
+Name of generated service implementation class. This is not set by the
+deployer. It is derived during deployment.
+-->
+<!ELEMENT service-impl-class ( #PCDATA )>
+
+<!--
+The service-qname element declares the specific WSDL service
+element that is being refered to.  It is not set by the deployer.
+It is derived during deployment.
+-->
+<!ELEMENT service-qname (namespaceURI, localpart)>
+
+<!--
+The localpart element indicates the local part of a QNAME.
+-->
+<!ELEMENT localpart (#PCDATA)>
+
+<!--
+The namespaceURI element indicates a URI.
+-->
+<!ELEMENT namespaceURI (#PCDATA)>
+
+<!--
+This text nodes holds a value string.
+-->
+<!ELEMENT value (#PCDATA)>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-binding elements.
+
+Used in: message-security-binding
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-binding element is used to customize the
+webservice-endpoint or port to provider binding; either by binding the
+webservice-endpoint or port to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+These elements are typically NOT created as a result of the
+deployment of an application. They need only be created when the
+deployer or system administrator chooses to customize the
+webservice-endpoint or port to provider binding.
+
+The optional (repeating) message-security sub-element is used
+to accomplish the latter; in which case the specified
+message-security requirements override any defined with the
+provider.
+
+The auth-layer attribute identifies the message layer at which the
+message-security requirements are to be enforced.
+
+The optional provider-id attribute identifies the provider-config
+and thus the authentication provider that is to be used to satisfy
+the application specific message security requirements. If a value for
+the provider-id attribute is not specified, and a default
+provider is defined for the message layer, then it is used.
+if a value for the provider-id attribute is not specified, and a
+default provider is not defined at the layer, the authentication
+requirements defined in the message-security-binding are not
+enforced.
+
+Default:
+Used in: webservice-endpoint, port-info
+-->
+<!ELEMENT message-security-binding ( message-security* )>
+<!ATTLIST message-security-binding
+          auth-layer  %message-layer; #REQUIRED
+          provider-id CDATA           #IMPLIED >
+
+<!--
+The message-security element describes message security requirements
+that pertain to the request and response messages of the containing
+endpoint, or port
+
+When contained within a webservice-endpoint this element describes
+the message security requirements that pertain to the request and
+response messages of the containing endpoint. When contained within a
+port-info of a service-ref this element describes the message security
+requirements of the port of the referenced service.
+
+The one or more contained message elements define the methods or operations
+of the containing application, endpoint, or referenced service to which
+the message security requirements apply.
+
+Multiple message-security elements occur within a containing
+element when it is necessary to define different message
+security requirements for different messages within the encompassing
+context. In such circumstances, the peer elements should not overlap
+in the messages they pertain to. If there is any overlap in the
+identified messages, no message security requirements apply to
+the messages for which more than one message-security element apply.
+
+Also, no message security requirements apply to any messages of
+the encompassing context that are not identified by a message element.
+
+Default:
+Used in: webservice-endpoint, and port-info
+-->
+<!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+<!--
+The message element identifies the methods or operations to which
+the message security requirements apply.
+
+The identified methods or operations are methods or operations of
+the resource identified by the context in which the message-security
+element is defined (e.g. the the resource identified by the
+service-qname of the containing webservice-endpoint or service-ref).
+
+An empty message element indicates that the security requirements
+apply to all the methods or operations of the identified resource.
+
+When operation-name is specified, the security
+requirements defined in the containing message-security
+element apply to all the operations of the endpoint
+with the specified (and potentially overloaded) operation name.
+
+Default:
+Used in: message-security
+-->
+<!ELEMENT message ( java-method? | operation-name? )>
+
+<!--
+The java-method element is used to identify a method (or methods
+in the case of an overloaded method-name) of the java class
+indicated by the context in which the java-method is contained.
+
+Default:
+Used in: message
+-->
+<!ELEMENT java-method ( method-name, method-params? )>
+
+<!--
+The operation-name element is used to identify the WSDL name of an
+operation of a web service.
+
+Default:
+Used in: message
+-->
+<!ELEMENT operation-name ( #PCDATA )>
+
+<!--
+The request-protection element describes the authentication requirements
+that apply to a request.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent request-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default:
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * request-protection ( content-auth-policy* )
+ *
+ * If the request-protection element contains one or more
+ * content-auth-policy sub-elements, they define the authentication
+ * requirements to be applied to the identified request content. If multiple
+ * content-auth-policy sub-elements are defined, a request sender must
+ * satisfy the requirements independently, and in the specified order.
+ *
+ * The content-auth-policy element would be used to associate authentication
+ * requirements with the parts of the request or response object identified
+ * by the contained method-params or part-name-list sub-elements.
+ *
+ * The content-auth-policy element would be defined as follows:
+*
+ * content-auth-policy ( method-params | part-name-list )
+ * ATTLIST content-auth-policy
+ *         auth-source (sender | content) #IMPLIED
+ *         auth-recipient (before-content | after-content) #IMPLIED
+ *
+ * The part-name-list and part-name elements would be defined as follows:
+ *
+ * part-name-list ( part-name* )
+ * part-name ( #PCDATA )
+ *
+-->
+<!ELEMENT request-protection EMPTY >
+<!ATTLIST request-protection
+          auth-source (sender | content) #IMPLIED
+          auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The response-protection element describes the authentication requirements
+that apply to a response.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent response-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default:
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * response-protection ( content-auth-policy* )
+ *
+ * see request-protection element for more details
+ *
+-->
+<!ELEMENT response-protection EMPTY >
+<!ATTLIST response-protection
+          auth-source (sender | content) #IMPLIED
+          auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The method-name element contains the name of a service method of a web service
+implementation class.
+
+Used in: java-method
+-->
+<!ELEMENT method-name (#PCDATA)>
+<!--
+The method-params element contains a list of the fully-qualified Java
+type names of the method parameters.
+
+Used in: java-method
+-->
+<!ELEMENT method-params (method-param*)>
+
+<!--
+The method-param element contains the fully-qualified Java type name
+of a method parameter.
+
+Used in: method-params
+-->
+<!ELEMENT method-param (#PCDATA)>
+
+
+<!--
+  The value of the archive-name element will be used to derive the default 
+name of the app-name when app-name is not present in application.xml.
+  The default app name will be archive-name value minus the file extension. 
+For example, if archive-name is foo.ear, the default app-name will be foo.
+-->
+<!ELEMENT archive-name (#PCDATA)> 
+
+<!--
+Specifies the Enterprise Server release with which to be backward compatible 
+in terms of JAR visibility requirements for applications. 
+The current allowed value is v2, which refers to GlassFish version 2 or 
+Enterprise Server version 9.1 or 9.1.1. The Java EE 6 platform specification 
+imposes stricter requirements than Java EE 5 did on which JAR files can be 
+visible to various modules within an EAR file. Setting this element to v2 
+removes these Java EE 6 restrictions.
+-->
+<!ELEMENT compatibility (#PCDATA)>
+
+<!--
+The keep-state element indicates whether the state information should be
+preserved across redeployment.
+-->
+<!ELEMENT keep-state (#PCDATA)>
+
+<!--
+The version-identifier element contains the version information. The value is
+ retrieved at deployment.
+-->
+<!ELEMENT version-identifier (#PCDATA)>
+
+<!--
+Payara flag to delegate classloader to parent class or not
+-->
+<!ELEMENT classloading-delegate (#PCDATA)>
+
+<!--
+Payara flag to enable / disable implicit CDI for EAR file
+-->
+<!ELEMENT enable-implicit-cdi (#PCDATA)>
+
+<!--
+Payara flag to include / exclude specific JARs for CDI scanning inside EAR files
+-->
+<!ELEMENT scanning-exclude (#PCDATA)>
+<!ELEMENT scanning-include (#PCDATA)>
+
+<!--
+Payara flag to enable / specify whitelist for extreme ClassLoader isolation
+-->
+<!ELEMENT whitelist-package (#PCDATA)>
+
+<!-- 
+Syntax for supplying properties as name value pairs 
+-->
+<!ELEMENT property (description?)>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!ELEMENT description (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-ejb-jar_4_0-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-ejb-jar_4_0-1.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd">
+  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-ejb-jar_4_0-1.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-ejb-jar_4_0-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-ejb-jar_4_0-1.dtd
@@ -47,7 +47,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd">
+  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd
@@ -49,7 +49,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-0.dtd">
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd
@@ -49,7 +49,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd">
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd
@@ -49,7 +49,7 @@
 
   It must include a DOCTYPE of the following form:
 
-  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-0.dtd">
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-0.dtd">
 
 -->
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd
@@ -1,0 +1,871 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+    
+
+    Portions Copyright 2026 Payara Foundation and/or its affiliates
+-->
+
+<!--
+  XML DTD for Payara Application Server specific Jakarta EE web
+  deployment descriptor. This is a companion DTD to web-app_6_1.xsd
+  and web-common_6_1.xsd.
+
+  It must include a DOCTYPE of the following form:
+
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-0.dtd">
+
+-->
+
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+
+<!-- root element for vendor specific web application (module) configuration -->
+<!ELEMENT payara-web-app (context-root?, security-role-mapping*, servlet*, idempotent-url-pattern*, session-config?,
+                       ejb-ref*, resource-ref*, resource-env-ref*,  service-ref*,
+                       message-destination-ref*, cache?, class-loader?,
+                       jsp-config?, locale-charset-info?, parameter-encoding?,
+                       property*, valve*, message-destination*, webservice-description*, scanning-exclude*, scanning-include*, whitelist-package*, keep-state?, version-identifier?, container-initializer-enabled?, jaxrs-roles-allowed-enabled?)>
+<!ATTLIST payara-web-app error-url CDATA ""
+                      httpservlet-security-provider CDATA #IMPLIED>
+
+<!--
+  Idempotent URL Patterns
+    url-pattern      URL Pattern of the idempotent requests
+    num-of-retries  Specifies the number of times the Load Balancer will retry a request that is idempotent.
+-->
+<!ELEMENT idempotent-url-pattern EMPTY>
+<!ATTLIST idempotent-url-pattern url-pattern CDATA #REQUIRED
+                                 num-of-retries CDATA "-1">
+
+<!-- 
+ Context Root for the web application when the war file is a standalone module.
+ When the war module is part of the Jakarta EE Application, use the application.xml
+-->
+<!ELEMENT context-root (#PCDATA)>
+
+<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)>
+<!ELEMENT role-name (#PCDATA)>
+
+<!ELEMENT principal-name (#PCDATA)>
+<!ATTLIST principal-name class-name CDATA #IMPLIED>
+<!ELEMENT group-name (#PCDATA)>
+
+<!ELEMENT servlet (servlet-name, principal-name?, webservice-endpoint*)>
+
+<!ELEMENT session-config (session-manager?, session-properties?, cookie-properties?)>
+
+<!ENTITY % persistence-type "(memory | file | custom | ha | s1ws60 | mmap | replicated)">
+
+<!ELEMENT session-manager (manager-properties?, store-properties?)>
+<!ATTLIST session-manager persistence-type CDATA "memory">
+
+<!ELEMENT manager-properties (property*)>
+<!ELEMENT store-properties (property*)>
+<!ELEMENT session-properties (property*)>
+<!ELEMENT cookie-properties (property*)>
+
+<!ELEMENT jndi-name (#PCDATA)>
+
+<!ELEMENT resource-env-ref (resource-env-ref-name, jndi-name)>
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!ELEMENT resource-ref (res-ref-name, jndi-name, default-resource-principal?)>
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!ELEMENT default-resource-principal ( name,  password)>
+
+<!--
+This node holds information about a logical message destination
+-->
+<!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+<!--
+This node holds the name of a logical message destination
+-->
+<!ELEMENT message-destination-name (#PCDATA)>
+
+<!--
+message-destination-ref is used to directly bind a message destination reference
+to the jndi-name of a Queue,Topic, or some other physical destination. It should
+only be used when the corresponding message destination reference does not
+specify a message-destination-link to a logical message-destination.
+-->
+<!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+<!--
+name of a message-destination reference.
+-->
+<!ELEMENT message-destination-ref-name (#PCDATA)>
+
+<!--
+This text nodes holds a name string.
+-->
+<!ELEMENT name (#PCDATA)>
+
+<!--
+This element holds password text.
+-->
+<!ELEMENT password (#PCDATA)>
+
+
+<!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!ENTITY % scope "(context.attribute | request.header  | request.parameter | 
+                   request.cookie  | request.attribute | session.attribute)">
+<!ENTITY % key-scope "(context.attribute | request.header | request.parameter | 
+                       request.cookie | session.id | session.attribute)">
+<!ENTITY % expr "(equals | greater | lesser | not-equals | in-range)">
+
+<!-- cache element configures the cache for web application. iAS 7.0 web container    
+     supports one such cache object per application: i.e. <cache> is a sub element    
+     of <ias-web-app>. A cache can have zero or more cache-mapping elements and
+     zero or more customizable cache-helper classes.
+                                                                                   
+        max-entries        Maximum number of entries this cache may hold. [4096]
+        timeout-in-seconds Default timeout for the cache entries in seconds. [30]
+        enabled            Is this cache enabled? [true]
+-->
+<!ELEMENT cache (cache-helper*, default-helper?, property*, cache-mapping*)>
+<!ATTLIST cache  max-entries         CDATA     "4096"
+                 timeout-in-seconds  CDATA     "30"
+                 enabled             %boolean; "true">
+
+<!-- cache-helper specifies customizable class which implements CacheHelper interface. 
+
+     name                     Unique name for the helper class; this is referenced in
+                              the cache-mapping elements (see below).
+                              "default" is reserved for the built-in default helper.
+     class-name               Fully qualified class name of the cache-helper; this class
+                              must extend the com.sun.appserv.web.CacheHelper class.
+-->
+<!ELEMENT cache-helper (property*)>
+<!ATTLIST cache-helper name CDATA #REQUIRED
+                       class-name CDATA #REQUIRED>
+
+<!-- 
+Default, built-in cache-helper properties
+-->
+<!ELEMENT default-helper (property*)>
+
+<!-- 
+cache-mapping element defines what to be cached, the key to be used, any other   
+constraints to be applied and a customizable cache-helper to programmatically
+hook this information.
+-->
+<!ELEMENT cache-mapping ((servlet-name | url-pattern), 
+                        (cache-helper-ref |
+                        (dispatcher*, timeout?, refresh-field?, http-method*, key-field*, constraint-field*)))>
+
+<!-- 
+servlet-name element defines a named servlet to which this caching is enabled.
+the specified name must be present in the web application deployment descriptor
+(web.xml)
+-->
+<!ELEMENT servlet-name (#PCDATA)>
+
+<!-- 
+url-pattern element specifies the url pattern to which caching is to be enabled.
+See Servlet 2.3 specification section SRV. 11.2 for the applicable patterns.
+-->
+<!ELEMENT url-pattern  (#PCDATA)>
+
+<!-- 
+cache-helper-ref s a reference to the cache-helper used by this cache-mapping 
+-->
+<!ELEMENT cache-helper-ref (#PCDATA)>
+
+<!-- 
+Specifies the RequestDispatcher methods for which caching is to be
+enabled on the target resource. Valid values are REQUEST, FORWARD, INCLUDE,
+and ERROR (default: REQUEST).
+See SRV.6.2.5 of the Servlet 2.4 Specification for more information.
+-->
+<!ELEMENT dispatcher (#PCDATA)>
+
+<!-- 
+timeout element defines the cache timeout in seconds applicable for this mapping.
+default is to use cache object's timeout. The timeout value is specified statically
+ere (e.g. <timeout> 60 </timeout> or dynamically via fields in the relevant scope.
+
+   name             Name of the field where this timeout could be found
+   scope            Scope of the field. default scope is request attribute.
+-->
+<!ELEMENT timeout (#PCDATA)>
+<!ATTLIST timeout  name  CDATA  #IMPLIED
+                   scope %scope; 'request.attribute'>
+
+<!-- 
+http-method specifies HTTP method eligible for caching default is GET. 
+-->
+<!ELEMENT http-method (#PCDATA)>
+
+<!-- 
+specifies the request parameter name that triggers refresh. the cached entry 
+is refreshed when there such a request parameter is set to "true"
+example:
+<cache-mapping> 
+    <url-pattern> /quote </url-pattern> 
+    <refresh-field name="refresh" scope="request.parameter"/> 
+</cache-mapping> 
+-->
+<!ELEMENT refresh-field EMPTY>
+<!ATTLIST refresh-field name  CDATA       #REQUIRED
+                        scope %key-scope; 'request.parameter'>
+<!-- 
+key-field specifies a component of the key; container looks for the named 
+field in the given scope to access the cached entry. Default is to use
+the Servlet Path (the path section that corresponds to the servlet mapping 
+which activated this request). See Servlet 2.3 specification section SRV 4.4 
+on Servlet Path.
+
+  name             Name of the field to look for in the given scope
+  scope            Scope of the field. default scope is request parameter.
+-->
+<!ELEMENT key-field EMPTY>
+<!ATTLIST key-field name  CDATA       #REQUIRED
+                    scope %key-scope; 'request.parameter'>
+
+<!-- 
+constraint-field specifies a field whose value is used as a cacheability constraint.
+  
+  name                     Name of the field to look for in the given scope
+  scope                    Scope of the field. Default scope is request parameter.
+  cache-on-match           Should this constraint check pass, is the response cacheable?
+                           Default is true (i.e. cache the response on success match). 
+                           Useful to turn off caching when there is an attribute in the 
+                           scope (e.g. don't cache when there is an attribute called UID 
+                           in the session.attribute scope).
+  cache-on-match-failure   Should the constraint check fail, is response not cacheable?
+                           Default is false (i.e. a failure in enforcing the constraint
+                           would negate caching). Useful to turn on caching when the 
+                           an an attribute is not present (e.g. turn on caching 
+                           when there is no session or session attribute called UID).
+
+  Example 1: don't cache when there is a session attribute
+  <constraint-field name="UID" scope="session.attribute" cache-on-match="false">
+
+  Example 2: do cache only when there is no session attribute
+  <constraint-field name="UID" scope="session.attribute" 
+                    cache-on-match-failure="false">
+-->
+<!ELEMENT constraint-field (constraint-field-value*)>
+<!ATTLIST constraint-field  name                    CDATA      #REQUIRED
+                            scope                   %scope;    'request.parameter'
+                            cache-on-match          %boolean;  'true'
+                            cache-on-match-failure  %boolean;  'false'>
+
+<!-- 
+value element specifies the applicable value and a matching expression for a constraint-field
+  match-expr            Expression used to match the value. Default is 'equals'.
+
+  Example 1: cache when the category matches with any value other than a specific value
+  <constraint-field name="category" scope="request.parameter>
+    <value match-expr="equals" cache-on-match-failure="true">
+         bogus
+    </value>
+  </constraint-field>
+-->
+<!ELEMENT constraint-field-value (#PCDATA)>
+<!ATTLIST constraint-field-value 	match-expr              %expr;    'equals'
+                			cache-on-match          %boolean;  'true'
+                			cache-on-match-failure  %boolean;  'false'>
+
+<!--
+  The class-loader element allows developers to customize the behaviour
+  of their web application's classloader.
+
+  attributes
+    extra-class-path          List of comma-separated JAR files to be
+                              added to the web application's class path
+    delegate                  If set to false, the delegation behavior
+                              of the web application's classloader complies
+                              with the Servlet 2.3 specification,
+                              section 9.7.2, and gives preference to classes
+                              and resources within the WAR file or the
+                              extra-class-path over those higher up in the
+                              classloader hierarchy, unless those classes or
+                              resources are part of the Jakarta EE platform.
+                              If set to its default value of true, classes
+                              and resources residing in container-wide library
+                              JAR files are loaded in preference to classes
+                              and resources packaged within the WAR file or
+                              specified on the extra-class-path.
+    dynamic-reload-interval   Not supported. Included for backward
+                              compatibility with previous Sun Java System
+                              Web Server versions
+-->
+<!ELEMENT class-loader (property*)>
+<!ATTLIST class-loader extra-class-path CDATA  #IMPLIED
+                       delegate %boolean; 'true'
+                       dynamic-reload-interval CDATA #IMPLIED >
+
+<!ELEMENT jsp-config (property*)>
+
+<!ELEMENT locale-charset-info (locale-charset-map+, parameter-encoding?)>
+<!ATTLIST locale-charset-info default-locale CDATA #IMPLIED>
+
+<!ELEMENT locale-charset-map (description?)>
+<!ATTLIST locale-charset-map locale  CDATA  #REQUIRED
+                             agent   CDATA  #IMPLIED
+                             charset CDATA  #REQUIRED>
+
+<!ELEMENT parameter-encoding EMPTY>
+<!ATTLIST parameter-encoding form-hint-field CDATA #IMPLIED
+			     default-charset CDATA #IMPLIED>
+
+<!-- 
+Syntax for supplying properties as name value pairs 
+-->
+<!ELEMENT property (description?)>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!--
+This text nodes holds a value string.
+-->
+<!ELEMENT value (#PCDATA)>
+
+<!ELEMENT valve (description?, property*)>
+<!ATTLIST valve name        CDATA  #REQUIRED
+                class-name  CDATA  #REQUIRED>
+
+<!--
+  					W E B   S E R V I C E S 
+-->
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+<!ELEMENT service-ref ( service-ref-name, port-info*, call-property*, wsdl-override?, service-impl-class?, service-qname? )>
+
+<!--
+Coded name (relative to java:comp/env) for a service-reference
+-->
+<!ELEMENT service-ref-name ( #PCDATA )>
+
+<!-- 
+Information for a port within a service-reference.
+
+Either service-endpoint-interface or wsdl-port or both
+(service-endpoint-interface and wsdl-port) should be specified.  
+
+If both are specified, wsdl-port represents the
+port the container should choose for container-managed port selection.
+
+The same wsdl-port value must not appear in
+more than one port-info entry within the same service-ref.
+
+If a particular service-endpoint-interface is using container-managed port
+selection, it must not appear in more than one port-info entry
+within the same service-ref.
+
+The optional message-security-binding element is used to customize the
+port to provider binding; either by binding the port to a specific provider
+or by providing a definition of the message security requirements to be
+enforced by the provider.
+
+-->
+<!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+<!--
+Fully qualified name of service endpoint interface
+-->
+<!ELEMENT service-endpoint-interface ( #PCDATA )>
+<!-- 
+Port used in port-info.  
+-->
+<!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+<!-- 
+JAXRPC property values that should be set on a stub before it's returned to 
+to the web service client.  The property names can be any properties supported
+by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+-->
+<!ELEMENT stub-property ( name, value )>
+
+<!-- 
+JAXRPC property values that should be set on a Call object before it's 
+returned to the web service client.  The property names can be any 
+properties supported by the JAXRPC Call implementation.  See javadoc
+for javax.xml.rpc.Call
+-->
+<!ELEMENT call-property ( name, value )>
+
+<!--
+This is a valid URL pointing to a final WSDL document. It is optional.
+If specified, the WSDL document at this URL will be used during
+deployment instead of the WSDL document associated with the
+service-ref in the standard deployment descriptor.
+
+Examples :
+
+  // available via HTTP
+  <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+  // in a file
+  <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+-->
+<!ELEMENT wsdl-override ( #PCDATA )>
+
+<!--
+Name of generated service implementation class. This is not set by the 
+deployer. It is derived during deployment.
+-->
+<!ELEMENT service-impl-class ( #PCDATA )>
+
+<!-- 
+The service-qname element declares the specific WSDL service
+element that is being refered to.  It is not set by the deployer.
+It is derived during deployment.
+-->
+<!ELEMENT service-qname (namespaceURI, localpart)>
+
+<!-- 
+Runtime information about a web service.  
+
+wsdl-publish-location is optionally used to specify 
+where the final wsdl and any dependent files should be stored.  This location
+resides on the file system from which deployment is initiated.
+
+-->
+<!ELEMENT webservice-description ( webservice-description-name, wsdl-publish-location? )>
+
+<!--
+Unique name of a webservice within a module
+-->
+<!ELEMENT webservice-description-name ( #PCDATA )>
+
+<!--
+file: URL of a directory to which a web-service-description's wsdl should be
+published during deployment.  Any required files will be published to this
+directory, preserving their location relative to the module-specific
+wsdl directory(META-INF/wsdl or WEB-INF/wsdl).
+
+Example :
+
+  For an ejb.jar whose webservices.xml wsdl-file element contains
+    META-INF/wsdl/a/Foo.wsdl 
+
+  <wsdl-publish-location>file:/home/user1/publish
+  </wsdl-publish-location>
+
+  The final wsdl will be stored in /home/user1/publish/a/Foo.wsdl
+
+-->
+<!ELEMENT wsdl-publish-location ( #PCDATA )>
+
+<!--
+Information about a web service endpoint.  
+
+The optional message-security-binding element is used to customize the
+webservice-endpoint to provider binding; either by binding the
+webservice-endpoint to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+When login-config is specified, a default message-security provider
+is not applied to the endpoint.
+-->
+<!ELEMENT webservice-endpoint ( port-component-name, endpoint-address-uri?, (login-config | message-security-binding)?, transport-guarantee?, service-qname?, tie-class?, servlet-impl-class?, debugging-enabled? )>
+
+<!--
+Unique name of a port component within a module
+-->
+<!ELEMENT port-component-name ( #PCDATA )>
+
+<!--
+Relative path combined with web server root to form fully qualified
+endpoint address for a web service endpoint.  For servlet endpoints, this
+value is relative to the servlet's web application context root.  In
+all cases, this value must be a fixed pattern(i.e. no "*" allowed).
+If the web service endpoint is a servlet that only implements a single
+endpoint has only one url-pattern, it is not necessary to set 
+this value since the container can derive it from web.xml.
+-->
+<!ELEMENT endpoint-address-uri ( #PCDATA )>
+
+<!--
+The name of tie implementation class for a port-component.  This is
+not specified by the deployer.  It is derived during deployment.
+-->
+<!ELEMENT tie-class (#PCDATA)>
+
+<!-- 
+Optional authentication configuration for an EJB web service endpoint.
+Not needed for servet web service endpoints.  Their security configuration
+is contained in the standard web application descriptor.
+-->
+<!ELEMENT login-config ( auth-method )>
+
+<!--
+The auth-method element is used to configure the authentication
+mechanism for the web application. As a prerequisite to gaining access
+to any web resources which are protected by an authorization
+constraint, a user must have authenticated using the configured
+mechanism.
+-->
+
+<!ELEMENT auth-method (#PCDATA)>
+
+<!--
+Name of application-written servlet impl class contained in deployed war.
+This is not set by the deployer.  It is derived by the container
+during deployment.
+-->
+<!ELEMENT servlet-impl-class (#PCDATA)>
+
+<!--
+Specify whether or not the debugging servlet should be enabled for this 
+Web Service endpoint. 
+
+Supported values : "true" to debug the endpoint
+-->
+<!ELEMENT debugging-enabled (#PCDATA)>
+
+<!--
+The transport-guarantee element specifies that the communication
+between client and server should be NONE, INTEGRAL, or
+CONFIDENTIAL. NONE means that the application does not require any
+transport guarantees. A value of INTEGRAL means that the application
+requires that the data sent between the client and server be sent in
+such a way that it can't be changed in transit. CONFIDENTIAL means
+that the application requires that the data be transmitted in a
+fashion that prevents other entities from observing the contents of
+the transmission. In most cases, the presence of the INTEGRAL or
+CONFIDENTIAL flag will indicate that the use of SSL is required.
+-->
+
+<!ELEMENT transport-guarantee (#PCDATA)>
+
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+
+<!--
+The localpart element indicates the local part of a QNAME.
+-->
+<!ELEMENT localpart (#PCDATA)>
+
+<!--
+The namespaceURI element indicates a URI.
+-->
+<!ELEMENT namespaceURI (#PCDATA)>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-binding elements.
+
+Used in: message-security-binding
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-binding element is used to customize the
+webservice-endpoint or port to provider binding; either by binding the
+webservice-endpoint or port to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+These elements are typically NOT created as a result of the
+deployment of an application. They need only be created when the
+deployer or system administrator chooses to customize the 
+webservice-endpoint or port to provider binding.
+
+The optional (repeating) message-security sub-element is used 
+to accomplish the latter; in which case the specified 
+message-security requirements override any defined with the
+provider.
+
+The auth-layer attribute identifies the message layer at which the
+message-security requirements are to be enforced.
+
+The optional provider-id attribute identifies the provider-config 
+and thus the authentication provider that is to be used to satisfy 
+the application specific message security requirements. If a value for 
+the provider-id attribute is not specified, and a default
+provider is defined for the message layer, then it is used. 
+if a value for the provider-id attribute is not specified, and a
+default provider is not defined at the layer, the authentication
+requirements defined in the message-security-binding are not
+enforced. 
+ 
+Default:
+Used in: webservice-endpoint, port-info
+-->
+<!ELEMENT message-security-binding ( message-security* )>
+<!ATTLIST message-security-binding
+          auth-layer  %message-layer; #REQUIRED
+          provider-id CDATA           #IMPLIED >
+
+<!--
+The message-security element describes message security requirements
+that pertain to the request and response messages of the containing 
+endpoint, or port
+
+When contained within a webservice-endpoint this element describes 
+the message security requirements that pertain to the request and 
+response messages of the containing endpoint. When contained within a 
+port-info of a service-ref this element describes the message security
+requirements of the port of the referenced service.
+
+The one or more contained message elements define the methods or operations
+of the containing application, endpoint, or referenced service to which 
+the message security requirements apply.
+
+Multiple message-security elements occur within a containing
+element when it is necessary to define different message
+security requirements for different messages within the encompassing
+context. In such circumstances, the peer elements should not overlap
+in the messages they pertain to. If there is any overlap in the
+identified messages, no message security requirements apply to
+the messages for which more than one message-security element apply.
+
+Also, no message security requirements apply to any messages of
+the encompassing context that are not identified by a message element. 
+ 
+Default:
+Used in: webservice-endpoint, and port-info
+-->
+<!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+<!--
+The message element identifies the methods or operations to which
+the message security requirements apply.
+
+The identified methods or operations are methods or operations of
+the resource identified by the context in which the message-security
+element is defined (e.g. the the resource identified by the
+service-qname of the containing webservice-endpoint or service-ref).
+
+An empty message element indicates that the security requirements
+apply to all the methods or operations of the identified resource.
+
+When operation-name is specified, the security
+requirements defined in the containing message-security 
+element apply to all the operations of the endpoint 
+with the specified (and potentially overloaded) operation name.
+
+Default: 
+Used in: message-security
+-->
+<!ELEMENT message ( java-method? | operation-name? )>
+
+<!--
+The java-method element is used to identify a method (or methods
+in the case of an overloaded method-name) of the java class 
+indicated by the context in which the java-method is contained.
+
+Default: 
+Used in: message
+-->
+<!ELEMENT java-method ( method-name, method-params? )>
+
+<!--
+The operation-name element is used to identify the WSDL name of an
+operation of a web service.
+
+Default: 
+Used in: message
+-->
+<!ELEMENT operation-name ( #PCDATA )>
+
+<!--
+The request-protection element describes the authentication requirements
+that apply to a request.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent request-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default: 
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * request-protection ( content-auth-policy* )
+ *
+ * If the request-protection element contains one or more
+ * content-auth-policy sub-elements, they define the authentication
+ * requirements to be applied to the identified request content. If multiple
+ * content-auth-policy sub-elements are defined, a request sender must
+ * satisfy the requirements independently, and in the specified order.  
+ *
+ * The content-auth-policy element would be used to associate authentication
+ * requirements with the parts of the request or response object identified
+ * by the contained method-params or part-name-list sub-elements.
+ *
+ * The content-auth-policy element would be defined as follows:
+ * 
+ * content-auth-policy ( method-params | part-name-list )
+ * ATTLIST content-auth-policy 
+ *         auth-source (sender | content) #IMPLIED
+ *	   auth-recipient (before-content | after-content) #IMPLIED
+ * 
+ * The part-name-list and part-name elements would be defined as follows:
+ *
+ * part-name-list ( part-name* )
+ * part-name ( #PCDATA )
+ *
+-->
+<!ELEMENT request-protection EMPTY >
+<!ATTLIST request-protection
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The response-protection element describes the authentication requirements
+that apply to a response.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent response-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default: 
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * response-protection ( content-auth-policy* )
+ *
+ * see request-protection element for more details
+ *
+-->
+<!ELEMENT response-protection EMPTY >
+<!ATTLIST response-protection
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The method-name element contains the name of a service method of a web service
+implementation class.
+
+Used in: java-method
+-->
+<!ELEMENT method-name (#PCDATA)>
+<!--
+The method-params element contains a list of the fully-qualified Java
+type names of the method parameters.
+
+Used in: java-method
+-->
+<!ELEMENT method-params (method-param*)>
+
+<!--
+The method-param element contains the fully-qualified Java type name
+of a method parameter.
+
+Used in: method-params
+-->
+<!ELEMENT method-param (#PCDATA)>
+
+<!--
+Payara flag to include / exclude specific JARs for CDI scanning inside EAR files
+-->
+<!ELEMENT scanning-exclude (#PCDATA)>
+<!ELEMENT scanning-include (#PCDATA)>
+
+<!--
+Payara flag to enable / specify whitelist for extreme ClassLoader isolation
+-->
+<!ELEMENT whitelist-package (#PCDATA)>
+
+<!--
+Payara element to ignore the default support for the RolesAllowed annotation on JAX-RS resources.
+When this is disabled, RolesAllowed can still be activated by other means, e.g. by the Jersey
+specific method. 
+-->
+<!ELEMENT jaxrs-roles-allowed-enabled (#PCDATA)>
+
+<!--
+The keep-state element indicates whether the state information should be
+preserved across redeployment.
+-->
+<!ELEMENT keep-state (#PCDATA)>
+
+<!--
+The version-identifier element contains the version information. The value is
+ retrieved at deployment.
+-->
+<!ELEMENT version-identifier (#PCDATA)>
+
+<!--
+Payara element to ignore servlet initializers
+-->
+<!ELEMENT container-initializer-enabled (#PCDATA)>

--- a/appserver/ejb/ejb-container/src/main/java/fish/payara/ejb/deployment/node/runtime/PayaraEjbBundleRuntimeNode.java
+++ b/appserver/ejb/ejb-container/src/main/java/fish/payara/ejb/deployment/node/runtime/PayaraEjbBundleRuntimeNode.java
@@ -71,12 +71,12 @@ public class PayaraEjbBundleRuntimeNode extends EjbBundleRuntimeNode {
 
     @Override
     public String getDocType() {
-        return DTDRegistry.PAYARA_EJBJAR_400_DTD_PUBLIC_ID;
+        return DTDRegistry.PAYARA7_EJBJAR_401_DTD_PUBLIC_ID;
     }
 
     @Override
     public String getSystemID() {
-        return DTDRegistry.PAYARA_EJBJAR_400_DTD_SYSTEM_ID;
+        return DTDRegistry.PAYARA7_EJBJAR_401_DTD_SYSTEM_ID;
     }
 
     /**
@@ -86,7 +86,9 @@ public class PayaraEjbBundleRuntimeNode extends EjbBundleRuntimeNode {
      * @return the doctype tag name
      */
     public static String registerBundle(Map publicIDToDTD) {
+        publicIDToDTD.put(DTDRegistry.PAYARA6_EJBJAR_400_DTD_PUBLIC_ID, DTDRegistry.PAYARA6_EJBJAR_400_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA_EJBJAR_400_DTD_PUBLIC_ID, DTDRegistry.PAYARA_EJBJAR_400_DTD_SYSTEM_ID);
+        publicIDToDTD.put(DTDRegistry.PAYARA7_EJBJAR_401_DTD_PUBLIC_ID, DTDRegistry.PAYARA7_EJBJAR_401_DTD_SYSTEM_ID);
         return RuntimeTagNames.PAYARA_EJB_RUNTIME_TAG;
     }
 }

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application-both.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application-both.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd">
+<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_11-0.dtd">
 <payara-application>
     <web>
         <!-- This aligns to the name of the WAR defined in the test itself -->

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application-both.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application-both.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application_11-0.dtd">
+<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd">
 <payara-application>
     <web>
         <!-- This aligns to the name of the WAR defined in the test itself -->

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd">
+<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara-application_11-0.dtd">
 <payara-application>
     <web>
         <!-- This aligns to the name of the WAR defined in the test itself -->

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara-application.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application_11-0.dtd">
+<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application_11-0.dtd">
 <payara-application>
     <web>
         <!-- This aligns to the name of the WAR defined in the test itself -->

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara6-application.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara6-application.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application_10-0.dtd">
+<payara-application>
+    <web>
+        <!-- This aligns to the name of the WAR defined in the test itself -->
+        <web-uri>helloworld.war</web-uri>
+        <context-root>/adios</context-root>
+    </web>
+</payara-application>

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara6-application.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara6-application.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-6/content_shared/appendix/schemas/payara6-application_10-0.dtd">
+<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application_10-0.dtd">
 <payara-application>
     <web>
         <!-- This aligns to the name of the WAR defined in the test itself -->

--- a/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
+++ b/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
@@ -107,7 +107,7 @@ public class HelloWorldIT {
     }
 
     @Deployment(name = "helloPayara6")
-    public static EnterpriseArchive createPayaraApplicationDeployment() {
+    public static EnterpriseArchive createPayara6ApplicationDeployment() {
         return ShrinkWrap.create(EnterpriseArchive.class, "helloworld-payara6.ear")
                 .addAsManifestResource(new File("src/test/META-INF", "payara6-application.xml"),
                         "payara-application.xml")

--- a/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
+++ b/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
@@ -106,6 +106,16 @@ public class HelloWorldIT {
                         .addAsWebInfResource(new File("src/test/webapp/WEB-INF", "beans.xml")));
     }
 
+    @Deployment(name = "helloPayara6")
+    public static EnterpriseArchive createPayaraApplicationDeployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, "helloworld-payara6.ear")
+                .addAsManifestResource(new File("src/test/META-INF", "payara6-application.xml"),
+                        "payara-application.xml")
+                .addAsModule(ShrinkWrap.create(WebArchive.class, "helloworld.war")
+                        .addClasses(Resources.class, HelloWorld.class)
+                        .addAsWebInfResource(new File("src/test/webapp/WEB-INF", "beans.xml")));
+    }
+
     @Test
     @RunAsClient
     @OperateOnDeployment("helloPayara")
@@ -172,5 +182,22 @@ public class HelloWorldIT {
         Assert.assertEquals(200, response.getStatus());
         Assert.assertEquals("Hello World!", message);
         Assert.assertTrue(uri.getPath().equals("/helloworld/"));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("helloPayara6")
+    public void checkContextRootVersionPayaraApplicationXml() {
+        WebTarget target = ClientBuilder.newClient().target(uri).path("resources").path("hello");
+        Response response = target.request().get();
+
+        System.out.println("Context root should be \"adios\" as defined by the EAR's payara-application.xml, " +
+                "overriding the default context root of \"helloworld-payara6\" obtained from the EAR's name: " + uri.getPath());
+
+        String message = response.readEntity(String.class);
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals("Hello World!", message);
+        Assert.assertTrue(uri.getPath().equals("/adios/"));
     }
 }

--- a/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
+++ b/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
@@ -187,7 +187,7 @@ public class HelloWorldIT {
     @Test
     @RunAsClient
     @OperateOnDeployment("helloPayara6")
-    public void checkContextRootVersionPayaraApplicationXml() {
+    public void checkContextRootVersionPayara6ApplicationXml() {
         WebTarget target = ClientBuilder.newClient().target(uri).path("resources").path("hello");
         Response response = target.request().get();
 

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/main/webapp/WEB-INF/payara-ejb-jar.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/main/webapp/WEB-INF/payara-ejb-jar.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd">
+<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd">
 <payara-ejb-jar>
     <enterprise-beans>
         <ejb>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/main/webapp/WEB-INF/payara-ejb-jar.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/main/webapp/WEB-INF/payara-ejb-jar.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-ejb-jar_4_0-0.dtd">
+<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-ejb-jar_4_0-0.dtd">
 <payara-ejb-jar>
     <enterprise-beans>
         <ejb>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/main/webapp/WEB-INF/payara-ejb-jar.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/main/webapp/WEB-INF/payara-ejb-jar.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-ejb-jar_4_0-0.dtd">
+<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd">
 <payara-ejb-jar>
     <enterprise-beans>
         <ejb>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/main/webapp/WEB-INF/payara-ejb-jar.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/main/webapp/WEB-INF/payara-ejb-jar.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd">
+<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-ejb-jar_4_0-1.dtd">
 <payara-ejb-jar>
     <enterprise-beans>
         <ejb>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/test/resources/ForFailures/META-INF/payara-ejb-jar.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/test/resources/ForFailures/META-INF/payara-ejb-jar.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd">
+<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd">
 <payara-ejb-jar>
     <enterprise-beans>
         <ejb>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/test/resources/ForFailures/META-INF/payara-ejb-jar.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/test/resources/ForFailures/META-INF/payara-ejb-jar.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-ejb-jar_4_0-0.dtd">
+<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-ejb-jar_4_0-0.dtd">
 <payara-ejb-jar>
     <enterprise-beans>
         <ejb>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/test/resources/ForFailures/META-INF/payara-ejb-jar.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/test/resources/ForFailures/META-INF/payara-ejb-jar.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-ejb-jar_4_0-0.dtd">
+<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-ejb-jar_4_0-0.dtd">
 <payara-ejb-jar>
     <enterprise-beans>
         <ejb>

--- a/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/test/resources/ForFailures/META-INF/payara-ejb-jar.xml
+++ b/appserver/tests/payara-samples/samples/clustered-singleton/clustered-singleton-test/src/test/resources/ForFailures/META-INF/payara-ejb-jar.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-ejb-jar_4_0-1.dtd">
+<!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 7 EJB 4.0//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-ejb-jar_4_0-1.dtd">
 <payara-ejb-jar>
     <enterprise-beans>
         <ejb>

--- a/appserver/tests/payara-samples/samples/use-bundled-jsf-primefaces/src/main/webapp/WEB-INF/payara-web.xml
+++ b/appserver/tests/payara-samples/samples/use-bundled-jsf-primefaces/src/main/webapp/WEB-INF/payara-web.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd">
+<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd">
 <payara-web-app error-url="">
     <context-root>usebundledjsfsample</context-root>
     <class-loader delegate="false"/>

--- a/appserver/tests/payara-samples/samples/use-bundled-jsf-primefaces/src/main/webapp/WEB-INF/payara-web.xml
+++ b/appserver/tests/payara-samples/samples/use-bundled-jsf-primefaces/src/main/webapp/WEB-INF/payara-web.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-web-app_6_1-0.dtd">
+<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-web-app_6_1-0.dtd">
 <payara-web-app error-url="">
     <context-root>usebundledjsfsample</context-root>
     <class-loader delegate="false"/>

--- a/appserver/tests/payara-samples/samples/use-bundled-jsf-primefaces/src/main/webapp/WEB-INF/payara-web.xml
+++ b/appserver/tests/payara-samples/samples/use-bundled-jsf-primefaces/src/main/webapp/WEB-INF/payara-web.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd">
+<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd">
 <payara-web-app error-url="">
     <context-root>usebundledjsfsample</context-root>
     <class-loader delegate="false"/>

--- a/appserver/tests/payara-samples/samples/use-bundled-jsf-primefaces/src/main/webapp/WEB-INF/payara-web.xml
+++ b/appserver/tests/payara-samples/samples/use-bundled-jsf-primefaces/src/main/webapp/WEB-INF/payara-web.xml
@@ -38,7 +38,7 @@
      only if the new code is made subject to such option by the copyright
      holder.
 -->
-<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-web-app_6_1-0.dtd">
+<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-web-app_6_1-1.dtd">
 <payara-web-app error-url="">
     <context-root>usebundledjsfsample</context-root>
     <class-loader delegate="false"/>

--- a/appserver/tests/quicklook/ejb/mdb/metadata/payara-application-client.xml
+++ b/appserver/tests/quicklook/ejb/mdb/metadata/payara-application-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client_11-0.dtd">
+<!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd">
 <!--
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.

--- a/appserver/tests/quicklook/ejb/mdb/metadata/payara-application-client.xml
+++ b/appserver/tests/quicklook/ejb/mdb/metadata/payara-application-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Patch 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd">
+<!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd">
 <!--
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.

--- a/appserver/tests/quicklook/ejb/mdb/metadata/payara-application-client.xml
+++ b/appserver/tests/quicklook/ejb/mdb/metadata/payara-application-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN" "https://raw.githubusercontent.com/payara/Payara-Documentation/main-7/docs/modules/ROOT/pages/Appendix/Schemas/payara-application-client_11-0.dtd">
+<!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara-application-client_11-0.dtd">
 <!--
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.

--- a/appserver/tests/quicklook/ejb/mdb/metadata/payara-application-client.xml
+++ b/appserver/tests/quicklook/ejb/mdb/metadata/payara-application-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Revision 1//EN" "https://gitlab.azulsystems.com/docs/payara/-/raw/main-7/content_shared/appendix/schemas/payara7-application-client_11-1.dtd">
+<!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application Client 11 Revision 1//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd">
 <!--
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/node/runtime/gf/PayaraWebBundleRuntimeNode.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/node/runtime/gf/PayaraWebBundleRuntimeNode.java
@@ -42,10 +42,12 @@
  */
 package org.glassfish.web.deployment.node.runtime.gf;
 
+import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA7_WEBAPP_611_DTD_PUBLIC_ID;
+import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA7_WEBAPP_611_DTD_SYSTEM_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_4_DTD_PUBLIC_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_4_DTD_SYSTEM_ID;
-import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_600_DTD_PUBLIC_ID;
-import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_600_DTD_SYSTEM_ID;
+import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA6_WEBAPP_600_DTD_PUBLIC_ID;
+import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA6_WEBAPP_600_DTD_SYSTEM_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_610_DTD_PUBLIC_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_610_DTD_SYSTEM_ID;
 import static com.sun.enterprise.deployment.xml.RuntimeTagNames.PAYARA_WEB_RUNTIME_TAG;
@@ -79,12 +81,12 @@ public class PayaraWebBundleRuntimeNode extends GFWebBundleRuntimeNode {
 
     @Override
     public String getDocType() {
-        return PAYARA_WEBAPP_610_DTD_PUBLIC_ID;
+        return PAYARA7_WEBAPP_611_DTD_PUBLIC_ID;
     }
 
     @Override
     public String getSystemID() {
-        return PAYARA_WEBAPP_610_DTD_SYSTEM_ID;
+        return PAYARA7_WEBAPP_611_DTD_SYSTEM_ID;
     }
 
     /**
@@ -96,8 +98,9 @@ public class PayaraWebBundleRuntimeNode extends GFWebBundleRuntimeNode {
      */
     public static String registerBundle(Map<String, String> publicIDToDTD, Map<String, List<Class<?>>> versionUpgrades) {
         publicIDToDTD.put(PAYARA_WEBAPP_4_DTD_PUBLIC_ID, PAYARA_WEBAPP_4_DTD_SYSTEM_ID);
-        publicIDToDTD.put(PAYARA_WEBAPP_600_DTD_PUBLIC_ID, PAYARA_WEBAPP_600_DTD_SYSTEM_ID);
+        publicIDToDTD.put(PAYARA6_WEBAPP_600_DTD_PUBLIC_ID, PAYARA6_WEBAPP_600_DTD_SYSTEM_ID);
         publicIDToDTD.put(PAYARA_WEBAPP_610_DTD_PUBLIC_ID, PAYARA_WEBAPP_610_DTD_SYSTEM_ID);
+        publicIDToDTD.put(PAYARA7_WEBAPP_611_DTD_PUBLIC_ID, PAYARA7_WEBAPP_611_DTD_SYSTEM_ID);
 
         return PAYARA_WEB_RUNTIME_TAG;
     }

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/node/runtime/gf/PayaraWebBundleRuntimeNode.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/node/runtime/gf/PayaraWebBundleRuntimeNode.java
@@ -44,6 +44,8 @@ package org.glassfish.web.deployment.node.runtime.gf;
 
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_4_DTD_PUBLIC_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_4_DTD_SYSTEM_ID;
+import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_600_DTD_PUBLIC_ID;
+import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_600_DTD_SYSTEM_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_610_DTD_PUBLIC_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_610_DTD_SYSTEM_ID;
 import static com.sun.enterprise.deployment.xml.RuntimeTagNames.PAYARA_WEB_RUNTIME_TAG;
@@ -94,6 +96,7 @@ public class PayaraWebBundleRuntimeNode extends GFWebBundleRuntimeNode {
      */
     public static String registerBundle(Map<String, String> publicIDToDTD, Map<String, List<Class<?>>> versionUpgrades) {
         publicIDToDTD.put(PAYARA_WEBAPP_4_DTD_PUBLIC_ID, PAYARA_WEBAPP_4_DTD_SYSTEM_ID);
+        publicIDToDTD.put(PAYARA_WEBAPP_600_DTD_PUBLIC_ID, PAYARA_WEBAPP_600_DTD_SYSTEM_ID);
         publicIDToDTD.put(PAYARA_WEBAPP_610_DTD_PUBLIC_ID, PAYARA_WEBAPP_610_DTD_SYSTEM_ID);
 
         return PAYARA_WEB_RUNTIME_TAG;


### PR DESCRIPTION
## Description
Follow-up to https://github.com/payara/Payara/pull/8125
In a similar vein to what was added in that PR, we have added Payara 6 deployment descriptors.

This PR "forward-ports" support for these older descriptors.

This PR also adjusts the raw.githubusercontent URLs in those descriptors to the new docs location in GitLab.

## Important Info
### Blockers
https://github.com/payara/Payara-Enterprise/pull/3084/

These PRs now block each other - they must be merged together

## Testing
### New tests
Extended the payara-application-xml functional test to check the Payara 6 application XML is still valid

### Testing Performed
Jenkins test please

### Testing Environment
Jenkins

## Documentation
https://gitlab.azulsystems.com/docs/payara/-/merge_requests/1

## Notes for Reviewers
See comments
