### PR TITLE
FISH-13708: Fix stale parent versions (7.2026.7 -> 7.2026.8) in agentic-ai modules

### DIFF
--- a/appserver/agentic-ai/agentic-ai-core/pom.xml
+++ b/appserver/agentic-ai/agentic-ai-core/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.server.internal.agentic-ai</groupId>
         <artifactId>agentic-ai</artifactId>
-        <version>7.2026.7-SNAPSHOT</version>
+        <version>7.2026.8-SNAPSHOT</version>
     </parent>
     <artifactId>agentic-ai-core</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/appserver/agentic-ai/pom.xml
+++ b/appserver/agentic-ai/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.server</groupId>
         <artifactId>payara-parent</artifactId>
-        <version>7.2026.7-SNAPSHOT</version>
+        <version>7.2026.8-SNAPSHOT</version>
     </parent>
     <groupId>fish.payara.server.internal.agentic-ai</groupId>
     <artifactId>agentic-ai</artifactId>

--- a/appserver/packager/agentic-ai/pom.xml
+++ b/appserver/packager/agentic-ai/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>packages</artifactId>
-        <version>7.2026.7-SNAPSHOT</version>
+        <version>7.2026.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>agentic-ai</artifactId>

--- a/appserver/packager/external/jakarta.agentic-ai-api/pom.xml
+++ b/appserver/packager/external/jakarta.agentic-ai-api/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>fish.payara.server.internal.packager</groupId>
         <artifactId>external</artifactId>
-        <version>7.2026.7-SNAPSHOT</version>
+        <version>7.2026.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.agentic-ai-api</artifactId>

--- a/appserver/tests/payara-samples/samples/agentic-ai-quickstart/pom.xml
+++ b/appserver/tests/payara-samples/samples/agentic-ai-quickstart/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <artifactId>payara-samples-profiled-tests</artifactId>
         <groupId>fish.payara.samples</groupId>
-        <version>7.2026.7-SNAPSHOT</version>
+        <version>7.2026.8-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/appserver/tests/payara-samples/samples/agentic-ai/pom.xml
+++ b/appserver/tests/payara-samples/samples/agentic-ai/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <artifactId>payara-samples-profiled-tests</artifactId>
         <groupId>fish.payara.samples</groupId>
-        <version>7.2026.7-SNAPSHOT</version>
+        <version>7.2026.8-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Description

The agentic-ai modules exist only on the Jakarta Agentic AI branch, so the version bump merged from `main` (7.2026.7 → 7.2026.8) did not touch them and they did not surface as merge conflicts. This left the agentic-ai packager building as `7.2026.7`, so `payara-web-featureset` (`7.2026.8`) could not resolve `fish.payara.server.internal.packager:agentic-ai:zip:7.2026.8-SNAPSHOT` and the build failed.

This bumps the stale parent `<version>` in the 6 affected agentic-ai module POMs to `7.2026.8-SNAPSHOT`, matching the rest of the reactor. Same class of fix as the earlier `7.2026.6 → 7.2026.7` correction.

Files:
- `appserver/agentic-ai/pom.xml`
- `appserver/agentic-ai/agentic-ai-core/pom.xml`
- `appserver/packager/agentic-ai/pom.xml`
- `appserver/packager/external/jakarta.agentic-ai-api/pom.xml`
- `appserver/tests/payara-samples/samples/agentic-ai/pom.xml`
- `appserver/tests/payara-samples/samples/agentic-ai-quickstart/pom.xml`

## Testing

- `mvn -DskipTests clean install -P QuickBuild` completes successfully (previously failed at `payara-web-featureset` on the unresolved `agentic-ai:zip` dependency).
- Jakarta Agentic AI TCK runs green against the built distribution: `181 tests, 0 failures, 0 errors, 24 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
