### PR TITLE
FISH-14030 FISH-14031: Duration metering for JAX-WS server, Context propagation for JAX-WS client

### DIFF
--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/InMemoryMetricExporter.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/InMemoryMetricExporter.java
@@ -1,0 +1,140 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.jaxws.test.otel;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class InMemoryMetricExporter implements MetricExporter {
+
+    private volatile boolean stopped;
+    private final List<MetricData> exported = new ArrayList<>();
+    private final AtomicInteger batches = new AtomicInteger(0);
+
+    @Inject
+    @ConfigProperty(name = "otel.metric.export.interval", defaultValue = "100")
+    long exportIntervalMs;
+
+    public void reset() {
+        synchronized (exported) {
+            exported.clear();
+            batches.set(0);
+        }
+    }
+
+    /**
+     * Returns all collected {@link HistogramPointData} for a given metric name,
+     * waiting up to 3 seconds for at least one export batch to arrive.
+     */
+    public List<HistogramPointData> getHistogramPoints(String metricName) {
+        waitForExport();
+        synchronized (exported) {
+            return exported.stream()
+                    .filter(m -> metricName.equals(m.getName()))
+                    .flatMap(m -> m.getHistogramData().getPoints().stream())
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private void waitForExport() {
+        int gen = batches.get();
+        long deadline = System.currentTimeMillis() + 3000;
+        while (batches.get() == gen && System.currentTimeMillis() < deadline) {
+            try { Thread.sleep(10); } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted waiting for metric export", e);
+            }
+        }
+        // Sleep one more export cycle to catch any trailing data — do NOT loop here because
+        // other metrics (JVM, Hazelcast) are exported continuously and would cause an infinite loop.
+        try { Thread.sleep(exportIntervalMs * 2); } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted waiting for metric export", e);
+        }
+    }
+
+    @Override
+    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+        return AggregationTemporality.DELTA;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<MetricData> metrics) {
+        if (stopped) return CompletableResultCode.ofFailure();
+        synchronized (exported) {
+            exported.addAll(metrics);
+            batches.incrementAndGet();
+        }
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override public CompletableResultCode flush() { return CompletableResultCode.ofSuccess(); }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        stopped = true;
+        return CompletableResultCode.ofSuccess();
+    }
+
+    public static class Provider implements ConfigurableMetricExporterProvider {
+        @Override
+        public MetricExporter createExporter(ConfigProperties c) {
+            return CDI.current().select(InMemoryMetricExporter.class).get();
+        }
+        @Override public String getName() { return "in-memory-jaxws"; }
+    }
+}

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JAXWSEjbEndPointService.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JAXWSEjbEndPointService.java
@@ -1,0 +1,85 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single license of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.samples.jaxws.test.otel;
+
+import fish.payara.samples.jaxws.endpoint.ejb.JAXWSEndPointInterface;
+
+import javax.xml.namespace.QName;
+import jakarta.xml.ws.Service;
+import jakarta.xml.ws.WebEndpoint;
+import jakarta.xml.ws.WebServiceClient;
+import jakarta.xml.ws.WebServiceFeature;
+import java.net.URL;
+
+/**
+ * Hand-written JAX-WS service client for the EJB-based JAX-WS endpoint.
+ *
+ * <p>This follows the same pattern as a {@code wsimport}-generated service class:
+ * it extends {@link Service} and exposes a typed {@link WebEndpoint} method so that
+ * container-managed {@code @WebServiceRef} injection can work without needing an
+ * external WSDL tool at build time.</p>
+ */
+@WebServiceClient(
+        name = "JAXWSEndPointImplementationService",
+        targetNamespace = "http://ejb.endpoint.jaxws.samples.payara.fish/",
+        wsdlLocation = "http://localhost:8080/JAXWSEndPointImplementationService/JAXWSEndPointImplementation?wsdl")
+public class JAXWSEjbEndPointService extends Service {
+
+    private static final QName SERVICE_QNAME = new QName(
+            "http://ejb.endpoint.jaxws.samples.payara.fish/",
+            "JAXWSEndPointImplementationService");
+
+    public JAXWSEjbEndPointService(URL wsdlLocation) {
+        super(wsdlLocation, SERVICE_QNAME);
+    }
+
+    public JAXWSEjbEndPointService(URL wsdlLocation, QName serviceName) {
+        super(wsdlLocation, serviceName);
+    }
+
+    public JAXWSEjbEndPointService(URL wsdlLocation, WebServiceFeature... features) {
+        super(wsdlLocation, SERVICE_QNAME, features);
+    }
+
+    @WebEndpoint(name = "JAXWSEndPointImplementationPort")
+    public JAXWSEndPointInterface getPort() {
+        return super.getPort(JAXWSEndPointInterface.class);
+    }
+}

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JaxWsOtelConfigSource.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JaxWsOtelConfigSource.java
@@ -49,7 +49,10 @@ public class JaxWsOtelConfigSource implements ConfigSource {
     private static final Map<String, String> PROPS = Map.of(
             "otel.sdk.disabled", "false",
             "otel.traces.exporter", "in-memory-jaxws",
-            "otel.bsp.schedule.delay", "10"
+            "otel.bsp.schedule.delay", "10",
+            "otel.metrics.exporter", "in-memory-jaxws",
+            "otel.metric.export.interval", "100",
+            "otel.logs.exporter", "none"
     );
 
     @Override public Map<String, String> getProperties() { return PROPS; }

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JaxWsRefClientBean.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JaxWsRefClientBean.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2010 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -16,8 +16,8 @@
  * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
  *
  * GPL Classpath Exception:
- * Oracle designates this particular file as subject to the "Classpath"
- * exception as provided by Oracle in the GPL Version 2 section of the License
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
  * file that accompanied this code.
  *
  * Modifications:
@@ -29,7 +29,7 @@
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding "[Contributor]
  * elects to include this software in this distribution under the [CDDL or GPL
- * Version 2] license."  If you don't indicate a single choice of license, a
+ * Version 2] license."  If you don't indicate a single license of license, a
  * recipient has the option to distribute your version of this file under
  * either the CDDL, the GPL Version 2 or to extend the choice of license to
  * its licensees as provided above.  However, if you add GPL Version 2 code
