### PR TITLE
FISH-14059 OSGi Shell

### DIFF
--- a/nucleus/osgi-platforms/osgi-cli-interactive/src/main/java/org/glassfish/osgi/cli/interactive/LocalOSGiShellCommand.java
+++ b/nucleus/osgi-platforms/osgi-cli-interactive/src/main/java/org/glassfish/osgi/cli/interactive/LocalOSGiShellCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2019-2021] Payara Foundation and/or affiliates
+// Portions Copyright 2019-2026 Payara Foundation and/or its affiliates
 
 package org.glassfish.osgi.cli.interactive;
 
@@ -268,7 +268,6 @@ public class LocalOSGiShellCommand extends CLICommand {
                 Terminal osgiShellTerminal = TerminalBuilder.builder()
                         .name(REMOTE_COMMAND)
                         .system(true)
-                        .streams(new FileInputStream(FileDescriptor.in), System.out)
                         .build();
 
                  reader = LineReaderBuilder.builder()

--- a/nucleus/osgi-platforms/osgi-cli-interactive/src/main/java/org/glassfish/osgi/cli/interactive/LocalOSGiShellCommand.java
+++ b/nucleus/osgi-platforms/osgi-cli-interactive/src/main/java/org/glassfish/osgi/cli/interactive/LocalOSGiShellCommand.java
@@ -260,15 +260,16 @@ public class LocalOSGiShellCommand extends CLICommand {
             shellType = cmd.executeAndReturnOutput(args).trim();
 
             if (file == null) {
-                if (terminal != null) {
-                    //Pause the asadmin terminal
-                    terminal.pause();
-                }
                 System.out.println(strings.get("multimodeIntro"));
-                Terminal osgiShellTerminal = TerminalBuilder.builder()
-                        .name(REMOTE_COMMAND)
-                        .system(true)
-                        .build();
+                Terminal osgiShellTerminal;
+                if (terminal != null) {
+                    osgiShellTerminal = terminal;
+                } else {
+                    osgiShellTerminal = TerminalBuilder.builder()
+                            .name(REMOTE_COMMAND)
+                            .system(true)
+                            .build();
+                }
 
                  reader = LineReaderBuilder.builder()
                         .appName(REMOTE_COMMAND)
@@ -300,7 +301,7 @@ public class LocalOSGiShellCommand extends CLICommand {
         } catch (IOException e) {
             throw new CommandException(e);
         } finally {
-            if (reader != null && reader.getTerminal() != null) {
+            if (reader != null && reader.getTerminal() != null && reader.getTerminal() != terminal) {
                 try {
                     reader.getTerminal().close();
                 } catch (IOException ioe) {
@@ -456,9 +457,6 @@ public class LocalOSGiShellCommand extends CLICommand {
                 // handle built-in exit and quit commands
                 // XXX - care about their arguments?
                 if (command.equals("exit") || command.equals("quit")) {
-                    if (terminal != null && terminal.paused()) {
-                        terminal.resume();
-                    }
                     break;
                 }
 
@@ -536,9 +534,11 @@ public class LocalOSGiShellCommand extends CLICommand {
     public void postConstruct() {
         super.postConstruct();
         try {
+            ProgramOptions remoteOptions = new ProgramOptions(locator.getService(ProgramOptions.class));
+            remoteOptions.setInteractive(false);
             cmd = new RemoteCLICommand(REMOTE_COMMAND,
-                locator.<ProgramOptions>getService(ProgramOptions.class),
-                locator.<Environment>getService(Environment.class));
+                remoteOptions,
+                locator.getService(Environment.class));
         } catch (CommandException ex) {
             // ignore - will be handled by execute()
         }

--- a/nucleus/osgi-platforms/osgi-cli-remote/src/main/java/org/glassfish/osgi/cli/remote/OSGiShellCommand.java
+++ b/nucleus/osgi-platforms/osgi-cli-remote/src/main/java/org/glassfish/osgi/cli/remote/OSGiShellCommand.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright [2018-2024] [Payara Foundation and/or its affiliates]
+// Portions Copyright 2018-2026 Payara Foundation and/or its affiliates
 
 package org.glassfish.osgi.cli.remote;
 
@@ -108,7 +108,7 @@ public class OSGiShellCommand implements AdminCommand, PostConstruct {
             new ConcurrentHashMap<String, RemoteCommandSession>();
 
     @Param(name = "command-line", primary = true, optional = true, multiple = true, defaultValue = "help")
-    private Object commandLine;
+    private List<String> commandLine;
 
     @Param(name = "session", optional = true)
     private String sessionOp;
@@ -158,10 +158,8 @@ public class OSGiShellCommand implements AdminCommand, PostConstruct {
 
                 if(commandLine == null) {
                     params.set("DEFAULT".toLowerCase(Locale.US), "asadmin-osgi-shell");
-                } else if(commandLine instanceof String) {
-                    params.set("DEFAULT".toLowerCase(Locale.US), (String) commandLine);
-                } else if(commandLine instanceof List) {
-                    params.set("DEFAULT".toLowerCase(Locale.US), (List<String>) commandLine);
+                } else {
+                    params.set("DEFAULT".toLowerCase(Locale.US), commandLine);
                 }
 
                 if(sessionOp != null) {
@@ -189,35 +187,16 @@ public class OSGiShellCommand implements AdminCommand, PostConstruct {
         if(commandLine == null) {
             cmd = "asadmin-osgi-shell";
             cmdName = cmd;
-        } else if(commandLine instanceof String) {
-            cmd = (String) commandLine;
-            cmdName = cmd;
-        } else if(commandLine instanceof List) {
-            for(Object arg : (List) commandLine) {
-                if(cmd.length() == 0) {
-                    // first arg
-                    cmd = (String) arg;
-                    cmdName = cmd;
-                } else {
-                    cmd += " " + (String) arg;
-                }
-            }
-        } else if(commandLine instanceof String[]) {
-            for(Object arg : (String[]) commandLine) {
-                if(cmd.length() == 0) {
-                    // first arg
-                    cmd = (String) arg;
-                    cmdName = cmd;
-                } else {
-                    cmd += " " + (String) arg;
-                }
-            }
         } else {
-            // shouldn't happen...
-            report.setMessage("Unable to deal with argument list of type "
-                    + commandLine.getClass().getName());
-            report.setActionExitCode(ActionReport.ExitCode.WARNING);
-            return;
+            for(String arg : commandLine) {
+                if(cmd.isEmpty()) {
+                    // first arg
+                    cmd = arg;
+                    cmdName = cmd;
+                } else {
+                    cmd += " " + arg;
+                }
+            }
         }
 
         // standard output...

--- a/nucleus/osgi-platforms/osgi-cli-remote/src/main/java/org/glassfish/osgi/cli/remote/OSGiShellCommand.java
+++ b/nucleus/osgi-platforms/osgi-cli-remote/src/main/java/org/glassfish/osgi/cli/remote/OSGiShellCommand.java
@@ -58,6 +58,7 @@ import java.util.logging.Logger;
 import jakarta.inject.Inject;
 import org.apache.felix.service.command.CommandProcessor;
 import org.apache.felix.service.command.CommandSession;
+import org.apache.felix.service.command.Converter;
 import org.apache.felix.shell.ShellService;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
@@ -285,7 +286,10 @@ public class OSGiShellCommand implements AdminCommand, PostConstruct {
                 } else if("execute".equals(sessionOp)) {
                     RemoteCommandSession remote = sessions.get(sessionId);
                     CommandSession session = remote.attach(in, out, err);
-                    session.execute(cmd);
+                    Object result = session.execute(cmd);
+                    if (result != null) {
+                        out.println(session.format(result, Converter.INSPECT));
+                    }
                     remote.detach();
                 } else if("stop".equals(sessionOp)) {
                     RemoteCommandSession remote = sessions.remove(sessionId);


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
- Resolves FISH-14059
  - Prevents the `IllegalArgumentException` and property syntax error that block the `osgi-shell` command.
  - Fixes an issue where OSGi Shell commands would execute as expected, but not output any feedback.
  - Fixes an issue where executing any command in the OSGi Shell would would return a warning message that a system terminal could not be created and a dumb terminal was in use instead.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
- Started the domain.
- Ran `asadmin osgi-shell`
- Within the OSGi Shell, ran `lb` and observed the output.
- Exited the shell and stopped the domain.

Tested both normally and in multi-mode.

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Maven version: 3.9.14
Java version: 21.0.10, vendor: Azul Systems, Inc.
Default locale: en_GB, platform encoding: UTF-8
OS name: "windows 11", version: "10.0", arch: "amd64", family: "windows"

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
