### PR TITLE
FISH-14132 web.xml configured realm name is ignored on Payara 7 for JAX-WS webservices

### DIFF
--- a/appserver/security/webservices.security/src/main/java/com/sun/enterprise/security/jauth/jaspic/provider/config/SoapAuthenticationService.java
+++ b/appserver/security/webservices.security/src/main/java/com/sun/enterprise/security/jauth/jaspic/provider/config/SoapAuthenticationService.java
@@ -135,14 +135,13 @@ public class SoapAuthenticationService extends BaseAuthenticationService {
     @Override
     protected CallbackHandler getCallbackHandler() {
         String realmName = null;
-        WebServiceEndpoint wse = (WebServiceEndpoint) map.get(PipeConstants.SERVICE_ENDPOINT);
-        if (wse != null) {
-            Application app = wse.getBundleDescriptor().getApplication();
-            if (app != null) {
-                realmName = app.getRealm();
-            }
+        WebServiceEndpoint webServiceEndpoint = (WebServiceEndpoint) map.get(PipeConstants.SERVICE_ENDPOINT);
+        if (webServiceEndpoint != null) {
+            BundleDescriptor bundleDescriptor = webServiceEndpoint.getBundleDescriptor();
+            Application app = bundleDescriptor != null ? bundleDescriptor.getApplication() : null;
+            realmName = app != null ? app.getRealm() : null;
             if (realmName == null) {
-                realmName = wse.getRealm();
+                realmName = webServiceEndpoint.getRealm();
             }
         }
         return new ServerContainerCallbackHandler(realmName);

--- a/appserver/security/webservices.security/src/main/java/com/sun/enterprise/security/jauth/jaspic/provider/config/SoapAuthenticationService.java
+++ b/appserver/security/webservices.security/src/main/java/com/sun/enterprise/security/jauth/jaspic/provider/config/SoapAuthenticationService.java
@@ -54,6 +54,7 @@ import com.sun.enterprise.security.common.ClientSecurityContext;
 import com.sun.enterprise.security.ee.authentication.jakarta.AuthMessagePolicy;
 import com.sun.enterprise.security.ee.authentication.jakarta.ConfigDomainParser;
 import com.sun.enterprise.security.ee.authentication.jakarta.WebServicesDelegate;
+import com.sun.enterprise.security.ee.authentication.jakarta.callback.ServerContainerCallbackHandler;
 import com.sun.enterprise.security.ee.authorization.EJBPolicyContextDelegate;
 import com.sun.enterprise.security.webservices.PipeConstants;
 import com.sun.enterprise.util.LocalStringManagerImpl;
@@ -129,6 +130,22 @@ public class SoapAuthenticationService extends BaseAuthenticationService {
                 : null;
 
         this.ejbDelegate = new EJBPolicyContextDelegate();
+    }
+
+    @Override
+    protected CallbackHandler getCallbackHandler() {
+        String realmName = null;
+        WebServiceEndpoint wse = (WebServiceEndpoint) map.get(PipeConstants.SERVICE_ENDPOINT);
+        if (wse != null) {
+            Application app = wse.getBundleDescriptor().getApplication();
+            if (app != null) {
+                realmName = app.getRealm();
+            }
+            if (realmName == null) {
+                realmName = wse.getRealm();
+            }
+        }
+        return new ServerContainerCallbackHandler(realmName);
     }
 
     @Override

--- a/appserver/tests/payara-samples/samples/jaxws-security/src/main/java/fish/payara/samples/jaxws/security/ejb/CalculatorService.java
+++ b/appserver/tests/payara-samples/samples/jaxws-security/src/main/java/fish/payara/samples/jaxws/security/ejb/CalculatorService.java
@@ -37,19 +37,19 @@
  *    only if the new code is made subject to such option by the copyright
  *    holder.
  */
-package fish.payara.samples.jaxws.security.servlet;
+package fish.payara.samples.jaxws.security.ejb;
 
-import fish.payara.cdi.auth.roles.RolesPermitted;
-import jakarta.enterprise.context.Dependent;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ejb.Stateless;
 import jakarta.jws.WebMethod;
 import jakarta.jws.WebService;
 
 @WebService(serviceName="CalculatorService")
-@Dependent
-public class CalculatorServiceSrv {
+@Stateless
+public class CalculatorService {
 
     @WebMethod(operationName = "helloRestricted")
-    @RolesPermitted("hello")
+    @RolesAllowed("hello")
     public String helloRestricted() {
         return "Hello, world!";
     }

--- a/appserver/tests/payara-samples/samples/jaxws-security/src/main/java/fish/payara/samples/jaxws/security/servlet/CalculatorService.java
+++ b/appserver/tests/payara-samples/samples/jaxws-security/src/main/java/fish/payara/samples/jaxws/security/servlet/CalculatorService.java
@@ -37,19 +37,19 @@
  *    only if the new code is made subject to such option by the copyright
  *    holder.
  */
-package fish.payara.samples.jaxws.security.ejb;
+package fish.payara.samples.jaxws.security.servlet;
 
-import jakarta.annotation.security.RolesAllowed;
-import jakarta.ejb.Stateless;
+import fish.payara.cdi.auth.roles.RolesPermitted;
+import jakarta.enterprise.context.Dependent;
 import jakarta.jws.WebMethod;
 import jakarta.jws.WebService;
 
 @WebService(serviceName="CalculatorService")
-@Stateless
-public class CalculatorServiceEjb {
+@Dependent
+public class CalculatorService {
 
     @WebMethod(operationName = "helloRestricted")
-    @RolesAllowed("hello")
+    @RolesPermitted("hello")
     public String helloRestricted() {
         return "Hello, world!";
     }

--- a/appserver/tests/payara-samples/samples/jaxws-security/src/main/webapp/WEB-INF/wsit-fish.payara.samples.jaxws.security.ejb.CalculatorService.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-security/src/main/webapp/WEB-INF/wsit-fish.payara.samples.jaxws.security.ejb.CalculatorService.xml
@@ -10,7 +10,7 @@
     <message name="NegativeNumberException"/>
     <message name="log"/>
     <message name="logResponse"/>
-    <portType name="CalculatorServiceEjb">
+    <portType name="CalculatorService">
         <operation name="add">
             <input message="tns:add"/>
             <output message="tns:addResponse"/>
@@ -21,7 +21,7 @@
             <output message="tns:logResponse"/>
         </operation>
     </portType>
-    <binding name="CalculatorServicePortBinding" type="tns:CalculatorServiceEjb">
+    <binding name="CalculatorServicePortBinding" type="tns:CalculatorService">
         <wsp:PolicyReference URI="#CalculatorServicePortBindingPolicy"/>
         <operation name="add">
             <input></input>

--- a/appserver/tests/payara-samples/samples/jaxws-security/src/main/webapp/WEB-INF/wsit-fish.payara.samples.jaxws.security.servlet.CalculatorService.xml
+++ b/appserver/tests/payara-samples/samples/jaxws-security/src/main/webapp/WEB-INF/wsit-fish.payara.samples.jaxws.security.servlet.CalculatorService.xml
@@ -10,7 +10,7 @@
     <message name="NegativeNumberException"/>
     <message name="log"/>
     <message name="logResponse"/>
-    <portType name="CalculatorServiceSrv">
+    <portType name="CalculatorService">
         <operation name="add">
             <input message="tns:add"/>
             <output message="tns:addResponse"/>
@@ -21,7 +21,7 @@
             <output message="tns:logResponse"/>
         </operation>
     </portType>
-    <binding name="CalculatorServicePortBinding" type="tns:CalculatorServiceEjb">
+    <binding name="CalculatorServicePortBinding" type="tns:CalculatorService">
         <wsp:PolicyReference URI="#CalculatorServicePortBindingPolicy"/>
         <operation name="add">
             <input></input>

--- a/appserver/tests/payara-samples/samples/jaxws-security/src/test/java/fish/payara/samples/jaxws/security/servlet/ServletEndpointTest.java
+++ b/appserver/tests/payara-samples/samples/jaxws-security/src/test/java/fish/payara/samples/jaxws/security/servlet/ServletEndpointTest.java
@@ -101,33 +101,29 @@ public class ServletEndpointTest extends JAXWSEndpointTest {
         insecureSSLConfigurator.revertSSLConfiguration();
     }
 
-    //@Test
-    // TODO - uncomment after solving problem: "MustUnderstand headers:[{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}Security] are not understood"
-    //@RunAsClient
+    @Test
+    @RunAsClient
     public void testUnrestrictedSoapRequest() throws IOException, URISyntaxException {
         serviceConnection = sendSoapHttpRequest("request.xml");
         assertResponseOK(serviceConnection);
     }
 
-    //@Test
-    // TODO - uncomment after solving problem: "MustUnderstand headers:[{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}Security] are not understood"
-    //@RunAsClient
+    @Test
+    @RunAsClient
     public void testPermittedSoapRequest() throws IOException, URISyntaxException {
         serviceConnection = sendSoapHttpRequest("request-restricted.xml");
         assertResponseOK(serviceConnection);
     }
 
-    //@Test
-    // TODO - uncomment after solving problem: "MustUnderstand headers:[{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}Security] are not understood"
-    //@RunAsClient
+    @Test
+    @RunAsClient
     public void testSoapRequestWithIncorrectCredentials() throws IOException, URISyntaxException {
         serviceConnection = sendSoapHttpRequest("request-with-bad-password.xml");
         assertResponseFailedWithMessage(serviceConnection, "Authentication of Username Password Token Failed");
     }
 
-    //@Test
-    // TODO - uncomment after solving problem: "MustUnderstand headers:[{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}Security] are not understood"
-    //@RunAsClient
+    @Test
+    @RunAsClient
     public void testSoapRequestUserNotAllowedExecution() throws IOException, URISyntaxException {
         serviceConnection = sendSoapHttpRequest("request-not-allowed.xml");
         assertResponseFailedWithMessage(serviceConnection, "Caller was not permitted access");


### PR DESCRIPTION
## Description
The integration of Epicyro caused a regression to JAX-WS webservice authentication. More Specifically webservices written using the *servlet* approach as implemented by the `ServletEndpointTest` . 

## Important Info

## Testing

### Testing Performed
Re-enabled the `ServletEndpointTest` and achieved a passing result.

## Notes for Reviewers
Note that this is a regression on Payara 7 only.