@@ -37,39 +37,32 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2022-2026] [Payara Foundation and/or its affiliates]
+package fish.payara.samples.jaxws.test.otel;
 
-package org.glassfish.webservices;
+import fish.payara.samples.jaxws.endpoint.ejb.JAXWSEndPointInterface;
+import jakarta.ejb.Stateless;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.WebServiceRef;
 
-import com.sun.xml.ws.api.server.Container;
-import com.sun.xml.ws.api.client.ServiceInterceptor;
+import java.util.Map;
 
-import com.sun.enterprise.deployment.ServiceReferenceDescriptor;
-import org.glassfish.internal.api.Globals;
+/**
+ * Stateless EJB that receives a JAX-WS client port via {@code @WebServiceRef} injection
+ * and overrides the endpoint address at runtime via {@link BindingProvider#ENDPOINT_ADDRESS_PROPERTY}.
+ *
+ * <p>This is the canonical Jakarta EE pattern for consuming a JAX-WS service whose
+ * URL is not known at deployment time (e.g. changes per environment).</p>
+ */
+@Stateless
+public class JaxWsRefClientBean {
 
-public class WSClientContainer extends Container {
+    @WebServiceRef(wsdlLocation = "http://localhost:8080/JAXWSEndPointImplementationService/JAXWSEndPointImplementation?wsdl")
+    JAXWSEjbEndPointService service;
 
-    ServiceReferenceDescriptor svcRef;
-    private org.glassfish.webservices.SecurityService  secServ;
-
-    public WSClientContainer(ServiceReferenceDescriptor ref) {
-        svcRef = ref;
-        if (Globals.getDefaultHabitat() != null) {
-            secServ = Globals.get(org.glassfish.webservices.SecurityService.class);
-        }
+    public String callEndpoint(String endpointAddress, String name) {
+        JAXWSEndPointInterface port = service.getPort();
+        Map<String, Object> context = ((BindingProvider) port).getRequestContext();
+        context.put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, endpointAddress);
+        return port.sayHi(name);
     }
-
-    public <T> T getSPI(Class<T> spiType) {
-
-        if (spiType == com.sun.xml.ws.assembler.metro.dev.ClientPipelineHook.class) {
-            if (secServ != null) {
-                return((T)(secServ.getClientPipelineHook(svcRef)));
-            }
-        }
-        if(spiType == ServiceInterceptor.class) {
-            return (T) ServiceInterceptor.aggregate(new PortCreationCallbackImpl(svcRef), WSContainerResolver.otelInterceptor());
-        }
-        return null;
-    }
-
 }

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JaxWsSpanIT.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JaxWsSpanIT.java
@@ -44,7 +44,9 @@ import fish.payara.samples.jaxws.endpoint.ejb.JAXWSEndPointImplementation;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import io.opentelemetry.sdk.metrics.data.HistogramPointData;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -89,6 +91,9 @@ public class JaxWsSpanIT {
     @Inject
     private InMemorySpanExporter exporter;
 
+    @Inject
+    private InMemoryMetricExporter metricExporter;
+
     @Deployment
     public static WebArchive deploy() {
         return ShrinkWrap.create(WebArchive.class, "jaxws-span-it.war")
@@ -99,9 +104,12 @@ public class JaxWsSpanIT {
                 .addClasses(
                         InMemorySpanExporter.class,
                         InMemorySpanExporter.Provider.class,
+                        InMemoryMetricExporter.class,
+                        InMemoryMetricExporter.Provider.class,
                         JaxWsOtelConfigSource.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporter.Provider.class)
+                .addAsServiceProvider(ConfigurableMetricExporterProvider.class, InMemoryMetricExporter.Provider.class)
                 .addAsServiceProvider(ConfigSource.class, JaxWsOtelConfigSource.class)
                 .addAsLibraries(
                         Maven.resolver()
@@ -114,6 +122,7 @@ public class JaxWsSpanIT {
     @Before
     public void reset() {
         exporter.reset();
+        metricExporter.reset();
     }
 
     // -------------------------------------------------------------------------
@@ -228,6 +237,46 @@ public class JaxWsSpanIT {
         assertThat(spans.stream().anyMatch(s -> s.getKind() == SpanKind.INTERNAL))
                 .describedAs("No INTERNAL child span should be created for JAX-WS methods")
                 .isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // http.server.request.duration histogram
+    // -------------------------------------------------------------------------
+
+    private static final String HTTP_SERVER_REQUEST_DURATION = "http.server.request.duration";
+
+    @Test
+    public void ejbEndpoint_httpDurationHistogramRecorded() throws Exception {
+        ejbEndpoint().sayHi("Payara");
+
+        // The JAX-WS client fetches the WSDL (GET) before the SOAP POST — filter to POST only.
+        HistogramPointData post = metricExporter.getHistogramPoints(HTTP_SERVER_REQUEST_DURATION).stream()
+                .filter(p -> "POST".equals(p.getAttributes().get(HTTP_REQUEST_METHOD)))
+                .findFirst().orElse(null);
+
+        assertThat(post)
+                .describedAs("EJB JAX-WS endpoint must emit an http.server.request.duration histogram point for POST")
+                .isNotNull();
+        assertThat(post.getSum())
+                .describedAs("Histogram duration must be positive")
+                .isGreaterThan(0.0);
+    }
+
+    @Test
+    public void servletEndpoint_httpDurationHistogramRecorded() throws Exception {
+        servletEndpoint().sayHi("Payara");
+
+        // The JAX-WS client fetches the WSDL (GET) before the SOAP POST — filter to POST only.
+        HistogramPointData post = metricExporter.getHistogramPoints(HTTP_SERVER_REQUEST_DURATION).stream()
+                .filter(p -> "POST".equals(p.getAttributes().get(HTTP_REQUEST_METHOD)))
+                .findFirst().orElse(null);
+
+        assertThat(post)
+                .describedAs("Servlet JAX-WS endpoint must emit an http.server.request.duration histogram point for POST")
+                .isNotNull();
+        assertThat(post.getSum())
+                .describedAs("Histogram duration must be positive")
+                .isGreaterThan(0.0);
     }
 
     // -------------------------------------------------------------------------

--- a/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JaxWsSpanIT.java
+++ b/appserver/tests/payara-samples/samples/jaxws-tracing/src/test/java/fish/payara/samples/jaxws/test/otel/JaxWsSpanIT.java
@@ -41,6 +41,7 @@ package fish.payara.samples.jaxws.test.otel;
 
 import fish.payara.samples.NotMicroCompatible;
 import fish.payara.samples.jaxws.endpoint.ejb.JAXWSEndPointImplementation;
+import jakarta.ejb.EJB;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
@@ -94,6 +95,9 @@ public class JaxWsSpanIT {
     @Inject
     private InMemoryMetricExporter metricExporter;
 
+    @EJB
+    private JaxWsRefClientBean refBean;
+
     @Deployment
     public static WebArchive deploy() {
         return ShrinkWrap.create(WebArchive.class, "jaxws-span-it.war")
@@ -106,7 +110,9 @@ public class JaxWsSpanIT {
                         InMemorySpanExporter.Provider.class,
                         InMemoryMetricExporter.class,
                         InMemoryMetricExporter.Provider.class,
-                        JaxWsOtelConfigSource.class)
+                        JaxWsOtelConfigSource.class,
+                        JAXWSEjbEndPointService.class,
+                        JaxWsRefClientBean.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsServiceProvider(ConfigurableSpanExporterProvider.class, InMemorySpanExporter.Provider.class)
                 .addAsServiceProvider(ConfigurableMetricExporterProvider.class, InMemoryMetricExporter.Provider.class)
@@ -240,6 +246,131 @@ public class JaxWsSpanIT {
     }
 
     // -------------------------------------------------------------------------
+    // Outbound JAX-WS client — CLIENT span and trace context propagation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void ejbEndpoint_clientSpanCreated() throws Exception {
+        ejbEndpoint().sayHi("Payara");
+
+        List<SpanData> spans = exporter.getSpans();
+        logSpans("ejbEndpoint_clientSpanCreated", spans);
+        SpanData client = findClient(spans);
+
+        assertThat(client)
+                .describedAs("Expected a CLIENT span for outbound JAX-WS call to EJB endpoint, got: %s", names(spans))
+                .isNotNull();
+        assertThat(client.getAttributes().get(HTTP_REQUEST_METHOD))
+                .describedAs("CLIENT span must have http.request.method=POST")
+                .isEqualTo("POST");
+    }
+
+    @Test
+    public void servletEndpoint_clientSpanCreated() throws Exception {
+        servletEndpoint().sayHi("Payara");
+
+        List<SpanData> spans = exporter.getSpans();
+        logSpans("servletEndpoint_clientSpanCreated", spans);
+        SpanData client = findClient(spans);
+
+        assertThat(client)
+                .describedAs("Expected a CLIENT span for outbound JAX-WS call to servlet endpoint, got: %s", names(spans))
+                .isNotNull();
+        assertThat(client.getAttributes().get(HTTP_REQUEST_METHOD))
+                .describedAs("CLIENT span must have http.request.method=POST")
+                .isEqualTo("POST");
+    }
+
+    @Test
+    public void ejbEndpoint_clientSpanPropagatesTraceContext() throws Exception {
+        ejbEndpoint().sayHi("Payara");
+
+        List<SpanData> spans = exporter.getSpans();
+        logSpans("ejbEndpoint_clientSpanPropagatesTraceContext", spans);
+        SpanData client = findClient(spans);
+        SpanData server = findServer(spans);
+
+        assertThat(client)
+                .describedAs("Expected a CLIENT span for outbound JAX-WS call, got: %s", names(spans))
+                .isNotNull();
+        assertThat(server)
+                .describedAs("Expected a SERVER span for EJB endpoint, got: %s", names(spans))
+                .isNotNull();
+        assertThat(client.getTraceId())
+                .describedAs("CLIENT and SERVER spans must share the same trace ID — W3C traceparent must be propagated")
+                .isEqualTo(server.getTraceId());
+        assertThat(server.getParentSpanId())
+                .describedAs("SERVER span's parent must be the CLIENT span")
+                .isEqualTo(client.getSpanId());
+    }
+
+    @Test
+    public void servletEndpoint_clientSpanPropagatesTraceContext() throws Exception {
+        servletEndpoint().sayHi("Payara");
+
+        List<SpanData> spans = exporter.getSpans();
+        logSpans("servletEndpoint_clientSpanPropagatesTraceContext", spans);
+        SpanData client = findClient(spans);
+        SpanData server = findServer(spans);
+
+        assertThat(client)
+                .describedAs("Expected a CLIENT span for outbound JAX-WS call, got: %s", names(spans))
+                .isNotNull();
+        assertThat(server)
+                .describedAs("Expected a SERVER span for servlet endpoint, got: %s", names(spans))
+                .isNotNull();
+        assertThat(client.getTraceId())
+                .describedAs("CLIENT and SERVER spans must share the same trace ID — W3C traceparent must be propagated")
+                .isEqualTo(server.getTraceId());
+        assertThat(server.getParentSpanId())
+                .describedAs("SERVER span's parent must be the CLIENT span")
+                .isEqualTo(client.getSpanId());
+    }
+
+    // -------------------------------------------------------------------------
+    // @WebServiceRef pattern — container-managed port, dynamic endpoint address
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void ejbEndpoint_webServiceRef_clientSpanCreated() throws Exception {
+        refBean.callEndpoint(ejbEndpointAddress(), "Payara");
+
+        List<SpanData> spans = exporter.getSpans();
+        logSpans("ejbEndpoint_webServiceRef_clientSpanCreated", spans);
+        SpanData client = findClient(spans);
+
+        assertThat(client)
+                .describedAs("Expected a CLIENT span for @WebServiceRef outbound JAX-WS call, got: %s", names(spans))
+                .isNotNull();
+        assertThat(client.getAttributes().get(HTTP_REQUEST_METHOD))
+                .describedAs("CLIENT span must have http.request.method=POST")
+                .isEqualTo("POST");
+    }
+
+    @Test
+    public void ejbEndpoint_webServiceRef_clientSpanPropagatesTraceContext() throws Exception {
+        refBean.callEndpoint(ejbEndpointAddress(), "Payara");
+
+        List<SpanData> spans = exporter.getSpans();
+        logSpans("ejbEndpoint_webServiceRef_clientSpanPropagatesTraceContext", spans);
+        SpanData client = findClient(spans);
+        SpanData server = findServer(spans);
+
+        assertThat(client)
+                .describedAs("Expected a CLIENT span for @WebServiceRef call, got: %s", names(spans))
+                .isNotNull();
+        assertThat(server)
+                .describedAs("Expected a SERVER span for EJB endpoint, got: %s", names(spans))
+                .isNotNull();
+        assertThat(client.getTraceId())
+                .describedAs("CLIENT and SERVER spans must share the same trace ID")
+                .isEqualTo(server.getTraceId());
+        assertThat(server.getParentSpanId())
+                .describedAs("SERVER span's parent must be the CLIENT span")
+                .isEqualTo(client.getSpanId());
+    }
+
+    // -------------------------------------------------------------------------
     // http.server.request.duration histogram
     // -------------------------------------------------------------------------
 
@@ -282,6 +413,11 @@ public class JaxWsSpanIT {
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private String ejbEndpointAddress() {
+        return baseUrl.getProtocol() + "://" + baseUrl.getHost() + ":" + baseUrl.getPort()
+                + "/JAXWSEndPointImplementationService/JAXWSEndPointImplementation";
+    }
 
     /** EJB endpoints are published at the server root (not under the WAR context path). */
     private fish.payara.samples.jaxws.endpoint.ejb.JAXWSEndPointInterface ejbEndpoint() throws Exception {
@@ -328,6 +464,14 @@ public class JaxWsSpanIT {
     private SpanData findServer(List<SpanData> spans) {
         return spans.stream()
                 .filter(s -> s.getKind() == SpanKind.SERVER)
+                .filter(s -> "POST".equals(s.getAttributes().get(HTTP_REQUEST_METHOD)))
+                .findFirst().orElse(null);
+    }
+
+    /** Finds the CLIENT span for an outbound SOAP POST request. */
+    private SpanData findClient(List<SpanData> spans) {
+        return spans.stream()
+                .filter(s -> s.getKind() == SpanKind.CLIENT)
                 .filter(s -> "POST".equals(s.getAttributes().get(HTTP_REQUEST_METHOD)))
                 .findFirst().orElse(null);
     }

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/EjbWebServiceServlet.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/EjbWebServiceServlet.java
@@ -53,9 +53,7 @@ import static org.glassfish.webservices.LogUtils.INVALID_REQUEST_SCHEME;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.logging.Logger;
 
 import jakarta.servlet.ServletException;
@@ -185,9 +183,9 @@ public class EjbWebServiceServlet extends HttpServlet {
 
         @Override
         public void afterDispatch(HttpServletResponse response) {
+            int status = response.getStatus();
             Span current = Span.current();
             if (current.isRecording()) {
-                int status = response.getStatus();
                 current.setAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, (long) status);
                 // SOAP faults are marked ERROR by JaxWsContainerRequestTelemetryTracingFilter.
                 // This covers non-SOAP error responses (e.g. 503 from the container).
@@ -195,19 +193,23 @@ public class EjbWebServiceServlet extends HttpServlet {
                     current.setStatus(StatusCode.ERROR);
                 }
             }
-            otelService.endDeferredSpan(null);
+            otelService.endDeferredSpanWithDuration(null, status);
         }
 
         @Override
         public void dispatchFailed(HttpServletResponse response, Throwable t) {
+            int status = response.getStatus();
+            // If the dispatcher threw before writing any status, default to 500.
+            if (status < 400) {
+                status = 500;
+            }
             Span current = Span.current();
             if (current.isRecording()) {
-                current.setAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE,
-                        (long) response.getStatus());
+                current.setAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, (long) status);
                 current.recordException(t);
                 current.setStatus(StatusCode.ERROR);
             }
-            otelService.endDeferredSpan(t);
+            otelService.endDeferredSpanWithDuration(t, status);
         }
     }
 

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/JaxWsClientTelemetryHandler.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/JaxWsClientTelemetryHandler.java
@@ -1,0 +1,187 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single license of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.webservices;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.xml.namespace.QName;
+
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.handler.soap.SOAPHandler;
+import jakarta.xml.ws.handler.soap.SOAPMessageContext;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.ServerAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+
+import fish.payara.opentracing.OpenTelemetryService;
+import fish.payara.opentracing.PropagationHelper;
+import org.glassfish.hk2.api.ServiceHandle;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.internal.api.Globals;
+
+/**
+ * Client-side JAX-WS SOAP handler that creates an OTel CLIENT span and injects
+ * W3C {@code traceparent}/{@code tracestate} headers into the outbound SOAP request.
+ */
+class JaxWsClientTelemetryHandler implements SOAPHandler<SOAPMessageContext> {
+
+    private static final String HELPER_KEY = PropagationHelper.class.getName() + ".jaxws-client";
+    private static final String PAYARA_SUBSYSTEM = "payara.subsystem";
+    private static final Logger LOGGER = Logger.getLogger(JaxWsClientTelemetryHandler.class.getName());
+
+    @Override
+    public boolean handleMessage(SOAPMessageContext context) {
+        if (Boolean.TRUE.equals(context.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))) {
+            startClientSpan(context);
+        } else {
+            finishClientSpan(context, false);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(SOAPMessageContext context) {
+        finishClientSpan(context, true);
+        return true;
+    }
+
+    @Override
+    public void close(MessageContext context) {
+        // Safety net: if the inbound handler never fired (e.g. transport error), end the span here.
+        PropagationHelper helper = (PropagationHelper) context.get(HELPER_KEY);
+        if (helper != null) {
+            helper.end();
+            helper.close();
+        }
+    }
+
+    @Override
+    public Set<QName> getHeaders() {
+        return Collections.emptySet();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void startClientSpan(SOAPMessageContext context) {
+        ServiceLocator locator = Globals.getDefaultBaseServiceLocator();
+        if (locator == null) {
+            return;
+        }
+        ServiceHandle<OpenTelemetryService> handle = locator.getServiceHandle(OpenTelemetryService.class);
+        if (handle == null || !handle.isActive() || !handle.getService().isEnabled()) {
+            return;
+        }
+        OpenTelemetryService otelService = handle.getService();
+
+        String endpointAddress = (String) context.get(BindingProvider.ENDPOINT_ADDRESS_PROPERTY);
+        URI uri = parseUri(endpointAddress);
+
+        var spanBuilder = otelService.getCurrentTracer()
+                .spanBuilder("POST")
+                .setSpanKind(SpanKind.CLIENT)
+                .setAttribute(HttpAttributes.HTTP_REQUEST_METHOD, "POST")
+                .setAttribute(PAYARA_SUBSYSTEM, "jakarta-xml-ws")
+                .setParent(Context.current());
+
+        if (uri != null) {
+            spanBuilder.setAttribute(UrlAttributes.URL_FULL, endpointAddress);
+            spanBuilder.setAttribute(ServerAttributes.SERVER_ADDRESS, uri.getHost());
+            if (uri.getPort() != -1) {
+                spanBuilder.setAttribute(ServerAttributes.SERVER_PORT, (long) uri.getPort());
+            }
+        }
+
+        Span span = spanBuilder.startSpan();
+        PropagationHelper helper = PropagationHelper.start(span, null);
+        context.put(HELPER_KEY, helper);
+        context.setScope(HELPER_KEY, MessageContext.Scope.HANDLER);
+
+        Map<String, List<String>> headers = (Map<String, List<String>>) context.get(MessageContext.HTTP_REQUEST_HEADERS);
+        if (headers == null) {
+            headers = new HashMap<>();
+            context.put(MessageContext.HTTP_REQUEST_HEADERS, headers);
+            context.setScope(MessageContext.HTTP_REQUEST_HEADERS, MessageContext.Scope.HANDLER);
+        }
+        Map<String, List<String>> outboundHeaders = headers;
+        otelService.getCurrentSdk().getPropagators().getTextMapPropagator().inject(
+                Context.current(),
+                outboundHeaders,
+                (carrier, key, value) -> carrier.put(key, List.of(value))
+        );
+    }
+
+    private void finishClientSpan(SOAPMessageContext context, boolean fault) {
+        PropagationHelper helper = (PropagationHelper) context.get(HELPER_KEY);
+        if (helper == null) {
+            return;
+        }
+        if (fault) {
+            helper.span().setStatus(StatusCode.ERROR, "SOAP Fault");
+        }
+        helper.end();
+        helper.close();
+        context.remove(HELPER_KEY);
+    }
+
+    private static URI parseUri(String address) {
+        if (address == null) {
+            return null;
+        }
+        try {
+            return new URI(address);
+        } catch (URISyntaxException e) {
+            LOGGER.log(Level.FINE, "Could not parse JAX-WS endpoint address as URI: {0}", address);
+            return null;
+        }
+    }
+}

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WSContainerResolver.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WSContainerResolver.java
@@ -37,11 +37,19 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions Copyright (c) 2026 Payara Foundation and/or its affiliates
 
 package org.glassfish.webservices;
 
+import com.sun.xml.ws.api.client.ServiceInterceptor;
 import com.sun.xml.ws.api.server.Container;
 import com.sun.xml.ws.api.server.ContainerResolver;
+import com.sun.xml.ws.developer.WSBindingProvider;
+import jakarta.xml.ws.Binding;
+import org.glassfish.internal.api.Globals;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import com.sun.enterprise.deployment.ServiceReferenceDescriptor;
 
@@ -51,8 +59,8 @@ import com.sun.enterprise.deployment.ServiceReferenceDescriptor;
  * @author Bhakti Mehta
  */
 public class WSContainerResolver extends ContainerResolver {
-   
-     
+
+
     private static final ThreadLocal<ServiceReferenceDescriptor> refs;
 
     static {
@@ -60,28 +68,54 @@ public class WSContainerResolver extends ContainerResolver {
         WSContainerResolver resolver = new WSContainerResolver();
         ContainerResolver.setInstance(resolver);
     }
-    
+
     private  WSContainerResolver() {
     }
 
-    
+
     public static void set(ServiceReferenceDescriptor ref) {
         refs.set(ref);
     }
-    
+
     public static void unset() {
         refs.set(null);
     }
-      
-    
+
+
     @Override
     public Container getContainer() {
         ServiceReferenceDescriptor svcRef = refs.get();
-        
+
         if (svcRef != null) {
             return new WSClientContainer(svcRef);
-        } else {
-            return Container.NONE;
         }
+        if (Globals.getDefaultHabitat() != null) {
+            return otelContainer();
+        }
+        return Container.NONE;
+    }
+
+    private static Container otelContainer() {
+        return new Container() {
+            @Override
+            public <T> T getSPI(Class<T> spiType) {
+                if (spiType == ServiceInterceptor.class) {
+                    return spiType.cast(otelInterceptor());
+                }
+                return null;
+            }
+        };
+    }
+
+    static ServiceInterceptor otelInterceptor() {
+        return new ServiceInterceptor() {
+            @Override
+            public void postCreateProxy(WSBindingProvider bp, Class<?> serviceEndpointInterface) {
+                Binding binding = bp.getBinding();
+                List<jakarta.xml.ws.handler.Handler> handlers = new ArrayList<>(binding.getHandlerChain());
+                handlers.add(new JaxWsClientTelemetryHandler());
+                binding.setHandlerChain(handlers);
+            }
+        };
     }
 }

--- a/nucleus/payara-modules/opentelemetry-tracing-starter/src/main/java/fish/payara/opentracing/DeferredContext.java
+++ b/nucleus/payara-modules/opentelemetry-tracing-starter/src/main/java/fish/payara/opentracing/DeferredContext.java
@@ -1,11 +1,56 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *    Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *     The contents of this file are subject to the terms of either the GNU
+ *     General Public License Version 2 only ("GPL") or the Common Development
+ *     and Distribution License("CDDL") (collectively, the "License").  You
+ *     may not use this file except in compliance with the License.  You can
+ *     obtain a copy of the License at
+ *     https://github.com/payara/Payara/blob/main/LICENSE.txt
+ *     See the License for the specific
+ *     language governing permissions and limitations under the License.
+ *
+ *     When distributing the software, include this License Header Notice in each
+ *     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ *     GPL Classpath Exception:
+ *     The Payara Foundation designates this particular file as subject to the "Classpath"
+ *     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *     file that accompanied this code.
+ *
+ *     Modifications:
+ *     If applicable, add the following below the License Header, with the fields
+ *     enclosed by brackets [] replaced by your own identifying information:
+ *     "Portions Copyright [year] [name of copyright owner]"
+ *
+ *     Contributor(s):
+ *     If you wish your version of this file to be governed by only the CDDL or
+ *     only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *     elects to include this software in this distribution under the [CDDL or GPL
+ *     Version 2] license."  If you don't indicate a single choice of license, a
+ *     recipient has the option to distribute your version of this file under
+ *     either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *     its licensees as provided above.  However, if you add GPL Version 2 code
+ *     and therefore, elected the GPL Version 2 license, then the option applies
+ *     only if the new code is made subject to such option by the copyright
+ *     holder.
+ */
 package fish.payara.opentracing;
 
+import fish.payara.telemetry.service.PayaraTelemetryConstants;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.semconv.ErrorAttributes;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
 
 import java.util.HashMap;
 
@@ -32,7 +77,7 @@ final class DeferredContext {
         local.set(new DeferredContext(carrier, operation, spanKind, attributes));
     }
 
-    public static void remove() {
+    static void remove() {
         local.remove();
     }
 
@@ -46,7 +91,9 @@ final class DeferredContext {
     private final String operation;
     private final SpanKind spanKind;
     private final Attributes attributes;
+    private final long startNanos;
     private PropagationHelper spanHelper;
+    private DoubleHistogram histogram;
 
     DeferredContext(HashMap<String, String> carrier, String operation,
                     SpanKind spanKind, Attributes attributes) {
@@ -54,9 +101,10 @@ final class DeferredContext {
         this.operation = operation;
         this.spanKind = spanKind;
         this.attributes = attributes;
+        this.startNanos = System.nanoTime();
     }
 
-    void apply(ContextPropagators propagators, Tracer currentTracer, Context current) {
+    void apply(ContextPropagators propagators, Tracer currentTracer, Context current, DoubleHistogram histogram) {
         Context parentContext = propagators.getTextMapPropagator()
                 .extract(current, carrier, CARRIER_GETTER);
         var span = currentTracer
@@ -66,6 +114,7 @@ final class DeferredContext {
                 .setAllAttributes(attributes)
                 .startSpan();
         this.spanHelper = PropagationHelper.start(span, parentContext);
+        this.histogram = histogram;
     }
 
     void end(Throwable error) {
@@ -73,5 +122,27 @@ final class DeferredContext {
             spanHelper.end(error);
             spanHelper.close();
         }
+    }
+
+    void endWithDuration(Throwable error, int httpStatus) {
+        end(error);
+        if (histogram == null) {
+            return;
+        }
+        double seconds = (System.nanoTime() - startNanos) * PayaraTelemetryConstants.NANO_CONVERSION;
+        String method = attributes.get(HttpAttributes.HTTP_REQUEST_METHOD);
+        String scheme = attributes.get(UrlAttributes.URL_SCHEME);
+        AttributesBuilder histoAttrs = Attributes.builder()
+                .put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, (long) httpStatus);
+        if (method != null) {
+            histoAttrs.put(HttpAttributes.HTTP_REQUEST_METHOD, method);
+        }
+        if (scheme != null) {
+            histoAttrs.put(UrlAttributes.URL_SCHEME, scheme);
+        }
+        if (httpStatus >= 500) {
+            histoAttrs.put(ErrorAttributes.ERROR_TYPE, Integer.toString(httpStatus));
+        }
+        histogram.record(seconds, histoAttrs.build());
     }
 }

--- a/nucleus/payara-modules/opentelemetry-tracing-starter/src/main/java/fish/payara/opentracing/OpenTelemetryService.java
+++ b/nucleus/payara-modules/opentelemetry-tracing-starter/src/main/java/fish/payara/opentracing/OpenTelemetryService.java
@@ -237,7 +237,8 @@ public class OpenTelemetryService implements EventListener {
         }
         // Use getCurrentSdk() rather than GlobalOpenTelemetry.get() so that both
         // extraction and span creation use the same per-app SDK instance consistently.
-        ctx.apply(getCurrentSdk().getPropagators(), getCurrentTracer(), Context.current());
+        ctx.apply(getCurrentSdk().getPropagators(), getCurrentTracer(), Context.current(),
+                getRequestDurationHistogram());
         return true;
     }
 
@@ -251,6 +252,21 @@ public class OpenTelemetryService implements EventListener {
         DeferredContext.remove();
         if (ctx != null) {
             ctx.end(error);
+        }
+    }
+
+    /**
+     * Ends the deferred span and records the {@code http.server.request.duration} histogram.
+     * Safe to call when no deferred context exists (no-op).
+     *
+     * @param error      the exception that caused the failure, or {@code null} on success
+     * @param httpStatus the HTTP response status code
+     */
+    public void endDeferredSpanWithDuration(Throwable error, int httpStatus) {
+        DeferredContext ctx = DeferredContext.get();
+        DeferredContext.remove();
+        if (ctx != null) {
+            ctx.endWithDuration(error, httpStatus);
         }
     }
 


### PR DESCRIPTION

## Description
This finalizes remaining word in OpenTelemetry support for Jakarta Web Services.

EJB webservice endpoints use Grizzly subsystem directly and therefore HTTP request duration needs to be tracked explicitly, since Catalina Standard Wrapper is not a participant here.

Invoking a remote SOAP service now creates a client span and propagates context over HTTP headers.

## Important Info

## Testing
### New tests

- server-side feature tested for both EJB and Servlet endpoints
- client-side feature tested for both programmatic port creation as well as `@WebServiceRef`



### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Zulu 21, MacOS 26, Maven 3.9.16

