### PR TITLE
FISH-9573 Use JUL for Access Logs to Console

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
@@ -59,7 +59,6 @@ import org.glassfish.web.LogFacade;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -74,7 +73,6 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.glassfish.internal.api.LogManager;
 
 /**
  * <p>Implementation of the <b>Valve</b> interface that generates a web server
@@ -97,7 +95,6 @@ public final class PEAccessLogValve
     private static final Logger _logger = LogFacade.getLogger();
 
     private static final ResourceBundle _resourceBundle = _logger.getResourceBundle();
-    private final LogManager logManager = org.glassfish.internal.api.Globals.get(LogManager.class);
 
     // Predefined patterns
     private static final String COMMON_PATTERN = "common";
@@ -649,9 +646,12 @@ public final class PEAccessLogValve
             try{
                 charBuffer.flip();
                 String bufString = charBuffer.toString();
-                if (accessLogToConsole && !bufString.isEmpty()) {
-                    PrintStream outStream = logManager != null ? logManager.getOutStream() : System.out;
-                    outStream.print(bufString.replaceAll("(?m)^", "AccessLog: "));
+                if (accessLogToConsole && !bufString.isEmpty() && _logger.isLoggable(Level.INFO)) {
+                    for (String line : bufString.split("\n")) {
+                        if (!line.isEmpty()) {
+                            _logger.info("AccessLog: " + line);
+                        }
+                    }
                 }
                 ByteBuffer byteBuffer =
                     ByteBuffer.wrap(bufString.getBytes(Charset.defaultCharset()));


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This PR changes the behaviour of how access logs are printed to the console, previously access logs were written directly to the stream bypassing JUL, this PR stops that and outputs the access logs to the console via JUL  and prints each access log individually. 
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Create prebootfile with 'set configs.config.server-config.http-service.access-log.log-to-console-enabled=true'
Started Payara Micro with: 
```
java -jar payara-micro.jar --prebootcommandfile prebootfile.txt --accesslog /Users/kalinchan/workspace/Payara/appserver/extras/payara-micro/payara-micro-distribution/target --accessloginterval 1 --deploy ~/Documents/clusterjsp.war
```
Visted clusterjsp and verified access log formatting in console/
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.11, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.11-zulu
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "26.5.2", arch: "aarch64", family: "mac"
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a