### PR TITLE
FISH-13915 FISH-13918 FISH-13952 FISH-14123 FISH-14124 Reapply MicroProfile Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
         <angus.mail.version>2.0.5</angus.mail.version>
         <opentelemetry.version>1.64.0</opentelemetry.version>
         <opentelemetry-bom.version>2.14.0</opentelemetry-bom.version>
-        <opentelemetry-semconv.version>1.30.0</opentelemetry-semconv.version>
+        <opentelemetry-semconv.version>1.42.0</opentelemetry-semconv.version>
         <opentelemetry-instrumentation-annotations.version>2.30.0</opentelemetry-instrumentation-annotations.version>
         <opentelemetry-instrumentation-annotation-support.version>2.30.0-alpha</opentelemetry-instrumentation-annotation-support.version>
         <jakarta.faces-api.version>4.1.2</jakarta.faces-api.version>


### PR DESCRIPTION
Reapplies the MicroProfile component upgrades which were previously reverted, but not then reapplied in the MicroProfile remerge, but then dependabot did an upgrade which conflicted with as it had done its own upgrade to a higher version, which git then reverted back to to the original reversion (trust me, git is stupid sometimes)
* https://github.com/payara/Payara/pull/8284 (original revert)
  * https://github.com/payara/Payara/pull/8273 (missing from [remerge](https://github.com/payara/Payara/pull/8306))
  * https://github.com/payara/Payara/pull/8267 (missing from [remerge](https://github.com/payara/Payara/pull/8306))
  * https://github.com/payara/Payara/pull/8269 (missing from [remerge](https://github.com/payara/Payara/pull/8306))
* https://github.com/payara/Payara/pull/8306 (remerge that was missing commits)
* https://github.com/payara/Payara/pull/8323 (dependabot upgrade to a higher version of https://github.com/payara/Payara/pull/8273)
* https://github.com/payara/Payara/pull/8324 (dependabot upgrade to a higher version of https://github.com/payara/Payara/pull/8269)
* https://github.com/payara/Payara/pull/8315 (reapply (incorrectly), which undid https://github.com/payara/Payara/pull/8323 and https://github.com/payara/Payara/pull/8324)
* https://github.com/payara/Payara/pull/8327 (revert https://github.com/payara/Payara/pull/8315)

