### PR TITLE
FISH-13494 FISH-14301 Forward-Port Payara 5 Deployment Descriptors

### DIFF
--- a/appserver/appclient/client/acc-config/src/test/java/org/glassfish/appclient/client/acc/config/util/XMLTest.java
+++ b/appserver/appclient/client/acc-config/src/test/java/org/glassfish/appclient/client/acc/config/util/XMLTest.java
@@ -72,7 +72,7 @@ import static org.junit.Assert.*;
  */
 public class XMLTest {
 
-    private static final String[] SAMPLE_XML_PATH = {"/sun-acc.xml", "/glassfish-acc.xml", "/payara6-acc.xml", "/payara-acc.xml", "/payara7-acc-p1.xml"};
+    private static final String[] SAMPLE_XML_PATH = {"/sun-acc.xml", "/glassfish-acc.xml", "/payara5-acc.xml", "/payara6-acc.xml", "/payara-acc.xml", "/payara7-acc-p1.xml"};
     
     private static final String FIRST_HOST = "glassfish.dev.java.net";
     private static final int FIRST_PORT = 3701;
@@ -175,6 +175,9 @@ public class XMLTest {
             GLASSFISH_ACC(
                 "-//GlassFish.org//DTD GlassFish Application Server 3.1 Application Client Container//EN",
                 "dtds/glassfish-application-client-container_1_3.dtd"),
+            PAYARA5_ACC(
+                    "-//Payara.fish//DTD Payara Application Server 5 Application Client Container//EN",
+                    "dtds/payara5-application-client-container_1_4-0.dtd"),
             PAYARA6_ACC(
                     "-//Payara.fish//DTD Payara Application Server 6 Application Client Container//EN",
                     "dtds/payara6-application-client-container_1_4-0.dtd"),

--- a/appserver/appclient/client/acc-config/src/test/resources/payara5-acc.xml
+++ b/appserver/appclient/client/acc-config/src/test/resources/payara5-acc.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<!-- Portions Copyright 2026 Payara Foundation and/or its affiliates -->
+
+<!--
+   Please remember to customize this file for your environment. The defaults for 
+   following fields may not be appropriate.  
+   - target-server name, address and port
+   - Property security.config in message-security-config
+-->
+
+<!DOCTYPE client-container PUBLIC "-//Payara.fish//DTD Payara Application Server 5 Application Client Container//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client-container_1_4-0.dtd">
+
+<client-container>
+  <target-server name="glassfish.dev.java.net" address="glassfish.dev.java.net" port="3701"/>
+  <target-server name="other.dev.java.net" address="other.dev.java.net" port="4701"/>
+  <log-service file="" level="WARNING"/>
+  <message-security-config auth-layer="SOAP">
+    <!-- turned off by default -->
+    <provider-config class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-id="XWS_ClientProvider" provider-type="client"> 
+      <request-policy auth-source="content"/>
+      <response-policy auth-source="content"/>
+      <property name="encryption.key.alias" value="s1as"/>
+      <property name="signature.key.alias" value="s1as"/>
+      <property name="dynamic.username.password" value="false"/>
+      <property name="debug" value="false"/>
+    </provider-config>
+    <provider-config class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-id="ClientProvider" provider-type="client"> 
+      <request-policy auth-source="content"/>
+      <response-policy auth-source="content"/>
+      <property name="encryption.key.alias" value="s1as"/>
+      <property name="signature.key.alias" value="s1as"/>
+      <property name="dynamic.username.password" value="false"/>
+      <property name="debug" value="false"/>
+      <property name="security.config" value="/Users/dochez/java/cvs/v3/publish/lib/appclient/wss-client-config-1.0.xml"/> 
+    </provider-config>
+  </message-security-config>
+  <property name="firstProp" value="firstValue"/>
+  <property name="secondProp" value="secondValue"/>
+</client-container>

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/xml/DTDRegistry.java
@@ -280,6 +280,10 @@ public final class DTDRegistry {
     @Deprecated
     public static final String PAYARA_WEBAPP_4_DTD_SYSTEM_ID = "https://docs.payara.fish/schemas/payara-web-app_4.dtd";
     @Deprecated
+    public static final String PAYARA5_WEBAPP_400_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 5 Servlet 4.0//EN";
+    @Deprecated
+    public static final String PAYARA5_WEBAPP_400_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-web-app_4_0-0.dtd";
+    @Deprecated
     public static final String PAYARA6_WEBAPP_600_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 6 Servlet 6.0//EN";
     @Deprecated
     public static final String PAYARA6_WEBAPP_600_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-web-app_6_0-0.dtd";
@@ -290,6 +294,10 @@ public final class DTDRegistry {
     public static final String PAYARA7_WEBAPP_611_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Server 7 Servlet 6.1 Revision 1//EN";
     public static final String PAYARA7_WEBAPP_611_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-web-app_6_1-1.dtd";
 
+    @Deprecated
+    public static final String PAYARA5_APPCLIENT_80_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 5 Jakarta EE Application Client 8//EN";
+    @Deprecated
+    public static final String PAYARA5_APPCLIENT_80_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client_8-0.dtd";
     @Deprecated
     public static final String PAYARA6_APPCLIENT_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application Client 10//EN";
     @Deprecated
@@ -302,6 +310,10 @@ public final class DTDRegistry {
     public static final String PAYARA7_APPCLIENT_111_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application-client_11-1.dtd";
 
     @Deprecated
+    public static final String PAYARA5_APPLICATION_80_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 5 Jakarta EE Application 8//EN";
+    @Deprecated
+    public static final String PAYARA5_APPLICATION_80_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application_8-0.dtd";
+    @Deprecated
     public static final String PAYARA6_APPLICATION_100_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 Jakarta EE Application 10//EN";
     @Deprecated
     public static final String PAYARA6_APPLICATION_100_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-application_10-0.dtd";
@@ -312,6 +324,10 @@ public final class DTDRegistry {
     public static final String PAYARA7_APPLICATION_111_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 7 Jakarta EE Application 11 Revision 1//EN";
     public static final String PAYARA7_APPLICATION_111_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara7-application_11-1.dtd";
 
+    @Deprecated
+    public static final String PAYARA5_EJBJAR_320_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 5 EJB 3.2//EN";
+    @Deprecated
+    public static final String PAYARA5_EJBJAR_320_DTD_SYSTEM_ID = "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-ejb-jar_3_2-0.dtd";
     @Deprecated
     public static final String PAYARA6_EJBJAR_400_DTD_PUBLIC_ID = "-//Payara.fish//DTD Payara Application Server 6 EJB 4.0//EN";
     @Deprecated

--- a/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/PayaraAppClientRuntimeNode.java
+++ b/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/PayaraAppClientRuntimeNode.java
@@ -91,6 +91,7 @@ public class PayaraAppClientRuntimeNode extends AppClientRuntimeNode {
      * @return the doctype tag name
      */
     public static String registerBundle(Map publicIDToDTD) {
+        publicIDToDTD.put(DTDRegistry.PAYARA5_APPCLIENT_80_DTD_PUBLIC_ID, DTDRegistry.PAYARA5_APPCLIENT_80_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA6_APPCLIENT_100_DTD_PUBLIC_ID, DTDRegistry.PAYARA6_APPCLIENT_100_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA_APPCLIENT_110_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPCLIENT_110_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA7_APPCLIENT_111_DTD_PUBLIC_ID, DTDRegistry.PAYARA7_APPCLIENT_111_DTD_SYSTEM_ID);

--- a/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/application/PayaraApplicationRuntimeNode.java
+++ b/appserver/deployment/dol/src/main/java/fish/payara/deployment/node/runtime/application/PayaraApplicationRuntimeNode.java
@@ -88,6 +88,7 @@ public class PayaraApplicationRuntimeNode extends ApplicationRuntimeNode {
      * @return the doctype tag name
      */
     public static String registerBundle(Map publicIDToDTD) {
+        publicIDToDTD.put(DTDRegistry.PAYARA5_APPLICATION_80_DTD_PUBLIC_ID, DTDRegistry.PAYARA5_APPLICATION_80_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA6_APPLICATION_100_DTD_PUBLIC_ID, DTDRegistry.PAYARA6_APPLICATION_100_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA_APPLICATION_110_DTD_PUBLIC_ID, DTDRegistry.PAYARA_APPLICATION_110_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA7_APPLICATION_111_DTD_PUBLIC_ID, DTDRegistry.PAYARA7_APPLICATION_111_DTD_SYSTEM_ID);

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client-container_1_4-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client-container_1_4-0.dtd
@@ -1,0 +1,291 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<!--  Portions Copyright 2022-2026 Payara Foundation and/or its affiliates -->
+
+
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+<!ENTITY % severity "(FINEST|FINER|FINE|CONFIG|INFO|WARNING|SEVERE|ALERT|FATAL)">
+
+<!-- Payara Application client container configuration
+    send-password   Specifies whether client authentication credentials should 
+                    be sent to the server. Without credential all accesses to 
+                    protected EJBs will result in exceptions.
+   message-security-config: Optional list of layer specific lists of
+     configured message security providers.
+-->
+<!ELEMENT client-container (target-server+, auth-realm?, client-credential?, log-service?, message-security-config*, property*)>
+<!ATTLIST client-container send-password %boolean; "true"> 
+
+<!-- Target server's IIOP listener configuration 
+    name        Application server instance name 
+    address     ip address or hostname (resolvable by DNS) of the ORB
+    port        port number of the ORB
+-->
+<!ELEMENT target-server (description?, security?)>
+<!ATTLIST target-server name             CDATA     #REQUIRED
+                        address          CDATA     #REQUIRED
+                        port             CDATA     #REQUIRED>
+                                                  
+<!ELEMENT description (#PCDATA)>
+
+<!-- Default client credentials that will be sent to server. If this element 
+     is present, then it will be automatically sent to the server, without
+     prompting the user for usename and password on the client side. 
+     user-name  User name credential   
+     password   Password credential
+     realm      The realm (specified by name) where credentials are to be 
+                resolved.
+ -->
+<!ELEMENT client-credential (property*)>
+<!ATTLIST client-credential user-name CDATA   #REQUIRED
+                            password  CDATA   #REQUIRED
+                            realm     CDATA   #IMPLIED>
+                                
+<!-- Logging service configuration. 
+
+     file   By default log file will be at $APPCLIENT_ROOT/logs/client.log
+            Can use this attribute to specify an alternate location.
+     level  sets the base level of severity. Messages at or above this 
+            setting get logged into the log file.
+ -->
+<!ELEMENT log-service (property*)>
+<!ATTLIST log-service  file                      CDATA      #IMPLIED
+                       level                     %severity; "SEVERE">
+
+<!-- SSL security  configuration for IIOP/SSL communication with 
+     the target-server.
+ -->
+<!ELEMENT security (ssl, cert-db)>
+
+<!-- Define SSL processing parameters
+
+     cert-nickname nickname of the server certificate in the certificate database 
+                   or the PKCS#11 token. In the certificate, the name format is
+                   tokenname:nickname. Including the tokenname: part of the name 
+                   in this attribute is optional.
+
+    ssl3-tls-ciphers (optional) A space-separated list of the SSL3 ciphers used, with
+                     the prefix + to enable or - to disable, for example
+                     +SSL_RSA_WITH_RC4_128_MD5.
+                     Allowed SSL3/TLS values are SSL_RSA_WITH_RC4_128_MD5,
+                     SSL_RSA_WITH_3DES_EDE_CBC_SHA, SSL_RSA_WITH_DES_CBC_SHA,
+                     SSL_RSA_EXPORT_WITH_RC4_40_MD5, SSL_RSA_WITH_NULL_MD5,
+                     SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_NULL_SHA
+
+    tls-rollback-enabled  (optional) Determines whether TLS rollback is enabled. TLS 
+                          rollback should be enabled for Microsoft Internet Explorer 
+                          5.0 and 5.5. 
+
+    client-auth-enabled   (optional) Determines whether client authentication is
+                          performed on every request, independent of ACL-based access 
+                          control.
+--> 
+<!ELEMENT ssl EMPTY>
+<!ATTLIST ssl cert-nickname        CDATA    #IMPLIED
+              ssl3-tls-ciphers     CDATA    #IMPLIED
+              tls-rollback-enabled CDATA    "true">
+
+<!-- Location and password to read the Certificate Database. iAS
+     (actually NSS) will provide utilities with which a certificate 
+     database can be created.
+
+     path     Specifies the absolute path where the cert database (cert7.db) 
+              is stored. 
+     password needed to open and read a cert database
+ -->
+<!ELEMENT cert-db EMPTY>
+<!ATTLIST cert-db path       CDATA #REQUIRED
+                  password   CDATA #REQUIRED>
+
+<!-- JAAS is available on Application Client Container. 
+     Optional configuration for JAAS authentication realm.
+     
+     name       defines the name of this realm
+     classname  defines the java class which implements this realm
+ -->
+<!ELEMENT auth-realm (property*)>
+<!ATTLIST auth-realm name            CDATA   #REQUIRED
+                     classname       CDATA   #REQUIRED>
+               
+<!-- Syntax for supplying properties as name value pairs -->
+<!ELEMENT property EMPTY>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-config elements.
+
+Used in: message-security-config
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-config element defines the message layer
+specific provider configurations of the application server.
+
+All of the providers within a message-security-config element
+must be able to perform authentication processing at
+the message layer defined by the value of the auth-layer 
+attribute. 
+
+The default-provider attribute may be used to identify 
+the server provider to be invoked for any application 
+for which a specific server provider has not been bound.
+
+The default-client-provider attribute may be used to identify 
+the client provider to be invoked for any application 
+for which a specific client provider has not been bound.
+
+At most one (non-null) default server provider and at most one
+(non-null) default client provider may be identified 
+among all the same layer message-security-config elements. 
+
+When a default provider of a type is not defined for a message 
+layer, the container will only invoke a provider of the type
+(at the layer) for those applications for which a specific
+provider has been bound.
+
+Default: 
+Used in: security-service
+-->
+<!ELEMENT message-security-config ( provider-config+ )>
+<!ATTLIST message-security-config 
+          auth-layer %message-layer; #REQUIRED
+	  default-provider        CDATA #IMPLIED
+	  default-client-provider CDATA #IMPLIED>
+
+<!--
+The provider-config element defines the configuration of
+an authentication provider.
+
+The provider-id attibute contains an identifier that can be used to
+reference the provider-config.
+
+The request-policy and response-policy sub-elements define
+the authentication policy requirements associated 
+with the request and response processing performed by the
+authentication provider (respectively).
+
+the provider-type attribute defines whether the provider is a client
+authentication provider or a server authentication provider.
+
+The class-name attribute defines the java implementation class of the 
+provider. Client authentication providers must implement the 
+com.sun.enterprise.security.jauth.ClientAuthModule interface. Server-side
+providers must implement the com.sun.enterprise.security.jauth.ServerAuthModule
+interface. A provider may implement both interfaces, but it must implement
+the interface corresponding to its provider type.
+
+The optional list of property elements may be used to configure provider
+specific property values. These values will be passed to the provider
+when its initialize method is called.
+
+A provider-config with no contained request-policy or response-policy
+sub-elements, is a null provider. The container will not instantiate
+or invoke the methods of a null provider, and as such the implementation
+class of a null provider need not exist.
+
+Default: 
+Used in: message-security-config
+-->
+<!ELEMENT provider-config ( request-policy?, response-policy?, property* )>
+<!ATTLIST provider-config
+          provider-id CDATA                   #REQUIRED
+	  provider-type  (client | server | client-server) #REQUIRED
+          class-name      CDATA            #REQUIRED>
+
+<!--
+The request-policy element is used to define the authentication policy 
+requirements associated with the request processing performed by an 
+authentication provider (i.e. when a client provider's 
+ClientAuthModule.initiateRequest method is called or when a
+server provider's ServerAuthModule.validateRequest is called).
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+Default: 
+Used in: provider-config
+-->
+<!ELEMENT request-policy EMPTY >
+<!ATTLIST request-policy 
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+<!--
+The response-policy element is used to define the authentication policy 
+requirements associated with the response processing performed by an 
+authentication provider (i.e. when a client provider's 
+ClientAuthModule.validateResponse method is called or when a
+server provider's ServerAuthModule.secureResponse method is called).
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+Default: 
+Used in: provider-config
+-->
+<!ELEMENT response-policy EMPTY >
+<!ATTLIST response-policy 
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client-container_1_4-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client-container_1_4-0.dtd
@@ -103,6 +103,18 @@
                    tokenname:nickname. Including the tokenname: part of the name 
                    in this attribute is optional.
 
+     ssl2-enabled  (optional) Determines whether SSL2 is enabled.
+
+     ssl3-enabled  (optional) Determines whether SSL3 is enabled.
+
+                   If both SSL2 and SSL3 are enabled for a virtual server, the server
+                   tries SSL3 encryption first. If that fails, the server tries SSL2
+                   encryption.
+
+    ssl2ciphers    (optional) A space-separated list of the SSL2 ciphers used, with
+                   the prefix + to enable or - to disable, for example +rc4. Allowed
+                   values are rc4, rc4export, rc2, rc2export, idea, des, desede3.
+
     ssl3-tls-ciphers (optional) A space-separated list of the SSL3 ciphers used, with
                      the prefix + to enable or - to disable, for example
                      +SSL_RSA_WITH_RC4_128_MD5.
@@ -111,17 +123,24 @@
                      SSL_RSA_EXPORT_WITH_RC4_40_MD5, SSL_RSA_WITH_NULL_MD5,
                      SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_NULL_SHA
 
-    tls-rollback-enabled  (optional) Determines whether TLS rollback is enabled. TLS 
+
+    tls-enabled     (optional) Determines whether TLS is enabled.
+
+    tls-rollback-enabled  (optional) Determines whether TLS rollback is enabled. TLS
                           rollback should be enabled for Microsoft Internet Explorer 
                           5.0 and 5.5. 
 
-    client-auth-enabled   (optional) Determines whether client authentication is
+    client-auth-enabled   (optional) Determines whether SSL3 client authentication is
                           performed on every request, independent of ACL-based access 
                           control.
 --> 
 <!ELEMENT ssl EMPTY>
 <!ATTLIST ssl cert-nickname        CDATA    #IMPLIED
+              ssl2-enabled         CDATA    "false"
+              ssl2-ciphers         CDATA    #IMPLIED
+              ssl3-enabled         CDATA    "true"
               ssl3-tls-ciphers     CDATA    #IMPLIED
+              tls-enabled          CDATA    "true"
               tls-rollback-enabled CDATA    "true">
 
 <!-- Location and password to read the Certificate Database. iAS

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client_8-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client_8-0.dtd
@@ -1,0 +1,559 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2012 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+        <!-- Portions Copyright 2026 Payara Foundation and/or its affiliates -->
+
+        <!--
+          XML DTD for Payara Application Server specific Jakarta EE Client Application
+          deployment descriptor. This is a companion DTD to application-client_8.xsd
+
+          It must include a DOCTYPE of the following form:
+
+          <!DOCTYPE payara-application-client PUBLIC "-//Payara.fish//DTD Payara Application Server 5 Jakarta EE Application Client 8//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application-client_8-0.dtd">
+
+        -->
+
+        <!--
+        payara-application-client is the root element describing all the runtime bindings of a single application client
+        -->
+        <!ELEMENT payara-application-client (ejb-ref*, resource-ref*, resource-env-ref*, service-ref*,
+                message-destination-ref*, message-destination*, java-web-start-access?, version-identifier?)>
+
+        <!--
+        name of a resource reference.
+        -->
+        <!ELEMENT res-ref-name (#PCDATA)>
+
+        <!--
+        resource-env-ref holds all the runtime bindings of a resource env reference.
+        -->
+        <!ELEMENT resource-env-ref ( resource-env-ref-name, jndi-name )>
+
+        <!--
+        name of a resource env reference.
+        -->
+        <!ELEMENT resource-env-ref-name (#PCDATA)>
+
+        <!--
+        resource-ref holds the runtime bindings of a resource reference.
+        -->
+        <!ELEMENT resource-ref  ( res-ref-name, jndi-name,  default-resource-principal?)>
+
+        <!--
+        default-resource-principal specifies the default principal that the container
+        will use to access a resource.
+        -->
+        <!ELEMENT default-resource-principal ( name,  password)>
+
+        <!--
+        name element holds the user name
+        -->
+        <!ELEMENT name (#PCDATA)>
+
+        <!--
+        password element holds a password string.
+        -->
+        <!ELEMENT password (#PCDATA)>
+
+        <!--
+        ejb-ref element which binds an ejb reference to a jndi name.
+        -->
+        <!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+
+        <!--
+        ejb-ref-name locates the name of the ejb reference in the application.
+        -->
+        <!ELEMENT ejb-ref-name (#PCDATA)>
+
+        <!--
+        jndi name of the associated entity
+        -->
+        <!ELEMENT  jndi-name (#PCDATA)>
+
+        <!--
+        This node holds information about a logical message destination
+        -->
+        <!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+        <!--
+        This node holds the name of a logical message destination
+        -->
+        <!ELEMENT message-destination-name (#PCDATA)>
+
+        <!--
+        message-destination-ref is used to directly bind a message destination reference
+        to the jndi-name of a Queue,Topic, or some other physical destination. It should
+        only be used when the corresponding message destination reference does not
+        specify a message-destination-link to a logical message-destination.
+        -->
+        <!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+        <!--
+        name of a message-destination reference.
+        -->
+        <!ELEMENT message-destination-ref-name (#PCDATA)>
+
+        <!--
+        Specifies the name of a durable subscription associated with a message-driven bean's
+        destination.  Required for a Topic destination, if subscription-durability is set to
+        Durable (in ejb-jar.xml)
+        -->
+
+        <!--
+                      W E B   S E R V I C E S
+        -->
+        <!--
+        Runtime settings for a web service reference.  In the simplest case,
+        there is no runtime information required for a service ref.  Runtime info
+        is only needed in the following cases :
+         * to define the port that should be used to resolve a container-managed port
+         * to define default Stub/Call property settings for Stub objects
+         * to define the URL of a final WSDL document to be used instead of
+        the one packaged with a service-ref
+        -->
+        <!ELEMENT service-ref ( service-ref-name, port-info*, call-property*,
+                wsdl-override?, service-impl-class?, service-qname? )>
+
+        <!--
+        Coded name (relative to java:comp/env) for a service-reference
+        -->
+        <!ELEMENT service-ref-name ( #PCDATA )>
+
+        <!--
+        Information for a port within a service-reference.
+
+        Either service-endpoint-interface or wsdl-port or both
+        (service-endpoint-interface and wsdl-port) should be specified.
+
+        If both are specified, wsdl-port represents the
+        port the container should choose for container-managed port selection.
+
+        The same wsdl-port value must not appear in
+        more than one port-info entry within the same service-ref.
+
+        If a particular service-endpoint-interface is using container-managed port
+        selection, it must not appear in more than one port-info entry
+        within the same service-ref.
+
+        The optional message-security-binding element is used to customize the
+        port to provider binding; either by binding the port to a specific provider
+        or by providing a definition of the message security requirements to be
+        enforced by the provider.
+
+        -->
+        <!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+        <!--
+        Fully qualified name of service endpoint interface
+        -->
+        <!ELEMENT service-endpoint-interface ( #PCDATA )>
+        <!--
+        Port used in port-info.
+        -->
+        <!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+        <!--
+        JAXRPC property values that should be set on a stub before it's returned to
+        to the web service client.  The property names can be any properties supported
+        by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+        -->
+        <!ELEMENT stub-property ( name, value )>
+
+        <!--
+        JAXRPC property values that should be set on a Call object before it's
+        returned to the web service client.  The property names can be any
+        properties supported by the JAXRPC Call implementation.  See javadoc
+        for javax.xml.rpc.Call
+        -->
+        <!ELEMENT call-property ( name, value )>
+
+        <!--
+        This is a valid URL pointing to a final WSDL document. It is optional.
+        If specified, the WSDL document at this URL will be used during
+        deployment instead of the WSDL document associated with the
+        service-ref in the standard deployment descriptor.
+
+        Examples :
+
+          // available via HTTP
+          <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+          // in a file
+          <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+        -->
+        <!ELEMENT wsdl-override ( #PCDATA )>
+
+        <!--
+        Name of generated service implementation class. This is not set by the
+        deployer. It is derived during deployment.
+        -->
+        <!ELEMENT service-impl-class ( #PCDATA )>
+
+        <!--
+        The service-qname element declares the specific WSDL service
+        element that is being refered to.  It is not set by the deployer.
+        It is derived during deployment.
+        -->
+        <!ELEMENT service-qname (namespaceURI, localpart)>
+
+        <!--
+        The localpart element indicates the local part of a QNAME.
+        -->
+        <!ELEMENT localpart (#PCDATA)>
+
+        <!--
+        The namespaceURI element indicates a URI.
+        -->
+        <!ELEMENT namespaceURI (#PCDATA)>
+
+        <!--
+        This text nodes holds a value string.
+        -->
+        <!ELEMENT value (#PCDATA)>
+
+        <!--
+        The message-layer entity is used to define the value of the
+        auth-layer attribute of message-security-binding elements.
+
+        Used in: message-security-binding
+        -->
+        <!ENTITY % message-layer    "(SOAP)">
+
+        <!--
+        The message-security-binding element is used to customize the
+        webservice-endpoint or port to provider binding; either by binding the
+        webservice-endpoint or port to a specific provider or by providing a
+        definition of the message security requirements to be enforced by the
+        provider.
+
+        These elements are typically NOT created as a result of the
+        deployment of an application. They need only be created when the
+        deployer or system administrator chooses to customize the
+        webservice-endpoint or port to provider binding.
+
+        The optional (repeating) message-security sub-element is used
+        to accomplish the latter; in which case the specified
+        message-security requirements override any defined with the
+        provider.
+
+        The auth-layer attribute identifies the message layer at which the
+        message-security requirements are to be enforced.
+
+        The optional provider-id attribute identifies the provider-config
+        and thus the authentication provider that is to be used to satisfy
+        the application specific message security requirements. If a value for
+        the provider-id attribute is not specified, and a default
+        provider is defined for the message layer, then it is used.
+        if a value for the provider-id attribute is not specified, and a
+        default provider is not defined at the layer, the authentication
+        requirements defined in the message-security-binding are not
+        enforced.
+
+        Default:
+        Used in: webservice-endpoint, port-info
+        -->
+        <!ELEMENT message-security-binding ( message-security* )>
+        <!ATTLIST message-security-binding
+                auth-layer  %message-layer; #REQUIRED
+                provider-id CDATA           #IMPLIED >
+
+        <!--
+        The message-security element describes message security requirements
+        that pertain to the request and response messages of the containing
+        endpoint, or port
+
+        When contained within a webservice-endpoint this element describes
+        the message security requirements that pertain to the request and
+        response messages of the containing endpoint. When contained within a
+        port-info of a service-ref this element describes the message security
+        requirements of the port of the referenced service.
+
+        The one or more contained message elements define the methods or operations
+        of the containing application, endpoint, or referenced service to which
+        the message security requirements apply.
+
+        Multiple message-security elements occur within a containing
+        element when it is necessary to define different message
+        security requirements for different messages within the encompassing
+        context. In such circumstances, the peer elements should not overlap
+        in the messages they pertain to. If there is any overlap in the
+        identified messages, no message security requirements apply to
+        the messages for which more than one message-security element apply.
+
+        Also, no message security requirements apply to any messages of
+        the encompassing context that are not identified by a message element.
+
+        Default:
+        Used in: webservice-endpoint, and port-info
+        -->
+        <!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+        <!--
+        The message element identifies the methods or operations to which
+        the message security requirements apply.
+
+        The identified methods or operations are methods or operations of
+        the resource identified by the context in which the message-security
+        element is defined (e.g. the the resource identified by the
+        service-qname of the containing webservice-endpoint or service-ref).
+
+        An empty message element indicates that the security requirements
+        apply to all the methods or operations of the identified resource.
+
+        When operation-name is specified, the security
+        requirements defined in the containing message-security
+        element apply to all the operations of the endpoint
+        with the specified (and potentially overloaded) operation name.
+
+        Default:
+        Used in: message-security
+        -->
+        <!ELEMENT message ( java-method? | operation-name? )>
+
+        <!--
+        The java-method element is used to identify a method (or methods
+        in the case of an overloaded method-name) of the java class
+        indicated by the context in which the java-method is contained.
+
+        Default:
+        Used in: message
+        -->
+        <!ELEMENT java-method ( method-name, method-params? )>
+
+        <!--
+        The operation-name element is used to identify the WSDL name of an
+        operation of a web service.
+
+        Default:
+        Used in: message
+        -->
+        <!ELEMENT operation-name ( #PCDATA )>
+
+        <!--
+        The request-protection element describes the authentication requirements
+        that apply to a request.
+
+        The auth-source attribute defines a requirement for message layer
+        sender authentication (e.g. username password) or content authentication
+        (e.g. digital signature).
+
+        The auth-recipient attribute defines a requirement for message
+        layer authentication of the reciever of a message to its sender (e.g. by
+        XML encryption).
+
+        The before-content attribute value indicates that recipient
+        authentication (e.g. encryption) is to occur before any
+        content authentication (e.g. encrypt then sign) with respect
+        to the target of the containing auth-policy.
+
+        An absent request-protection element is the recommended shorthand
+        for a request-protection element with unspecified values for both the
+        auth-source and auth-recipient attributes.
+
+        Default:
+        Used in: message-security
+
+         * Expected evolution to support partial message protection:
+         *
+         * request-protection ( content-auth-policy* )
+         *
+         * If the request-protection element contains one or more
+         * content-auth-policy sub-elements, they define the authentication
+         * requirements to be applied to the identified request content. If multiple
+         * content-auth-policy sub-elements are defined, a request sender must
+         * satisfy the requirements independently, and in the specified order.
+         *
+         * The content-auth-policy element would be used to associate authentication
+         * requirements with the parts of the request or response object identified
+         * by the contained method-params or part-name-list sub-elements.
+         *
+         * The content-auth-policy element would be defined as follows:
+         *
+         * content-auth-policy ( method-params | part-name-list )
+         * ATTLIST content-auth-policy
+         *         auth-source (sender | content) #IMPLIED
+         *	   auth-recipient (before-content | after-content) #IMPLIED
+         *
+         * The part-name-list and part-name elements would be defined as follows:
+         *
+         * part-name-list ( part-name* )
+         * part-name ( #PCDATA )
+         *
+        -->
+        <!ELEMENT request-protection EMPTY >
+        <!ATTLIST request-protection
+                auth-source (sender | content) #IMPLIED
+                auth-recipient (before-content | after-content) #IMPLIED>
+
+        <!--
+        The response-protection element describes the authentication requirements
+        that apply to a response.
+
+        The auth-source attribute defines a requirement for message layer
+        sender authentication (e.g. username password) or content authentication
+        (e.g. digital signature).
+
+        The auth-recipient attribute defines a requirement for message
+        layer authentication of the reciever of a message to its sender (e.g. by
+        XML encryption).
+
+        The before-content attribute value indicates that recipient
+        authentication (e.g. encryption) is to occur before any
+        content authentication (e.g. encrypt then sign) with respect
+        to the target of the containing auth-policy.
+
+        An absent response-protection element is the recommended shorthand
+        for a request-protection element with unspecified values for both the
+        auth-source and auth-recipient attributes.
+
+        Default:
+        Used in: message-security
+
+         * Expected evolution to support partial message protection:
+         *
+         * response-protection ( content-auth-policy* )
+         *
+         * see request-protection element for more details
+         *
+        -->
+        <!ELEMENT response-protection EMPTY >
+        <!ATTLIST response-protection
+                auth-source (sender | content) #IMPLIED
+                auth-recipient (before-content | after-content) #IMPLIED>
+
+        <!--
+        The method-name element contains the name of a service method of a web service
+        implementation class.
+
+        Used in: java-method
+        -->
+        <!ELEMENT method-name (#PCDATA)>
+        <!--
+        The method-params element contains a list of the fully-qualified Java
+        type names of the method parameters.
+
+        Used in: java-method
+        -->
+        <!ELEMENT method-params (method-param*)>
+
+        <!--
+        The method-param element contains the fully-qualified Java type name
+        of a method parameter.
+
+        Used in: method-params
+        -->
+        <!ELEMENT method-param (#PCDATA)>
+
+        <!--
+                                    J A V A   W E B   S T A R T    A C C E S S
+        -->
+
+        <!--
+        The java-web-start-access element contains all information relevant to Java
+        Web Start access to the app client.
+
+        Note that all elements that support Java Web Start access appear below
+        the java-web-start-access definition alphabetically by tag name.
+
+        The context-root subelement allows the developer to specify what context root
+        will be used for addressing the app client via Java Web Start.  If absent, the
+        app server uses a default context root value.
+
+        The eligible subelement allows the developer to control whether this app client
+        should allow Java Web Start access.  If this value is false, then Java Web Start
+        will never be allowed access.  Default: true.
+
+        The vendor subelement allows the developer to specify the vendor name that Java
+        Web Start should display to the end-user as the app client is downloaded and launched.
+
+        The jnlp-doc subelement gives the developer a way to direct the generation of
+        the JNLP document describing the app client launch.
+
+        Used in: payara-application-client
+        -->
+        <!ELEMENT java-web-start-access (context-root?, eligible?, vendor?, jnlp-doc?)>
+
+        <!--
+        The context-root element allows the developer to specify the context root
+        with which Java Web Start should access the app client.  The app server
+        provides a default value if the developer omits this.
+
+        Used in: java-web-start-access
+        -->
+        <!ELEMENT context-root (#PCDATA)>
+
+        <!--
+        The eligible element allows the developer to indicate whether Java Web Start
+        access should ever be permitted to launch this app client.
+
+        Used in: java-web-start-access
+        -->
+        <!ELEMENT eligible (#PCDATA)>
+
+        <!--
+        The vendor element allows the developer to indicate what vendor name Java Web Start
+        should display in the splash screen as the app client is downloaded and/or launched.
+
+        Used in: java-web-start-access
+        -->
+        <!ELEMENT vendor (#PCDATA)>
+
+        <!--
+        The jnlp-doc element's href attribute refers to a JNLP file in the app
+        client or in the EAR which is merged with the generated JNLP to create the final
+        JNLP which is used to launch the app client.  This href must be a relative
+        URI.  Note that the path may instead be specified as the text value of the
+        jnlp-doc element. Using the text value is described in the published documentation
+        so we need to allow either.  Users should not specify both; if they do results
+        are unpredictable.
+
+        Used in: java-web-start-access
+        -->
+        <!ELEMENT jnlp-doc (#PCDATA)>
+        <!ATTLIST jnlp-doc
+                href CDATA #IMPLIED>
+
+        <!--
+        The version-identifier element contains the version information. The value is
+         retrieved at deployment.
+        -->
+        <!ELEMENT version-identifier (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application_8-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application_8-0.dtd
@@ -1,0 +1,575 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+    Portions Copyright 2026 Payara Foundation and/or its affiliates
+-->
+
+<!--
+  XML DTD for Payara Application Server specific Jakarta EE Application
+  deployment descriptor. This is a companion DTD to application_8.xsd
+
+  It must include a DOCTYPE of the following form:
+
+  <!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 5 Jakarta EE Application 8//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application_8-0.dtd">
+
+-->
+
+<!--
+This is the root element of the runtime descriptor document.
+-->
+<!ELEMENT payara-application (web*, pass-by-reference?, unique-id?, security-role-mapping*, realm?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, message-destination*, archive-name?, compatibility?, keep-state?, version-identifier?, classloading-delegate?, enable-implicit-cdi?, scanning-exclude*, scanning-include*, whitelist-package*, property*) >
+
+<!ELEMENT web (web-uri, context-root)>
+<!ELEMENT web-uri (#PCDATA)>
+<!ELEMENT context-root (#PCDATA)>
+
+<!-- Pass by Reference semantics:  EJB spec requires pass by value,
+     which will be the default mode of operation. This can be set
+     to true for non-compliant and possibly higher performance.
+     For a stand-alone, this can be set at this level. By setting
+     a similarly named element at payara-application, it can apply to
+     all the enclosed ejb modules. Allowed values are true and
+     false. Default will be false.
+ -->
+<!ELEMENT pass-by-reference (#PCDATA)>
+
+<!-- Automatically generated and updated at deployment/redeployment
+     Needs to be unqiue in the system.
+  -->
+<!ELEMENT unique-id (#PCDATA)>
+
+<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)>
+
+<!ELEMENT role-name (#PCDATA)>
+<!ELEMENT principal-name (#PCDATA)>
+<!ATTLIST principal-name class-name CDATA #IMPLIED>
+<!ELEMENT group-name (#PCDATA)>
+
+<!--
+  realm: Allows specifying an optional authentication realm name which will
+    be used to process all authentication requests associated with this
+    application. If this element is not specified (or if it is given but
+    does not match the name of a configured realm) then the default realm
+    set in the server instances security-service element will be used
+    instead.
+-->
+<!ELEMENT realm (#PCDATA)>
+
+<!--
+name of a resource reference.
+-->
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!--
+resource-env-ref holds all the runtime bindings of a resource env reference.
+-->
+<!ELEMENT resource-env-ref ( resource-env-ref-name, jndi-name )>
+
+<!--
+name of a resource env reference.
+-->
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!--
+resource-ref holds the runtime bindings of a resource reference.
+-->
+<!ELEMENT resource-ref  ( res-ref-name, jndi-name,  default-resource-principal?)>
+
+<!--
+default-resource-principal specifies the default principal that the container
+will use to access a resource.
+-->
+<!ELEMENT default-resource-principal ( name,  password)>
+
+<!--
+name element holds the user name
+-->
+<!ELEMENT name (#PCDATA)>
+
+<!--
+password element holds a password string.
+-->
+<!ELEMENT password (#PCDATA)>
+
+<!--
+ejb-ref element which binds an ejb reference to a jndi name.
+-->
+<!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+
+<!--
+ejb-ref-name locates the name of the ejb reference in the application.
+-->
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!--
+jndi name of the associated entity
+-->
+<!ELEMENT  jndi-name (#PCDATA)>
+
+<!--
+This node holds information about a logical message destination
+-->
+<!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+<!--
+This node holds the name of a logical message destination
+-->
+<!ELEMENT message-destination-name (#PCDATA)>
+
+<!--
+message-destination-ref is used to directly bind a message destination reference
+to the jndi-name of a Queue,Topic, or some other physical destination. It should
+only be used when the corresponding message destination reference does not
+specify a message-destination-link to a logical message-destination.
+-->
+<!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+<!--
+name of a message-destination reference.
+-->
+<!ELEMENT message-destination-ref-name (#PCDATA)>
+
+<!--
+                        W E B   S E R V I C E S
+-->
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+<!ELEMENT service-ref ( service-ref-name, port-info*, call-property*,
+                wsdl-override?, service-impl-class?, service-qname? )>
+
+<!--
+Coded name (relative to java:comp/env) for a service-reference
+-->
+<!ELEMENT service-ref-name ( #PCDATA )>
+
+<!--
+Information for a port within a service-reference.
+
+Either service-endpoint-interface or wsdl-port or both
+(service-endpoint-interface and wsdl-port) should be specified.
+
+If both are specified, wsdl-port represents the
+port the container should choose for container-managed port selection.
+
+The same wsdl-port value must not appear in
+more than one port-info entry within the same service-ref.
+
+If a particular service-endpoint-interface is using container-managed port
+selection, it must not appear in more than one port-info entry
+within the same service-ref.
+
+The optional message-security-binding element is used to customize the
+port to provider binding; either by binding the port to a specific provider
+or by providing a definition of the message security requirements to be
+enforced by the provider.
+
+-->
+<!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+<!--
+Fully qualified name of service endpoint interface
+-->
+<!ELEMENT service-endpoint-interface ( #PCDATA )>
+<!--
+Port used in port-info.
+-->
+<!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+<!--
+JAXRPC property values that should be set on a stub before it's returned to
+to the web service client.  The property names can be any properties supported
+by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+-->
+<!ELEMENT stub-property ( name, value )>
+
+<!--
+JAXRPC property values that should be set on a Call object before it's
+returned to the web service client.  The property names can be any
+properties supported by the JAXRPC Call implementation.  See javadoc
+for javax.xml.rpc.Call
+-->
+<!ELEMENT call-property ( name, value )>
+
+<!--
+This is a valid URL pointing to a final WSDL document. It is optional.
+If specified, the WSDL document at this URL will be used during
+deployment instead of the WSDL document associated with the
+service-ref in the standard deployment descriptor.
+
+Examples :
+
+  // available via HTTP
+  <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+  // in a file
+  <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+-->
+<!ELEMENT wsdl-override ( #PCDATA )>
+
+<!--
+Name of generated service implementation class. This is not set by the
+deployer. It is derived during deployment.
+-->
+<!ELEMENT service-impl-class ( #PCDATA )>
+
+<!--
+The service-qname element declares the specific WSDL service
+element that is being refered to.  It is not set by the deployer.
+It is derived during deployment.
+-->
+<!ELEMENT service-qname (namespaceURI, localpart)>
+
+<!--
+The localpart element indicates the local part of a QNAME.
+-->
+<!ELEMENT localpart (#PCDATA)>
+
+<!--
+The namespaceURI element indicates a URI.
+-->
+<!ELEMENT namespaceURI (#PCDATA)>
+
+<!--
+This text nodes holds a value string.
+-->
+<!ELEMENT value (#PCDATA)>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-binding elements.
+
+Used in: message-security-binding
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-binding element is used to customize the
+webservice-endpoint or port to provider binding; either by binding the
+webservice-endpoint or port to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+These elements are typically NOT created as a result of the
+deployment of an application. They need only be created when the
+deployer or system administrator chooses to customize the
+webservice-endpoint or port to provider binding.
+
+The optional (repeating) message-security sub-element is used
+to accomplish the latter; in which case the specified
+message-security requirements override any defined with the
+provider.
+
+The auth-layer attribute identifies the message layer at which the
+message-security requirements are to be enforced.
+
+The optional provider-id attribute identifies the provider-config
+and thus the authentication provider that is to be used to satisfy
+the application specific message security requirements. If a value for
+the provider-id attribute is not specified, and a default
+provider is defined for the message layer, then it is used.
+if a value for the provider-id attribute is not specified, and a
+default provider is not defined at the layer, the authentication
+requirements defined in the message-security-binding are not
+enforced.
+
+Default:
+Used in: webservice-endpoint, port-info
+-->
+<!ELEMENT message-security-binding ( message-security* )>
+<!ATTLIST message-security-binding
+          auth-layer  %message-layer; #REQUIRED
+          provider-id CDATA           #IMPLIED >
+
+<!--
+The message-security element describes message security requirements
+that pertain to the request and response messages of the containing
+endpoint, or port
+
+When contained within a webservice-endpoint this element describes
+the message security requirements that pertain to the request and
+response messages of the containing endpoint. When contained within a
+port-info of a service-ref this element describes the message security
+requirements of the port of the referenced service.
+
+The one or more contained message elements define the methods or operations
+of the containing application, endpoint, or referenced service to which
+the message security requirements apply.
+
+Multiple message-security elements occur within a containing
+element when it is necessary to define different message
+security requirements for different messages within the encompassing
+context. In such circumstances, the peer elements should not overlap
+in the messages they pertain to. If there is any overlap in the
+identified messages, no message security requirements apply to
+the messages for which more than one message-security element apply.
+
+Also, no message security requirements apply to any messages of
+the encompassing context that are not identified by a message element.
+
+Default:
+Used in: webservice-endpoint, and port-info
+-->
+<!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+<!--
+The message element identifies the methods or operations to which
+the message security requirements apply.
+
+The identified methods or operations are methods or operations of
+the resource identified by the context in which the message-security
+element is defined (e.g. the the resource identified by the
+service-qname of the containing webservice-endpoint or service-ref).
+
+An empty message element indicates that the security requirements
+apply to all the methods or operations of the identified resource.
+
+When operation-name is specified, the security
+requirements defined in the containing message-security
+element apply to all the operations of the endpoint
+with the specified (and potentially overloaded) operation name.
+
+Default:
+Used in: message-security
+-->
+<!ELEMENT message ( java-method? | operation-name? )>
+
+<!--
+The java-method element is used to identify a method (or methods
+in the case of an overloaded method-name) of the java class
+indicated by the context in which the java-method is contained.
+
+Default:
+Used in: message
+-->
+<!ELEMENT java-method ( method-name, method-params? )>
+
+<!--
+The operation-name element is used to identify the WSDL name of an
+operation of a web service.
+
+Default:
+Used in: message
+-->
+<!ELEMENT operation-name ( #PCDATA )>
+
+<!--
+The request-protection element describes the authentication requirements
+that apply to a request.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent request-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default:
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * request-protection ( content-auth-policy* )
+ *
+ * If the request-protection element contains one or more
+ * content-auth-policy sub-elements, they define the authentication
+ * requirements to be applied to the identified request content. If multiple
+ * content-auth-policy sub-elements are defined, a request sender must
+ * satisfy the requirements independently, and in the specified order.
+ *
+ * The content-auth-policy element would be used to associate authentication
+ * requirements with the parts of the request or response object identified
+ * by the contained method-params or part-name-list sub-elements.
+ *
+ * The content-auth-policy element would be defined as follows:
+*
+ * content-auth-policy ( method-params | part-name-list )
+ * ATTLIST content-auth-policy
+ *         auth-source (sender | content) #IMPLIED
+ *         auth-recipient (before-content | after-content) #IMPLIED
+ *
+ * The part-name-list and part-name elements would be defined as follows:
+ *
+ * part-name-list ( part-name* )
+ * part-name ( #PCDATA )
+ *
+-->
+<!ELEMENT request-protection EMPTY >
+<!ATTLIST request-protection
+          auth-source (sender | content) #IMPLIED
+          auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The response-protection element describes the authentication requirements
+that apply to a response.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent response-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default:
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * response-protection ( content-auth-policy* )
+ *
+ * see request-protection element for more details
+ *
+-->
+<!ELEMENT response-protection EMPTY >
+<!ATTLIST response-protection
+          auth-source (sender | content) #IMPLIED
+          auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The method-name element contains the name of a service method of a web service
+implementation class.
+
+Used in: java-method
+-->
+<!ELEMENT method-name (#PCDATA)>
+<!--
+The method-params element contains a list of the fully-qualified Java
+type names of the method parameters.
+
+Used in: java-method
+-->
+<!ELEMENT method-params (method-param*)>
+
+<!--
+The method-param element contains the fully-qualified Java type name
+of a method parameter.
+
+Used in: method-params
+-->
+<!ELEMENT method-param (#PCDATA)>
+
+
+<!--
+  The value of the archive-name element will be used to derive the default
+name of the app-name when app-name is not present in application.xml.
+  The default app name will be archive-name value minus the file extension.
+For example, if archive-name is foo.ear, the default app-name will be foo.
+-->
+<!ELEMENT archive-name (#PCDATA)>
+
+<!--
+Specifies the Enterprise Server release with which to be backward compatible
+in terms of JAR visibility requirements for applications.
+The current allowed value is v2, which refers to GlassFish version 2 or
+Enterprise Server version 9.1 or 9.1.1. The Java EE 6 platform specification
+imposes stricter requirements than Java EE 5 did on which JAR files can be
+visible to various modules within an EAR file. Setting this element to v2
+removes these Java EE 6 restrictions.
+-->
+<!ELEMENT compatibility (#PCDATA)>
+
+<!--
+The keep-state element indicates whether the state information should be
+preserved across redeployment.
+-->
+<!ELEMENT keep-state (#PCDATA)>
+
+<!--
+The version-identifier element contains the version information. The value is
+ retrieved at deployment.
+-->
+<!ELEMENT version-identifier (#PCDATA)>
+
+<!--
+Payara flag to delegate classloader to parent class or not
+-->
+<!ELEMENT classloading-delegate (#PCDATA)>
+
+<!--
+Payara flag to enable / disable implicit CDI for EAR file
+-->
+<!ELEMENT enable-implicit-cdi (#PCDATA)>
+
+<!--
+Payara flag to include / exclude specific JARs for CDI scanning inside EAR files
+-->
+<!ELEMENT scanning-exclude (#PCDATA)>
+<!ELEMENT scanning-include (#PCDATA)>
+
+<!--
+Payara flag to enable / specify whitelist for extreme ClassLoader isolation
+-->
+<!ELEMENT whitelist-package (#PCDATA)>
+
+<!--
+Syntax for supplying properties as name value pairs
+-->
+<!ELEMENT property (description?)>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!ELEMENT description (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-ejb-jar_3_2-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-ejb-jar_3_2-0.dtd
@@ -64,7 +64,7 @@ System unique object id. Automatically generated and updated at deployment/redep
 <!--
 This is the root element describing all the runtime of an ejb-jar in the application.
 -->
-<!ELEMENT enterprise-beans (name?, unique-id?, ejb*,
+<!ELEMENT enterprise-beans (name?, unique-id?, ejb*, pm-descriptors?, cmp-resource?,
 	message-destination*, webservice-description*, property*, webservice-default-login-config?)>
 
 <!--
@@ -81,7 +81,7 @@ Additional properties applicable to a stateful session bean:
     bean-cache, webservice-endpoint, checkpointed-methods?, checkpoint-at-end-of-method?
 
 Additional properties applicable to an entity bean:
-   is-read-only-bean?, refresh-period-in-seconds?, commit-option?, bean-cache?, bean-pool?, flush-at-end-of-method?
+   is-read-only-bean?, refresh-period-in-seconds?, cmp?, commit-option?, bean-cache?, bean-pool?, flush-at-end-of-method?
 
 Additional properties applicable to a message-driven bean:
    mdb-resource-adapter?, mdb-connection-factory?, jms-durable-subscription-name?, 
@@ -90,10 +90,10 @@ Additional properties applicable to a message-driven bean:
 -->
 
 <!ELEMENT ejb (ejb-name, jndi-name?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, pass-by-reference?, 
-               principal?, mdb-connection-factory?, jms-durable-subscription-name?,
+               cmp?, principal?, mdb-connection-factory?, jms-durable-subscription-name?,
                jms-max-messages-load?, ior-security-config?, is-read-only-bean?, clustered-bean?, clustered-key-name?, clustered-lock-type?, clustered-attach-postconstruct?, clustered-detach-predestroy?,
                refresh-period-in-seconds?, commit-option?, cmt-timeout-in-seconds?, use-thread-pool-id?, gen-classes?, 
-               bean-pool?, bean-cache?, mdb-resource-adapter?, webservice-endpoint*, flush-at-end-of-method?, checkpoint-at-end-of-method?, per-request-load-balancing?)>
+               bean-pool?, bean-cache?, mdb-resource-adapter?, webservice-endpoint*, flush-at-end-of-method?, checkpointed-methods?, checkpoint-at-end-of-method?, per-request-load-balancing?)>
 
 <!-- 
 This attribute is only applicable for stateful session bean 
@@ -164,6 +164,44 @@ The ejb ref name locates the name of the ejb reference in the application.
 <!ELEMENT ejb-ref-name (#PCDATA)>
 
 <!--
+This element describes runtime information for a CMP EntityBean object for
+EJB1.1 and EJB2.0 beans.
+-->
+<!ELEMENT cmp (mapping-properties?, is-one-one-cmp?, one-one-finders?, prefetch-disabled?)>
+
+<!--
+This contains the location of the persistence vendor specific O/R mapping file
+-->
+<!ELEMENT mapping-properties (#PCDATA)>
+
+<!--
+This element in deprecated. It has been left in the DTD for validation purposes.
+Any value will be ignored by the runtime.
+-->
+<!ELEMENT is-one-one-cmp (#PCDATA)>
+
+<!--
+This root element contains the finders for CMP 1.1.
+-->
+<!ELEMENT one-one-finders (finder+ )>
+
+<!--
+This element allows to selectively disable relationship prefetching for finders of a bean.
+Used in: cmp
+-->
+<!ELEMENT prefetch-disabled (query-method+)>
+
+<!--
+Used in: prefetch-disabled
+-->
+<!ELEMENT query-method (method-name, method-params)>
+
+<!--
+This root element contains the finder for CMP 1.1 with a method-name and query parameters
+-->
+<!ELEMENT finder (method-name, query-params?, query-filter?, query-variables?,  query-ordering?)>
+
+<!--
 The method-name element contains a name of an enterprise bean method
 or the asterisk (*) character. The asterisk is used when the element
 denotes all the methods of an enterprise bean's component and home
@@ -172,6 +210,55 @@ interfaces.
 Used in: method, finder, query-method, java-method
 -->
 <!ELEMENT method-name (#PCDATA)>
+
+
+<!--
+This contains the query parameters for CMP 1.1 finder
+-->
+<!ELEMENT query-params (#PCDATA)>
+
+<!--
+This optional element contains the query filter for CMP 1.1 finder
+-->
+<!ELEMENT query-filter (#PCDATA)>
+
+<!--
+This optional element contains variables in query expression for CMP 1.1 finder
+-->
+<!ELEMENT query-variables (#PCDATA)>
+
+<!--
+This optional element contains the ordering specification for CMP 1.1 finder.
+-->
+
+<!ELEMENT query-ordering (#PCDATA)>
+
+<!--
+This element identifies the database and the policy for processing CMP beans
+storage. The jndi-name element identifies either the persistence-manager-
+factory-resource or the jdbc-resource as defined in the server configuration.
+-->
+<!ELEMENT cmp-resource (jndi-name, default-resource-principal?, property*,
+        create-tables-at-deploy?, drop-tables-at-undeploy?,
+        database-vendor-name?, schema-generator-properties?)>
+
+<!--
+This element contains the override properties for the schema generation
+from CMP beans in this module.
+-->
+<!ELEMENT schema-generator-properties (property*) >
+
+<!--
+This element specifies whether automatic creation of tables for the CMP beans
+is done at module deployment. Acceptable values are true or false
+-->
+<!ELEMENT create-tables-at-deploy ( #PCDATA )>
+
+<!--
+This element specifies whether automatic dropping of tables for the CMP beans
+is done at module undeployment. Acceptabel values are true of false
+-->
+<!ELEMENT drop-tables-at-undeploy ( #PCDATA )>
 
 <!--
 This element specifies the database vendor name for ddl files generated at
@@ -287,6 +374,23 @@ pseudo-random selection policy.
 <!ELEMENT victim-selection-policy (#PCDATA)>
 
 <!--
+Support backward compatibility with AS7.1
+Now deprecated in 8.1 and later releases
+Use checkpoint-at-end-of-method element instead
+
+The methods should be separated by semicolons.
+The param list should separated by commas.
+All method param types should be full qualified.
+Variable name is allowed for the param type.
+No return type or exception type.
+Example:
+foo(java.lang.String, a.b.c d); bar(java.lang.String s)
+
+Used in: ejb
+-->
+<!ELEMENT checkpointed-methods (#PCDATA)>
+
+<!--
 The equivalent element of checkpointed-methods for 8.1 and later releases
 
 Used in: ejb
@@ -297,7 +401,7 @@ Used in: ejb
 bean-pool is a root element containing the bean pool properties. Used
 for stateless session bean, entity bean, and message-driven bean pools.
 -->
-<!ELEMENT bean-pool (steady-pool-size?, resize-quantity?, max-pool-size?, pool-idle-timeout-in-seconds?)>
+<!ELEMENT bean-pool (steady-pool-size?, resize-quantity?, max-pool-size?, pool-idle-timeout-in-seconds?, max-wait-time-in-millis?)>
 
 <!--
 steady-pool-size specified the initial and minimum number of beans that must be maintained in the pool. 
@@ -340,6 +444,12 @@ Specifies the timeout for transactions started by the container. This value must
 Specifes the thread pool that will be used to process any invocation on this ejb
 -->
 <!ELEMENT use-thread-pool-id (#PCDATA)>
+
+<!--
+Specifies the maximum time that the caller is willing to wait to get a bean from the pool.
+Wait time is infinite, if the value specified is 0. Deprecated.
+-->
+<!ELEMENT max-wait-time-in-millis (#PCDATA)>
 
 <!--
 refresh-period-in-seconds specifies the rate at which the read-only-bean must be refreshed 
@@ -500,6 +610,52 @@ ejb modules. Allowed values are true and false. Default will be false.
 <!ELEMENT pass-by-reference (#PCDATA)>
 
 <!--
+PM descriptors contain one or more pm descriptors, but only one of them must
+be in use at any given time. If not specified, the Sun CMP is used.
+-->
+<!ELEMENT pm-descriptors ( pm-descriptor+, pm-inuse)>
+
+<!--
+pm-descriptor describes the pluggable vendor implementation for the CMP
+support of the CMP entity beans in this module.
+-->
+<!ELEMENT pm-descriptor ( pm-identifier, pm-version, pm-config?, pm-class-generator?, pm-mapping-factory?)>
+
+<!--
+pm-identifier element identifies the vendor who provides the CMP implementation
+-->
+<!ELEMENT pm-identifier (#PCDATA)>
+
+<!--
+pm-version further specifies which version of PM vendor product to be used
+-->
+<!ELEMENT pm-version (#PCDATA)>
+
+<!--
+pm-config specifies the vendor specific config file to be used
+-->
+<!ELEMENT pm-config (#PCDATA)>
+
+<!--
+pm-class-generator specifies the vendor specific class generator to be used
+at the module deploymant time. This is the name of the class specific to this
+vendor.
+-->
+<!ELEMENT pm-class-generator (#PCDATA)>
+
+<!--
+pm-mapping-factory specifies the vendor specific mapping factory
+This is the name of the class specific to a vendor.
+-->
+<!ELEMENT pm-mapping-factory (#PCDATA)>
+
+<!--
+pm-inuse specifies which CMP vendor is used.
+-->
+<!ELEMENT pm-inuse (pm-identifier, pm-version)>
+
+
+<!--
 This holds the runtime configuration properties of the message-driven bean 
 in its operation environment.  For example, this may include information 
 about the name of a physical JMS destination etc.
@@ -561,7 +717,7 @@ Used in: ejb
 
 
 <!--
-Used in: flush-at-end-of-method, checkpoint-at-end-of-method
+Used in: flush-at-end-of-method, checkpoint-at-end-of-method, prefetch-disabled
 -->
 <!ELEMENT method (description?, ejb-name?, method-name, method-intf?, method-params?)>
 
@@ -588,7 +744,7 @@ Used in: method
 The method-params element contains a list of the fully-qualified Java
 type names of the method parameters.
 
-Used in: method, java-method
+Used in: method, query-method, java-method
 -->
 <!ELEMENT method-params (method-param*)>
 

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-ejb-jar_3_2-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-ejb-jar_3_2-0.dtd
@@ -1,0 +1,1071 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+    Portions Copyright 2026 Payara Foundation and/or its affiliates
+-->
+
+<!--
+  XML DTD for Payara Server specific EJB jar module
+  deployment descriptor. This is a companion DTD for ejb-jar_3_2.xsd
+
+  It must include a DOCTYPE of the following form:
+
+  <!DOCTYPE payara-ejb-jar PUBLIC "-//Payara.fish//DTD Payara Application Server 5 EJB 3.2//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-ejb-jar_3_2-0.dtd">
+
+-->
+
+<!--
+This is the root element of the ejb module descriptor document.
+-->
+<!ELEMENT payara-ejb-jar (security-role-mapping*, enterprise-beans, compatibility?, disable-nonportable-jndi-names?, keep-state?, version-identifier?, property*) >
+
+<!-- 
+System unique object id. Automatically generated and updated at deployment/redeployment 
+-->
+<!ELEMENT unique-id (#PCDATA)>
+
+<!--
+This is the root element describing all the runtime of an ejb-jar in the application.
+-->
+<!ELEMENT enterprise-beans (name?, unique-id?, ejb*,
+	message-destination*, webservice-description*, property*, webservice-default-login-config?)>
+
+<!--
+This is the element describing runtime bindings for a single ejb.
+
+Properties applicable to all types of beans:
+     ejb-name, ejb-ref*, jndi-name, resource-ref*, resource-env-ref*, message-destination-ref*, pass-by-reference?, 
+     ior-security-config?, gen-classes?, service-ref*
+
+Additional properties applicable to a stateless session bean:
+    bean-pool, webservice-endpoint
+
+Additional properties applicable to a stateful session bean:
+    bean-cache, webservice-endpoint, checkpointed-methods?, checkpoint-at-end-of-method?
+
+Additional properties applicable to an entity bean:
+   is-read-only-bean?, refresh-period-in-seconds?, commit-option?, bean-cache?, bean-pool?, flush-at-end-of-method?
+
+Additional properties applicable to a message-driven bean:
+   mdb-resource-adapter?, mdb-connection-factory?, jms-durable-subscription-name?, 
+   jms-max-messages-load?, bean-pool?
+   ( In case of MDB, jndi-name is the jndi name of the associated jms destination )
+-->
+
+<!ELEMENT ejb (ejb-name, jndi-name?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, pass-by-reference?, 
+               principal?, mdb-connection-factory?, jms-durable-subscription-name?,
+               jms-max-messages-load?, ior-security-config?, is-read-only-bean?, clustered-bean?, clustered-key-name?, clustered-lock-type?, clustered-attach-postconstruct?, clustered-detach-predestroy?,
+               refresh-period-in-seconds?, commit-option?, cmt-timeout-in-seconds?, use-thread-pool-id?, gen-classes?, 
+               bean-pool?, bean-cache?, mdb-resource-adapter?, webservice-endpoint*, flush-at-end-of-method?, checkpoint-at-end-of-method?, per-request-load-balancing?)>
+
+<!-- 
+This attribute is only applicable for stateful session bean 
+-->
+<!ATTLIST ejb availability-enabled CDATA #IMPLIED>
+
+<!--
+The text in this element matches the ejb-name of the ejb to which it refers in ejb-jar.xml.
+
+Used in ejb, method
+-->
+<!ELEMENT ejb-name (#PCDATA)>
+
+<!--
+The text in this element is a true/false flag for read only beans.
+-->
+<!ELEMENT is-read-only-bean (#PCDATA)>
+
+<!--
+The text in this element is a true/false flag for Payara clustered singleton beans.
+-->
+<!ELEMENT clustered-bean (#PCDATA)>
+
+<!--
+The text in this element is a key name for Payara clustered singleton bean object.
+-->
+<!ELEMENT clustered-key-name (#PCDATA)>
+
+<!--
+The text in this element is a lock type for Payara clustered singleton bean.
+It can be one of inherit, none, and lock
+-->
+<!ELEMENT clustered-lock-type (#PCDATA)>
+
+<!--
+The text in this element is a true/false flag for Payara clustered singleton beans
+whether to call @PostConstruct methods when attaching bean to the cluster when
+this bean already exists on another node. (not really created)
+Default is true
+-->
+<!ELEMENT clustered-attach-postconstruct (#PCDATA)>
+
+<!--
+The text in this element is a true/false flag for Payara clustered singleton beans
+whether to call @PreDestroy methods when detaching bean from the cluster and
+this bean also exists on another node. (not really destroyed)
+Default is true
+-->
+<!ELEMENT clustered-detach-predestroy (#PCDATA)>
+
+<!--
+This element contains a true/false flag that controls the per-request load balancing
+behavior of EJB 2.x/3.x Remote client invocations on a stateless session bean. If set
+to true, per-request load balancing is enabled for the associated stateless session
+bean.  If set to false or not set, per-request load balancing is not enabled. 
+-->
+<!ELEMENT per-request-load-balancing (#PCDATA)>
+
+<!--
+This is the root element which binds an ejb reference to a jndi name.
+It is used for both ejb remote reference and ejb local reference.
+-->
+<!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+
+<!--
+The ejb ref name locates the name of the ejb reference in the application.
+-->
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!--
+The method-name element contains a name of an enterprise bean method
+or the asterisk (*) character. The asterisk is used when the element
+denotes all the methods of an enterprise bean's component and home
+interfaces.
+
+Used in: method, finder, query-method, java-method
+-->
+<!ELEMENT method-name (#PCDATA)>
+
+<!--
+This element specifies the database vendor name for ddl files generated at
+module deployment. Default is SQL92.
+-->
+<!ELEMENT database-vendor-name ( #PCDATA )>
+
+<!--
+This element specifies the connection factory associated with a message-driven bean.
+-->
+<!ELEMENT mdb-connection-factory (jndi-name, default-resource-principal?)>
+
+<!--
+This node holds information about a logical message destination
+-->
+<!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+<!--
+This node holds the name of a logical message destination
+-->
+<!ELEMENT message-destination-name (#PCDATA)>
+
+<!--
+message-destination-ref is used to directly bind a message destination reference
+to the jndi-name of a Queue,Topic, or some other physical destination. It should
+only be used when the corresponding message destination reference does not
+specify a message-destination-link to a logical message-destination.
+-->
+<!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+<!--
+name of a message-destination reference.
+-->
+<!ELEMENT message-destination-ref-name (#PCDATA)>
+
+<!--
+Specifies the name of a durable subscription associated with a message-driven bean's 
+destination.  Required for a Topic destination, if subscription-durability is set to 
+Durable (in ejb-jar.xml)
+-->
+<!ELEMENT jms-durable-subscription-name (#PCDATA)>
+
+<!--
+A string value specifies the maximum number of messages to load into a JMS session 
+at one time for a message-driven bean to serve. If not specified, the default is 1.
+-->
+<!ELEMENT jms-max-messages-load (#PCDATA)>
+
+<!--
+This element contains all the generated class names for a bean.
+-->
+<!ELEMENT gen-classes ( remote-impl?, local-impl?, remote-home-impl?, local-home-impl? )>
+
+<!--
+This contains the fully qualified class name of the generated EJBObject impl class. 
+-->
+<!ELEMENT remote-impl (#PCDATA)>
+
+<!--
+This contains the fully qualified class name of the generated EJBLocalObject impl class. 
+-->
+<!ELEMENT local-impl (#PCDATA)>
+
+<!--
+This contains the fully qualified class name of the generated EJBHome impl class. 
+-->
+<!ELEMENT remote-home-impl (#PCDATA)>
+
+<!--
+This contains the fully qualified class name of the generated EJBLocalHome impl class. 
+-->
+<!ELEMENT local-home-impl (#PCDATA)>
+
+<!--
+This contains the bean cache properties. Used only for entity beans and stateful session beans
+-->
+<!ELEMENT bean-cache (max-cache-size?, resize-quantity?, is-cache-overflow-allowed?, cache-idle-timeout-in-seconds?, removal-timeout-in-seconds?, victim-selection-policy?)>
+
+<!--
+max-cache-size defines the maximum number of beans in the cache. Should be greater than 1.
+Default is 512.
+-->
+<!ELEMENT max-cache-size (#PCDATA)>
+
+<!--
+is-cache-overflow-allowed is a boolean which indicates if the cache size is a hard limit or not. 
+Default is true i.e there is no hard limit. max-cache-size is a hint to the cache implementation.
+-->
+<!ELEMENT is-cache-overflow-allowed (#PCDATA)>
+
+<!--
+cache-idle-timeout-in-seconds specifies the maximum time that a stateful session bean or 
+entity bean is allowed to be idle in the cache. After this time, the bean is passivated 
+to backup store. This is a hint to server. Default value for cache-idle-timeout-in-seconds 
+is 600 seconds.
+-->
+<!ELEMENT cache-idle-timeout-in-seconds (#PCDATA)>
+
+
+<!--
+The amount of time that the bean remains passivated (i.e. idle in the backup store) is 
+controlled by removal-timeout-in-seconds parameter.  Note that if a bean was not accessed beyond 
+removal-timeout-in-seconds, then it will be removed from the backup store and hence will not 
+be accessible to the client. The Default value for removal-timeout-in-seconds is 60min.
+-->
+<!ELEMENT removal-timeout-in-seconds (#PCDATA)>
+
+<!--
+victim-selection-policy specifies the algorithm to use to pick victims. 
+Possible values are FIFO | LRU | NRU. Default is NRU, which is actually 
+pseudo-random selection policy.
+-->
+<!ELEMENT victim-selection-policy (#PCDATA)>
+
+<!--
+The equivalent element of checkpointed-methods for 8.1 and later releases
+
+Used in: ejb
+-->
+<!ELEMENT checkpoint-at-end-of-method (method+)>
+
+<!--
+bean-pool is a root element containing the bean pool properties. Used
+for stateless session bean, entity bean, and message-driven bean pools.
+-->
+<!ELEMENT bean-pool (steady-pool-size?, resize-quantity?, max-pool-size?, pool-idle-timeout-in-seconds?)>
+
+<!--
+steady-pool-size specified the initial and minimum number of beans that must be maintained in the pool. 
+Valid values are from 0 to MAX_INTEGER. 
+-->
+<!ELEMENT steady-pool-size (#PCDATA)>
+
+<!--
+resize-quantity specifies the number of beans to be created or deleted when the pool 
+or cache is being serviced by the server. Valid values are from 0 to MAX_INTEGER and 
+subject to maximum size limit).  Default is 16.
+-->
+<!ELEMENT resize-quantity (#PCDATA)>
+
+<!--
+max-pool-size speifies the maximum pool size. Valid values are from 0 to MAX_INTEGER. 
+Default is 64.
+-->
+<!ELEMENT max-pool-size (#PCDATA)>
+
+<!--
+pool-idle-timeout-in-seconds specifies the maximum time that a stateless session bean or 
+message-driven bean is allowed to be idle in the pool. After this time, the bean is 
+passivated to backup store.  This is a hint to server. Default value for 
+pool-idle-timeout-in-seconds is 600 seconds.
+-->
+<!ELEMENT pool-idle-timeout-in-seconds (#PCDATA)>
+
+<!--
+A string field whose valid values are either "B", or "C". Default is "B" 
+-->
+<!ELEMENT commit-option (#PCDATA)>
+
+<!--
+Specifies the timeout for transactions started by the container. This value must be greater than zero, else it will be ignored by the container.
+-->
+<!ELEMENT cmt-timeout-in-seconds (#PCDATA)>
+
+<!--
+Specifes the thread pool that will be used to process any invocation on this ejb
+-->
+<!ELEMENT use-thread-pool-id (#PCDATA)>
+
+<!--
+refresh-period-in-seconds specifies the rate at which the read-only-bean must be refreshed 
+from the data source. 0 (never refreshed) and positive (refreshed at specified intervals).
+Specified value is a hint to the container.  Default is 600 seconds.
+-->
+<!ELEMENT refresh-period-in-seconds (#PCDATA)>
+
+<!--
+Specifies the jndi name string.
+-->
+<!ELEMENT  jndi-name (#PCDATA)>
+
+<!--
+This text nodes holds a name string.
+-->
+<!ELEMENT name (#PCDATA)>
+
+<!--
+This element holds password text.
+-->
+<!ELEMENT password (#PCDATA)>
+
+<!--
+This node describes a username on the platform.
+-->
+<!ELEMENT principal (name)>
+
+<!-- 
+security-role-mapping element maps the user principal or group 
+to a different principal on the server. 
+-->
+<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)> 
+
+<!-- 
+role-name specifies an accepted role 
+-->
+<!ELEMENT role-name (#PCDATA)> 
+
+<!-- 
+principal-name specifies a valid principal 
+-->
+<!ELEMENT principal-name (#PCDATA)> 
+<!ATTLIST principal-name class-name CDATA #IMPLIED>
+
+<!-- 
+group-name specifies a valid group name 
+-->
+<!ELEMENT group-name (#PCDATA)> 
+
+<!--
+The name of a resource reference.
+-->
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!--
+resource-env-ref holds all the runtime bindings of a resource env reference.
+-->
+<!ELEMENT resource-env-ref ( resource-env-ref-name, jndi-name )>
+
+<!--
+name of a resource env reference.
+-->
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!--
+resource-ref node holds all the runtime bindings of a resource reference.
+-->
+<!ELEMENT resource-ref  (res-ref-name, jndi-name, default-resource-principal?)>
+
+<!--
+user name and password to be used when none are specified while accesing a resource
+-->
+<!ELEMENT default-resource-principal ( name,  password)>
+
+<!--
+ior-security-config element describes the security configuration information for the IOR.
+-->  
+<!ELEMENT ior-security-config ( transport-config? , as-context?, sas-context?  )> 
+
+<!--
+transport-config is the root element for security between the end points
+-->
+<!ELEMENT transport-config ( integrity, confidentiality, establish-trust-in-target, establish-trust-in-client )> 
+
+<!--
+integrity element indicates if the server (target) supports integrity protected messages. 
+The valid values are NONE, SUPPORTED or REQUIRED
+-->  
+<!ELEMENT integrity ( #PCDATA)>
+
+<!--
+confidentiality element indicates if the server (target) supports privacy protected 
+messages. The values are NONE, SUPPORTED or REQUIRED
+-->  
+<!ELEMENT confidentiality ( #PCDATA)>
+
+<!--
+establish-trust-in-target element indicates if the target is capable of authenticating to a client. 
+The values are NONE or SUPPORTED.
+-->  
+<!ELEMENT establish-trust-in-target ( #PCDATA)>
+
+<!--
+establish-trust-in-client element indicates if the target is capable of authenticating a client. The
+values are NONE, SUPPORTED or REQUIRED.
+-->  
+<!ELEMENT establish-trust-in-client ( #PCDATA)>
+
+<!--
+as-context (CSIv2 authentication service) is the element describing the authentication 
+mechanism that will be used to authenticate the client. If specified it will be the 
+username-password mechanism.
+-->  
+<!ELEMENT as-context ( auth-method, realm, required )> 
+
+<!--
+required element specifies if the authentication method specified is required
+to be used for client authentication. If so the EstablishTrustInClient bit
+will be set in the target_requires field of the AS_Context. The element value
+is either true or false. 
+-->  
+<!ELEMENT required ( #PCDATA )> 
+
+<!--
+auth-method element describes the authentication method.
+For CSIv2, the only supported value is USERNAME_PASSWORD.
+For EJB web service endpoint, supported values are BASIC and CLIENT-CERT.
+-->  
+<!ELEMENT auth-method ( #PCDATA )> 
+
+<!--
+realm element describes the realm in which the user is authenticated. Must be 
+a valid realm that is registered in server configuration.
+-->  
+<!ELEMENT realm ( #PCDATA )> 
+
+<!--
+sas-context (related to CSIv2 security attribute service) element describes 
+the sas-context fields.
+-->  
+<!ELEMENT sas-context ( caller-propagation )> 
+
+<!--
+caller-propagation element indicates if the target will accept propagated caller identities
+The values are NONE or SUPPORTED.
+-->  
+<!ELEMENT caller-propagation ( #PCDATA) >
+
+<!-- 
+pass-by-reference elements controls use of Pass by Reference semantics.  
+EJB spec requires pass by value, which will be the default mode of operation. 
+This can be set to true for non-compliant operation and possibly higher 
+performance. For a stand-alone server, this can be used. By setting a similarly 
+named element at payara-application.xml, it can apply to all the enclosed
+ejb modules. Allowed values are true and false. Default will be false.
+ -->
+<!ELEMENT pass-by-reference (#PCDATA)>
+
+<!--
+This holds the runtime configuration properties of the message-driven bean 
+in its operation environment.  For example, this may include information 
+about the name of a physical JMS destination etc.
+Defined this way to match the activation-config on the standard
+deployment descriptor for message-driven bean.
+-->
+<!ELEMENT activation-config ( description?, activation-config-property+ ) >
+
+<!--
+provide an element description
+
+Used in activation-config, method
+-->
+<!ELEMENT description (#PCDATA)>
+
+<!--
+This hold a particular activation config propery name-value pair
+-->
+<!ELEMENT activation-config-property ( 
+  activation-config-property-name, activation-config-property-value ) >
+
+<!--
+This holds the name of a runtime activation-config property
+-->
+<!ELEMENT activation-config-property-name ( #PCDATA ) >
+
+<!--
+This holds the value of a runtime activation-config property
+-->
+<!ELEMENT activation-config-property-value ( #PCDATA ) >
+
+<!--
+This node holds the module ID of the resource adapter that
+is responsible for delivering messages to the message-driven
+bean, as well as the runtime configuration information for
+the mdb.
+-->
+<!ELEMENT mdb-resource-adapter ( resource-adapter-mid, activation-config? )>
+
+<!--
+This node holds the module ID of the resource adapter that is responsible 
+for delivering messages to the message-driven bean.
+-->
+<!ELEMENT resource-adapter-mid ( #PCDATA ) >
+
+<!--
+This text nodes holds a value string.
+-->
+<!ELEMENT value (#PCDATA)>
+
+<!--
+This declares the list of methods that would be allowed to be flushed at the 
+completion of the method. Applicable to entity beans with container managed 
+persistence
+
+Used in: ejb
+-->
+<!ELEMENT flush-at-end-of-method (method+)>
+
+
+<!--
+Used in: flush-at-end-of-method, checkpoint-at-end-of-method
+-->
+<!ELEMENT method (description?, ejb-name?, method-name, method-intf?, method-params?)>
+
+
+<!--
+The method-intf element allows a method element to differentiate
+between the methods with the same name and signature that are multiply
+defined across the component and home interfaces (e.g., in both an
+enterprise bean's remote and local interfaces; in both an enterprise bean's
+home and remote interfaces, etc.)
+
+The method-intf element must be one of the following:
+	<method-intf>Home</method-intf>
+	<method-intf>Remote</method-intf>
+	<method-intf>LocalHome</method-intf>
+	<method-intf>Local</method-intf>
+
+Used in: method
+-->
+<!ELEMENT method-intf (#PCDATA)>
+
+
+<!--
+The method-params element contains a list of the fully-qualified Java
+type names of the method parameters.
+
+Used in: method, java-method
+-->
+<!ELEMENT method-params (method-param*)>
+
+
+<!--
+The method-param element contains the fully-qualified Java type name
+of a method parameter.
+
+Used in: method-params
+-->
+<!ELEMENT method-param (#PCDATA)>
+
+
+<!--
+  			W E B   S E R V I C E S 
+-->
+<!--
+Information about a web service endpoint.
+
+The optional message-security-binding element is used to customize the
+webservice-endpoint to provider binding; either by binding the
+webservice-endpoint to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+When login-config is specified, a default message-security provider
+is not applied to the endpoint.
+-->
+<!ELEMENT webservice-endpoint ( port-component-name, endpoint-address-uri?, (login-config | message-security-binding)?, transport-guarantee?, service-qname?, tie-class?, servlet-impl-class?, debugging-enabled? )>
+
+<!--
+Unique name of a port component within a module
+-->
+<!ELEMENT port-component-name ( #PCDATA )>
+
+<!--
+Relative path combined with web server root to form fully qualified
+endpoint address for a web service endpoint.  For servlet endpoints, this
+value is relative to the servlet's web application context root.  In
+all cases, this value must be a fixed pattern(i.e. no "*" allowed).
+If the web service endpoint is a servlet that only implements a single
+endpoint has only one url-pattern, it is not necessary to set 
+this value since the container can derive it from web.xml.
+-->
+<!ELEMENT endpoint-address-uri ( #PCDATA )>
+
+<!--
+The name of tie implementation class for a port-component.  This is
+not specified by the deployer.  It is derived during deployment.
+-->
+<!ELEMENT tie-class (#PCDATA)>
+
+<!-- 
+The service-qname element declares the specific WSDL service
+element that is being refered to.  It is not set by the deployer.
+It is derived during deployment.
+-->
+<!ELEMENT service-qname (namespaceURI, localpart)>
+
+<!--
+The localpart element indicates the local part of a QNAME.
+-->
+<!ELEMENT localpart (#PCDATA)>
+
+<!--
+The namespaceURI element indicates a URI.
+-->
+<!ELEMENT namespaceURI (#PCDATA)>
+
+<!-- 
+Optional authentication configuration for an EJB web service endpoint.
+Not needed for servet web service endpoints.  Their security configuration
+is contained in the standard web application descriptor.
+-->
+<!ELEMENT login-config ( auth-method, realm? )>
+
+<!--
+Name of application-written servlet impl class contained in deployed war.
+This is not set by the deployer.  It is derived by the container
+during deployment.
+-->
+<!ELEMENT servlet-impl-class (#PCDATA)>
+
+<!--
+Specify whether or not the debugging servlet should be enabled for this 
+Web Service endpoint. 
+
+Supported values : "true" to debug the endpoint
+-->
+<!ELEMENT debugging-enabled (#PCDATA)>
+
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+<!ELEMENT service-ref ( service-ref-name, port-info*, call-property*, wsdl-override?, service-impl-class?, service-qname? )>
+
+<!--
+Coded name (relative to java:comp/env) for a service-reference
+-->
+<!ELEMENT service-ref-name ( #PCDATA )>
+
+<!--
+Name of generated service implementation class. This is not set by the 
+deployer. It is derived during deployment.
+-->
+<!ELEMENT service-impl-class ( #PCDATA )>
+
+<!-- 
+Information for a port within a service-reference.
+
+Either service-endpoint-interface or wsdl-port or both
+(service-endpoint-interface and wsdl-port) should be specified.  
+
+If both are specified, wsdl-port represents the
+port the container should choose for container-managed port selection.
+
+The same wsdl-port value must not appear in
+more than one port-info entry within the same service-ref.
+
+If a particular service-endpoint-interface is using container-managed port
+selection, it must not appear in more than one port-info entry
+within the same service-ref.
+
+The optional message-security-binding element is used to customize the
+port to provider binding; either by binding the port to a specific provider
+or by providing a definition of the message security requirements to be
+enforced by the provider.
+
+-->
+<!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+<!--
+Fully qualified name of service endpoint interface
+-->
+<!ELEMENT service-endpoint-interface ( #PCDATA )>
+
+<!--
+Specifies that the communication between client and server should 
+be NONE, INTEGRAL, or CONFIDENTIAL. NONE means that the application 
+does not require any transport guarantees. A value of INTEGRAL means 
+that the application requires that the data sent between the client 
+and server be sent in such a way that it can't be changed in transit. 
+CONFIDENTIAL means that the application requires that the data be 
+transmitted in a fashion that prevents other entities from observing 
+the contents of the transmission. In most cases, the presence of the 
+INTEGRAL or CONFIDENTIAL flag will indicate that the use of SSL is 
+required.
+-->
+<!ELEMENT transport-guarantee ( #PCDATA )>
+
+
+<!-- 
+Port used in port-info.  
+-->
+<!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+<!-- 
+JAXRPC property values that should be set on a stub before it's returned to 
+to the web service client.  The property names can be any properties supported
+by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+-->
+<!ELEMENT stub-property ( name, value )>
+
+<!-- 
+JAXRPC property values that should be set on a Call object before it's 
+returned to the web service client.  The property names can be any 
+properties supported by the JAXRPC Call implementation.  See javadoc
+for javax.xml.rpc.Call
+-->
+<!ELEMENT call-property ( name, value )>
+
+<!-- 
+Runtime information about a web service.  
+
+wsdl-publish-location is optionally used to specify 
+where the final wsdl and any dependent files should be stored.  This location
+resides on the file system from which deployment is initiated.
+
+-->
+<!ELEMENT webservice-description ( webservice-description-name, wsdl-publish-location? )>
+
+<!--
+Unique name of a webservice within a module
+-->
+<!ELEMENT webservice-description-name ( #PCDATA )>
+
+<!--
+This is a valid URL pointing to a final WSDL document. It is optional.
+If specified, the WSDL document at this URL will be used during
+deployment instead of the WSDL document associated with the
+service-ref in the standard deployment descriptor.
+
+Examples :
+
+  // available via HTTP
+  <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+  // in a file
+  <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+-->
+<!ELEMENT wsdl-override ( #PCDATA )>
+
+<!--
+file: URL of a directory to which a web-service-description's wsdl should be
+published during deployment.  Any required files will be published to this
+directory, preserving their location relative to the module-specific
+wsdl directory(META-INF/wsdl or WEB-INF/wsdl).
+
+Example :
+
+  For an ejb.jar whose webservices.xml wsdl-file element contains
+    META-INF/wsdl/a/Foo.wsdl 
+
+  <wsdl-publish-location>file:/home/user1/publish
+  </wsdl-publish-location>
+
+  The final wsdl will be stored in /home/user1/publish/a/Foo.wsdl
+
+-->
+<!ELEMENT wsdl-publish-location ( #PCDATA )>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-config elements.
+
+Used in: message-security-config
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-binding element is used to customize the
+webservice-endpoint or port to provider binding; either by binding the
+webservice-endpoint or port to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+These elements are typically NOT created as a result of the
+deployment of an application. They need only be created when the
+deployer or system administrator chooses to customize the 
+webservice-endpoint or port to provider binding.
+
+The optional (repeating) message-security sub-element is used 
+to accomplish the latter; in which case the specified 
+message-security requirements override any defined with the
+provider.
+
+The auth-layer attribute identifies the message layer at which the
+message-security requirements are to be enforced.
+
+The optional provider-id attribute identifies the provider-config 
+and thus the authentication provider that is to be used to satisfy 
+the application specific message security requirements. If a value for 
+the provider-id attribute is not specified, and a default
+provider is defined for the message layer, then it is used. 
+if a value for the provider-id attribute is not specified, and a
+default provider is not defined at the layer, the authentication
+requirements defined in the message-security-binding are not
+enforced. 
+ 
+Default:
+Used in: webservice-endpoint, port-info
+-->
+<!ELEMENT message-security-binding ( message-security* )>
+<!ATTLIST message-security-binding
+          auth-layer  %message-layer; #REQUIRED
+          provider-id CDATA           #IMPLIED >
+
+<!--
+The message-security element describes message security requirements
+that pertain to the request and response messages of the containing 
+endpoint, or port
+
+When contained within a webservice-endpoint this element describes 
+the message security requirements that pertain to the request and 
+response messages of the containing endpoint. When contained within a 
+port-info of a service-ref this element describes the message security
+requirements of the port of the referenced service.
+
+The one or more contained message elements define the methods or operations
+of the containing application, endpoint, or referenced service to which 
+the message security requirements apply.
+
+Multiple message-security elements occur within a containing
+element when it is necessary to define different message
+security requirements for different messages within the encompassing
+context. In such circumstances, the peer elements should not overlap
+in the messages they pertain to. If there is any overlap in the
+identified messages, no message security requirements apply to
+the messages for which more than one message-security element apply.
+
+Also, no message security requirements apply to any messages of
+the encompassing context that are not identified by a message element. 
+ 
+Default:
+Used in: webservice-endpoint, and port-info
+-->
+<!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+<!--
+The message element identifies the methods or operations to which
+the message security requirements apply.
+
+The identified methods or operations are methods or operations of
+the resource identified by the context in which the message-security
+element is defined (e.g. the the resource identified by the
+service-qname of the containing webservice-endpoint or service-ref).
+
+An empty message element indicates that the security requirements
+apply to all the methods or operations of the identified resource.
+
+When operation-name is specified, the security
+requirements defined in the containing message-security 
+element apply to all the operations of the endpoint 
+with the specified (and potentially overloaded) operation name.
+
+Default: 
+Used in: message-security
+-->
+<!ELEMENT message ( java-method? | operation-name? )>
+
+<!--
+The java-method element is used to identify a method (or methods
+in the case of an overloaded method-name) of the java class 
+indicated by the context in which the java-method is contained.
+
+Default: 
+Used in: message
+-->
+<!ELEMENT java-method ( method-name, method-params? )>
+
+<!--
+The operation-name element is used to identify the WSDL name of an
+operation of a web service.
+
+Default: 
+Used in: message
+-->
+<!ELEMENT operation-name ( #PCDATA )>
+
+<!--
+The request-protection element describes the authentication requirements
+that apply to a request.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent request-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default: 
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * request-protection ( content-auth-policy* )
+ *
+ * If the request-protection element contains one or more
+ * content-auth-policy sub-elements, they define the authentication
+ * requirements to be applied to the identified request content. If multiple
+ * content-auth-policy sub-elements are defined, a request sender must
+ * satisfy the requirements independently, and in the specified order.  
+ *
+ * The content-auth-policy element would be used to associate authentication
+ * requirements with the parts of the request or response object identified
+ * by the contained method-params or part-name-list sub-elements.
+ *
+ * The content-auth-policy element would be defined as follows:
+ * 
+ * content-auth-policy ( method-params | part-name-list )
+ * ATTLIST content-auth-policy 
+ *         auth-source (sender | content) #IMPLIED
+ *	   auth-recipient (before-content | after-content) #IMPLIED
+ * 
+ * The part-name-list and part-name elements would be defined as follows:
+ *
+ * part-name-list ( part-name* )
+ * part-name ( #PCDATA )
+ *
+-->
+<!ELEMENT request-protection EMPTY >
+<!ATTLIST request-protection
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The response-protection element describes the authentication requirements
+that apply to a response.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent response-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default: 
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * response-protection ( content-auth-policy* )
+ *
+ * see request-protection element for more details
+ *
+-->
+<!ELEMENT response-protection EMPTY >
+<!ATTLIST response-protection
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+Specifies the Enterprise Server release with which to be backward compatible
+in terms of JAR visibility requirements for applications.
+The current allowed value is v2, which refers to GlassFish version 2 or
+Enterprise Server version 9.1 or 9.1.1. The Java EE 6 platform specification
+imposes stricter requirements than Java EE 5 did on which JAR files can be 
+visible to various modules. Setting this element to v2
+removes these Java EE 6 restrictions.
+-->
+<!ELEMENT compatibility (#PCDATA)>
+
+<!--
+The disable-nonportable-jndi-names element indicates whether the Payara-
+specific, nonportable jndi names for EJB are disabled.  Acceptable values
+are true and false.  The default value is false.
+-->
+<!ELEMENT disable-nonportable-jndi-names (#PCDATA)>
+
+<!--
+The keep-state element indicates whether the state information should be 
+preserved across redeployment.
+-->
+<!ELEMENT keep-state (#PCDATA)>
+
+<!--
+The version-identifier element contains the version information. The value is
+ retrieved at deployment.
+-->
+<!ELEMENT version-identifier (#PCDATA)>
+
+<!-- 
+Syntax for supplying properties as name value pairs 
+-->
+<!ELEMENT property (description?, name?, value?)>
+<!ATTLIST property name  CDATA  #IMPLIED
+                   value CDATA  #IMPLIED>
+
+<!--
+Optional Default authentication configuration for an EJB web service endpoint.
+The individual bean's configuration takes precedence, but this is the default
+-->
+<!ELEMENT webservice-default-login-config ( auth-method, realm? )>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-web-app_4_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-web-app_4_0-0.dtd
@@ -1,0 +1,871 @@
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+    
+
+    Portions Copyright 2026 Payara Foundation and/or its affiliates
+-->
+
+<!--
+  XML DTD for Payara Application Server specific Jakarta EE web
+  deployment descriptor. This is a companion DTD to web-app_4_0.xsd
+  and web-common_4_0.xsd.
+
+  It must include a DOCTYPE of the following form:
+
+  <!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 5 Servlet 4.0//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-web-app_4_0-0.dtd">
+
+-->
+
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+
+<!-- root element for vendor specific web application (module) configuration -->
+<!ELEMENT payara-web-app (context-root?, security-role-mapping*, servlet*, idempotent-url-pattern*, session-config?,
+                       ejb-ref*, resource-ref*, resource-env-ref*,  service-ref*,
+                       message-destination-ref*, cache?, class-loader?,
+                       jsp-config?, locale-charset-info?, parameter-encoding?,
+                       property*, valve*, message-destination*, webservice-description*, scanning-exclude*, scanning-include*, whitelist-package*, keep-state?, version-identifier?, container-initializer-enabled?, jaxrs-roles-allowed-enabled?)>
+<!ATTLIST payara-web-app error-url CDATA ""
+                      httpservlet-security-provider CDATA #IMPLIED>
+
+<!--
+  Idempotent URL Patterns
+    url-pattern      URL Pattern of the idempotent requests
+    num-of-retries  Specifies the number of times the Load Balancer will retry a request that is idempotent.
+-->
+<!ELEMENT idempotent-url-pattern EMPTY>
+<!ATTLIST idempotent-url-pattern url-pattern CDATA #REQUIRED
+                                 num-of-retries CDATA "-1">
+
+<!-- 
+ Context Root for the web application when the war file is a standalone module.
+ When the war module is part of the Jakarta EE Application, use the application.xml
+-->
+<!ELEMENT context-root (#PCDATA)>
+
+<!ELEMENT security-role-mapping (role-name, (principal-name | group-name)+)>
+<!ELEMENT role-name (#PCDATA)>
+
+<!ELEMENT principal-name (#PCDATA)>
+<!ATTLIST principal-name class-name CDATA #IMPLIED>
+<!ELEMENT group-name (#PCDATA)>
+
+<!ELEMENT servlet (servlet-name, principal-name?, webservice-endpoint*)>
+
+<!ELEMENT session-config (session-manager?, session-properties?, cookie-properties?)>
+
+<!ENTITY % persistence-type "(memory | file | custom | ha | s1ws60 | mmap | replicated)">
+
+<!ELEMENT session-manager (manager-properties?, store-properties?)>
+<!ATTLIST session-manager persistence-type CDATA "memory">
+
+<!ELEMENT manager-properties (property*)>
+<!ELEMENT store-properties (property*)>
+<!ELEMENT session-properties (property*)>
+<!ELEMENT cookie-properties (property*)>
+
+<!ELEMENT jndi-name (#PCDATA)>
+
+<!ELEMENT resource-env-ref (resource-env-ref-name, jndi-name)>
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!ELEMENT resource-ref (res-ref-name, jndi-name, default-resource-principal?)>
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!ELEMENT default-resource-principal ( name,  password)>
+
+<!--
+This node holds information about a logical message destination
+-->
+<!ELEMENT message-destination (message-destination-name, jndi-name)>
+
+<!--
+This node holds the name of a logical message destination
+-->
+<!ELEMENT message-destination-name (#PCDATA)>
+
+<!--
+message-destination-ref is used to directly bind a message destination reference
+to the jndi-name of a Queue,Topic, or some other physical destination. It should
+only be used when the corresponding message destination reference does not
+specify a message-destination-link to a logical message-destination.
+-->
+<!ELEMENT message-destination-ref (message-destination-ref-name, jndi-name)>
+
+<!--
+name of a message-destination reference.
+-->
+<!ELEMENT message-destination-ref-name (#PCDATA)>
+
+<!--
+This text nodes holds a name string.
+-->
+<!ELEMENT name (#PCDATA)>
+
+<!--
+This element holds password text.
+-->
+<!ELEMENT password (#PCDATA)>
+
+
+<!ELEMENT ejb-ref (ejb-ref-name, jndi-name)>
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!ENTITY % scope "(context.attribute | request.header  | request.parameter | 
+                   request.cookie  | request.attribute | session.attribute)">
+<!ENTITY % key-scope "(context.attribute | request.header | request.parameter | 
+                       request.cookie | session.id | session.attribute)">
+<!ENTITY % expr "(equals | greater | lesser | not-equals | in-range)">
+
+<!-- cache element configures the cache for web application. iAS 7.0 web container    
+     supports one such cache object per application: i.e. <cache> is a sub element    
+     of <ias-web-app>. A cache can have zero or more cache-mapping elements and
+     zero or more customizable cache-helper classes.
+                                                                                   
+        max-entries        Maximum number of entries this cache may hold. [4096]
+        timeout-in-seconds Default timeout for the cache entries in seconds. [30]
+        enabled            Is this cache enabled? [true]
+-->
+<!ELEMENT cache (cache-helper*, default-helper?, property*, cache-mapping*)>
+<!ATTLIST cache  max-entries         CDATA     "4096"
+                 timeout-in-seconds  CDATA     "30"
+                 enabled             %boolean; "true">
+
+<!-- cache-helper specifies customizable class which implements CacheHelper interface. 
+
+     name                     Unique name for the helper class; this is referenced in
+                              the cache-mapping elements (see below).
+                              "default" is reserved for the built-in default helper.
+     class-name               Fully qualified class name of the cache-helper; this class
+                              must extend the com.sun.appserv.web.CacheHelper class.
+-->
+<!ELEMENT cache-helper (property*)>
+<!ATTLIST cache-helper name CDATA #REQUIRED
+                       class-name CDATA #REQUIRED>
+
+<!-- 
+Default, built-in cache-helper properties
+-->
+<!ELEMENT default-helper (property*)>
+
+<!-- 
+cache-mapping element defines what to be cached, the key to be used, any other   
+constraints to be applied and a customizable cache-helper to programmatically
+hook this information.
+-->
+<!ELEMENT cache-mapping ((servlet-name | url-pattern), 
+                        (cache-helper-ref |
+                        (dispatcher*, timeout?, refresh-field?, http-method*, key-field*, constraint-field*)))>
+
+<!-- 
+servlet-name element defines a named servlet to which this caching is enabled.
+the specified name must be present in the web application deployment descriptor
+(web.xml)
+-->
+<!ELEMENT servlet-name (#PCDATA)>
+
+<!-- 
+url-pattern element specifies the url pattern to which caching is to be enabled.
+See Servlet 2.3 specification section SRV. 11.2 for the applicable patterns.
+-->
+<!ELEMENT url-pattern  (#PCDATA)>
+
+<!-- 
+cache-helper-ref s a reference to the cache-helper used by this cache-mapping 
+-->
+<!ELEMENT cache-helper-ref (#PCDATA)>
+
+<!-- 
+Specifies the RequestDispatcher methods for which caching is to be
+enabled on the target resource. Valid values are REQUEST, FORWARD, INCLUDE,
+and ERROR (default: REQUEST).
+See SRV.6.2.5 of the Servlet 2.4 Specification for more information.
+-->
+<!ELEMENT dispatcher (#PCDATA)>
+
+<!-- 
+timeout element defines the cache timeout in seconds applicable for this mapping.
+default is to use cache object's timeout. The timeout value is specified statically
+ere (e.g. <timeout> 60 </timeout> or dynamically via fields in the relevant scope.
+
+   name             Name of the field where this timeout could be found
+   scope            Scope of the field. default scope is request attribute.
+-->
+<!ELEMENT timeout (#PCDATA)>
+<!ATTLIST timeout  name  CDATA  #IMPLIED
+                   scope %scope; 'request.attribute'>
+
+<!-- 
+http-method specifies HTTP method eligible for caching default is GET. 
+-->
+<!ELEMENT http-method (#PCDATA)>
+
+<!-- 
+specifies the request parameter name that triggers refresh. the cached entry 
+is refreshed when there such a request parameter is set to "true"
+example:
+<cache-mapping> 
+    <url-pattern> /quote </url-pattern> 
+    <refresh-field name="refresh" scope="request.parameter"/> 
+</cache-mapping> 
+-->
+<!ELEMENT refresh-field EMPTY>
+<!ATTLIST refresh-field name  CDATA       #REQUIRED
+                        scope %key-scope; 'request.parameter'>
+<!-- 
+key-field specifies a component of the key; container looks for the named 
+field in the given scope to access the cached entry. Default is to use
+the Servlet Path (the path section that corresponds to the servlet mapping 
+which activated this request). See Servlet 2.3 specification section SRV 4.4 
+on Servlet Path.
+
+  name             Name of the field to look for in the given scope
+  scope            Scope of the field. default scope is request parameter.
+-->
+<!ELEMENT key-field EMPTY>
+<!ATTLIST key-field name  CDATA       #REQUIRED
+                    scope %key-scope; 'request.parameter'>
+
+<!-- 
+constraint-field specifies a field whose value is used as a cacheability constraint.
+  
+  name                     Name of the field to look for in the given scope
+  scope                    Scope of the field. Default scope is request parameter.
+  cache-on-match           Should this constraint check pass, is the response cacheable?
+                           Default is true (i.e. cache the response on success match). 
+                           Useful to turn off caching when there is an attribute in the 
+                           scope (e.g. don't cache when there is an attribute called UID 
+                           in the session.attribute scope).
+  cache-on-match-failure   Should the constraint check fail, is response not cacheable?
+                           Default is false (i.e. a failure in enforcing the constraint
+                           would negate caching). Useful to turn on caching when the 
+                           an an attribute is not present (e.g. turn on caching 
+                           when there is no session or session attribute called UID).
+
+  Example 1: don't cache when there is a session attribute
+  <constraint-field name="UID" scope="session.attribute" cache-on-match="false">
+
+  Example 2: do cache only when there is no session attribute
+  <constraint-field name="UID" scope="session.attribute" 
+                    cache-on-match-failure="false">
+-->
+<!ELEMENT constraint-field (constraint-field-value*)>
+<!ATTLIST constraint-field  name                    CDATA      #REQUIRED
+                            scope                   %scope;    'request.parameter'
+                            cache-on-match          %boolean;  'true'
+                            cache-on-match-failure  %boolean;  'false'>
+
+<!-- 
+value element specifies the applicable value and a matching expression for a constraint-field
+  match-expr            Expression used to match the value. Default is 'equals'.
+
+  Example 1: cache when the category matches with any value other than a specific value
+  <constraint-field name="category" scope="request.parameter>
+    <value match-expr="equals" cache-on-match-failure="true">
+         bogus
+    </value>
+  </constraint-field>
+-->
+<!ELEMENT constraint-field-value (#PCDATA)>
+<!ATTLIST constraint-field-value 	match-expr              %expr;    'equals'
+                			cache-on-match          %boolean;  'true'
+                			cache-on-match-failure  %boolean;  'false'>
+
+<!--
+  The class-loader element allows developers to customize the behaviour
+  of their web application's classloader.
+
+  attributes
+    extra-class-path          List of comma-separated JAR files to be
+                              added to the web application's class path
+    delegate                  If set to false, the delegation behavior
+                              of the web application's classloader complies
+                              with the Servlet 2.3 specification,
+                              section 9.7.2, and gives preference to classes
+                              and resources within the WAR file or the
+                              extra-class-path over those higher up in the
+                              classloader hierarchy, unless those classes or
+                              resources are part of the Jakarta EE platform.
+                              If set to its default value of true, classes
+                              and resources residing in container-wide library
+                              JAR files are loaded in preference to classes
+                              and resources packaged within the WAR file or
+                              specified on the extra-class-path.
+    dynamic-reload-interval   Not supported. Included for backward
+                              compatibility with previous Sun Java System
+                              Web Server versions
+-->
+<!ELEMENT class-loader (property*)>
+<!ATTLIST class-loader extra-class-path CDATA  #IMPLIED
+                       delegate %boolean; 'true'
+                       dynamic-reload-interval CDATA #IMPLIED >
+
+<!ELEMENT jsp-config (property*)>
+
+<!ELEMENT locale-charset-info (locale-charset-map+, parameter-encoding?)>
+<!ATTLIST locale-charset-info default-locale CDATA #IMPLIED>
+
+<!ELEMENT locale-charset-map (description?)>
+<!ATTLIST locale-charset-map locale  CDATA  #REQUIRED
+                             agent   CDATA  #IMPLIED
+                             charset CDATA  #REQUIRED>
+
+<!ELEMENT parameter-encoding EMPTY>
+<!ATTLIST parameter-encoding form-hint-field CDATA #IMPLIED
+			     default-charset CDATA #IMPLIED>
+
+<!-- 
+Syntax for supplying properties as name value pairs 
+-->
+<!ELEMENT property (description?)>
+<!ATTLIST property name  CDATA  #REQUIRED
+                   value CDATA  #REQUIRED>
+
+<!ELEMENT description (#PCDATA)>
+
+<!--
+This text nodes holds a value string.
+-->
+<!ELEMENT value (#PCDATA)>
+
+<!ELEMENT valve (description?, property*)>
+<!ATTLIST valve name        CDATA  #REQUIRED
+                class-name  CDATA  #REQUIRED>
+
+<!--
+  					W E B   S E R V I C E S 
+-->
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+<!ELEMENT service-ref ( service-ref-name, port-info*, call-property*, wsdl-override?, service-impl-class?, service-qname? )>
+
+<!--
+Coded name (relative to java:comp/env) for a service-reference
+-->
+<!ELEMENT service-ref-name ( #PCDATA )>
+
+<!-- 
+Information for a port within a service-reference.
+
+Either service-endpoint-interface or wsdl-port or both
+(service-endpoint-interface and wsdl-port) should be specified.  
+
+If both are specified, wsdl-port represents the
+port the container should choose for container-managed port selection.
+
+The same wsdl-port value must not appear in
+more than one port-info entry within the same service-ref.
+
+If a particular service-endpoint-interface is using container-managed port
+selection, it must not appear in more than one port-info entry
+within the same service-ref.
+
+The optional message-security-binding element is used to customize the
+port to provider binding; either by binding the port to a specific provider
+or by providing a definition of the message security requirements to be
+enforced by the provider.
+
+-->
+<!ELEMENT port-info ( service-endpoint-interface?, wsdl-port?, stub-property*, call-property*, message-security-binding? )>
+
+<!--
+Fully qualified name of service endpoint interface
+-->
+<!ELEMENT service-endpoint-interface ( #PCDATA )>
+<!-- 
+Port used in port-info.  
+-->
+<!ELEMENT wsdl-port ( namespaceURI, localpart )>
+
+<!-- 
+JAXRPC property values that should be set on a stub before it's returned to 
+to the web service client.  The property names can be any properties supported
+by the JAXRPC Stub implementation. See javadoc for javax.xml.rpc.Stub
+-->
+<!ELEMENT stub-property ( name, value )>
+
+<!-- 
+JAXRPC property values that should be set on a Call object before it's 
+returned to the web service client.  The property names can be any 
+properties supported by the JAXRPC Call implementation.  See javadoc
+for javax.xml.rpc.Call
+-->
+<!ELEMENT call-property ( name, value )>
+
+<!--
+This is a valid URL pointing to a final WSDL document. It is optional.
+If specified, the WSDL document at this URL will be used during
+deployment instead of the WSDL document associated with the
+service-ref in the standard deployment descriptor.
+
+Examples :
+
+  // available via HTTP
+  <wsdl-override>http://localhost:8000/myservice/myport?WSDL</wsdl-override>
+
+  // in a file
+  <wsdl-override>file:/home/user1/myfinalwsdl.wsdl</wsdl-override>
+
+-->
+<!ELEMENT wsdl-override ( #PCDATA )>
+
+<!--
+Name of generated service implementation class. This is not set by the 
+deployer. It is derived during deployment.
+-->
+<!ELEMENT service-impl-class ( #PCDATA )>
+
+<!-- 
+The service-qname element declares the specific WSDL service
+element that is being refered to.  It is not set by the deployer.
+It is derived during deployment.
+-->
+<!ELEMENT service-qname (namespaceURI, localpart)>
+
+<!-- 
+Runtime information about a web service.  
+
+wsdl-publish-location is optionally used to specify 
+where the final wsdl and any dependent files should be stored.  This location
+resides on the file system from which deployment is initiated.
+
+-->
+<!ELEMENT webservice-description ( webservice-description-name, wsdl-publish-location? )>
+
+<!--
+Unique name of a webservice within a module
+-->
+<!ELEMENT webservice-description-name ( #PCDATA )>
+
+<!--
+file: URL of a directory to which a web-service-description's wsdl should be
+published during deployment.  Any required files will be published to this
+directory, preserving their location relative to the module-specific
+wsdl directory(META-INF/wsdl or WEB-INF/wsdl).
+
+Example :
+
+  For an ejb.jar whose webservices.xml wsdl-file element contains
+    META-INF/wsdl/a/Foo.wsdl 
+
+  <wsdl-publish-location>file:/home/user1/publish
+  </wsdl-publish-location>
+
+  The final wsdl will be stored in /home/user1/publish/a/Foo.wsdl
+
+-->
+<!ELEMENT wsdl-publish-location ( #PCDATA )>
+
+<!--
+Information about a web service endpoint.  
+
+The optional message-security-binding element is used to customize the
+webservice-endpoint to provider binding; either by binding the
+webservice-endpoint to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+When login-config is specified, a default message-security provider
+is not applied to the endpoint.
+-->
+<!ELEMENT webservice-endpoint ( port-component-name, endpoint-address-uri?, (login-config | message-security-binding)?, transport-guarantee?, service-qname?, tie-class?, servlet-impl-class?, debugging-enabled? )>
+
+<!--
+Unique name of a port component within a module
+-->
+<!ELEMENT port-component-name ( #PCDATA )>
+
+<!--
+Relative path combined with web server root to form fully qualified
+endpoint address for a web service endpoint.  For servlet endpoints, this
+value is relative to the servlet's web application context root.  In
+all cases, this value must be a fixed pattern(i.e. no "*" allowed).
+If the web service endpoint is a servlet that only implements a single
+endpoint has only one url-pattern, it is not necessary to set 
+this value since the container can derive it from web.xml.
+-->
+<!ELEMENT endpoint-address-uri ( #PCDATA )>
+
+<!--
+The name of tie implementation class for a port-component.  This is
+not specified by the deployer.  It is derived during deployment.
+-->
+<!ELEMENT tie-class (#PCDATA)>
+
+<!-- 
+Optional authentication configuration for an EJB web service endpoint.
+Not needed for servet web service endpoints.  Their security configuration
+is contained in the standard web application descriptor.
+-->
+<!ELEMENT login-config ( auth-method )>
+
+<!--
+The auth-method element is used to configure the authentication
+mechanism for the web application. As a prerequisite to gaining access
+to any web resources which are protected by an authorization
+constraint, a user must have authenticated using the configured
+mechanism.
+-->
+
+<!ELEMENT auth-method (#PCDATA)>
+
+<!--
+Name of application-written servlet impl class contained in deployed war.
+This is not set by the deployer.  It is derived by the container
+during deployment.
+-->
+<!ELEMENT servlet-impl-class (#PCDATA)>
+
+<!--
+Specify whether or not the debugging servlet should be enabled for this 
+Web Service endpoint. 
+
+Supported values : "true" to debug the endpoint
+-->
+<!ELEMENT debugging-enabled (#PCDATA)>
+
+<!--
+The transport-guarantee element specifies that the communication
+between client and server should be NONE, INTEGRAL, or
+CONFIDENTIAL. NONE means that the application does not require any
+transport guarantees. A value of INTEGRAL means that the application
+requires that the data sent between the client and server be sent in
+such a way that it can't be changed in transit. CONFIDENTIAL means
+that the application requires that the data be transmitted in a
+fashion that prevents other entities from observing the contents of
+the transmission. In most cases, the presence of the INTEGRAL or
+CONFIDENTIAL flag will indicate that the use of SSL is required.
+-->
+
+<!ELEMENT transport-guarantee (#PCDATA)>
+
+<!--
+Runtime settings for a web service reference.  In the simplest case,
+there is no runtime information required for a service ref.  Runtime info
+is only needed in the following cases :
+ * to define the port that should be used to resolve a container-managed port
+ * to define default Stub/Call property settings for Stub objects
+ * to define the URL of a final WSDL document to be used instead of
+the one packaged with a service-ref
+-->
+
+<!--
+The localpart element indicates the local part of a QNAME.
+-->
+<!ELEMENT localpart (#PCDATA)>
+
+<!--
+The namespaceURI element indicates a URI.
+-->
+<!ELEMENT namespaceURI (#PCDATA)>
+
+<!--
+The message-layer entity is used to define the value of the
+auth-layer attribute of message-security-binding elements.
+
+Used in: message-security-binding
+-->
+<!ENTITY % message-layer    "(SOAP)">
+
+<!--
+The message-security-binding element is used to customize the
+webservice-endpoint or port to provider binding; either by binding the
+webservice-endpoint or port to a specific provider or by providing a
+definition of the message security requirements to be enforced by the
+provider.
+
+These elements are typically NOT created as a result of the
+deployment of an application. They need only be created when the
+deployer or system administrator chooses to customize the 
+webservice-endpoint or port to provider binding.
+
+The optional (repeating) message-security sub-element is used 
+to accomplish the latter; in which case the specified 
+message-security requirements override any defined with the
+provider.
+
+The auth-layer attribute identifies the message layer at which the
+message-security requirements are to be enforced.
+
+The optional provider-id attribute identifies the provider-config 
+and thus the authentication provider that is to be used to satisfy 
+the application specific message security requirements. If a value for 
+the provider-id attribute is not specified, and a default
+provider is defined for the message layer, then it is used. 
+if a value for the provider-id attribute is not specified, and a
+default provider is not defined at the layer, the authentication
+requirements defined in the message-security-binding are not
+enforced. 
+ 
+Default:
+Used in: webservice-endpoint, port-info
+-->
+<!ELEMENT message-security-binding ( message-security* )>
+<!ATTLIST message-security-binding
+          auth-layer  %message-layer; #REQUIRED
+          provider-id CDATA           #IMPLIED >
+
+<!--
+The message-security element describes message security requirements
+that pertain to the request and response messages of the containing 
+endpoint, or port
+
+When contained within a webservice-endpoint this element describes 
+the message security requirements that pertain to the request and 
+response messages of the containing endpoint. When contained within a 
+port-info of a service-ref this element describes the message security
+requirements of the port of the referenced service.
+
+The one or more contained message elements define the methods or operations
+of the containing application, endpoint, or referenced service to which 
+the message security requirements apply.
+
+Multiple message-security elements occur within a containing
+element when it is necessary to define different message
+security requirements for different messages within the encompassing
+context. In such circumstances, the peer elements should not overlap
+in the messages they pertain to. If there is any overlap in the
+identified messages, no message security requirements apply to
+the messages for which more than one message-security element apply.
+
+Also, no message security requirements apply to any messages of
+the encompassing context that are not identified by a message element. 
+ 
+Default:
+Used in: webservice-endpoint, and port-info
+-->
+<!ELEMENT message-security ( message+, request-protection?, response-protection? )>
+
+<!--
+The message element identifies the methods or operations to which
+the message security requirements apply.
+
+The identified methods or operations are methods or operations of
+the resource identified by the context in which the message-security
+element is defined (e.g. the the resource identified by the
+service-qname of the containing webservice-endpoint or service-ref).
+
+An empty message element indicates that the security requirements
+apply to all the methods or operations of the identified resource.
+
+When operation-name is specified, the security
+requirements defined in the containing message-security 
+element apply to all the operations of the endpoint 
+with the specified (and potentially overloaded) operation name.
+
+Default: 
+Used in: message-security
+-->
+<!ELEMENT message ( java-method? | operation-name? )>
+
+<!--
+The java-method element is used to identify a method (or methods
+in the case of an overloaded method-name) of the java class 
+indicated by the context in which the java-method is contained.
+
+Default: 
+Used in: message
+-->
+<!ELEMENT java-method ( method-name, method-params? )>
+
+<!--
+The operation-name element is used to identify the WSDL name of an
+operation of a web service.
+
+Default: 
+Used in: message
+-->
+<!ELEMENT operation-name ( #PCDATA )>
+
+<!--
+The request-protection element describes the authentication requirements
+that apply to a request.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent request-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default: 
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * request-protection ( content-auth-policy* )
+ *
+ * If the request-protection element contains one or more
+ * content-auth-policy sub-elements, they define the authentication
+ * requirements to be applied to the identified request content. If multiple
+ * content-auth-policy sub-elements are defined, a request sender must
+ * satisfy the requirements independently, and in the specified order.  
+ *
+ * The content-auth-policy element would be used to associate authentication
+ * requirements with the parts of the request or response object identified
+ * by the contained method-params or part-name-list sub-elements.
+ *
+ * The content-auth-policy element would be defined as follows:
+ * 
+ * content-auth-policy ( method-params | part-name-list )
+ * ATTLIST content-auth-policy 
+ *         auth-source (sender | content) #IMPLIED
+ *	   auth-recipient (before-content | after-content) #IMPLIED
+ * 
+ * The part-name-list and part-name elements would be defined as follows:
+ *
+ * part-name-list ( part-name* )
+ * part-name ( #PCDATA )
+ *
+-->
+<!ELEMENT request-protection EMPTY >
+<!ATTLIST request-protection
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The response-protection element describes the authentication requirements
+that apply to a response.
+
+The auth-source attribute defines a requirement for message layer
+sender authentication (e.g. username password) or content authentication 
+(e.g. digital signature).
+
+The auth-recipient attribute defines a requirement for message
+layer authentication of the reciever of a message to its sender (e.g. by 
+XML encryption).
+
+The before-content attribute value indicates that recipient
+authentication (e.g. encryption) is to occur before any 
+content authentication (e.g. encrypt then sign) with respect
+to the target of the containing auth-policy.
+
+An absent response-protection element is the recommended shorthand
+for a request-protection element with unspecified values for both the
+auth-source and auth-recipient attributes.
+
+Default: 
+Used in: message-security
+
+ * Expected evolution to support partial message protection:
+ *
+ * response-protection ( content-auth-policy* )
+ *
+ * see request-protection element for more details
+ *
+-->
+<!ELEMENT response-protection EMPTY >
+<!ATTLIST response-protection
+          auth-source (sender | content) #IMPLIED
+	  auth-recipient (before-content | after-content) #IMPLIED>
+
+<!--
+The method-name element contains the name of a service method of a web service
+implementation class.
+
+Used in: java-method
+-->
+<!ELEMENT method-name (#PCDATA)>
+<!--
+The method-params element contains a list of the fully-qualified Java
+type names of the method parameters.
+
+Used in: java-method
+-->
+<!ELEMENT method-params (method-param*)>
+
+<!--
+The method-param element contains the fully-qualified Java type name
+of a method parameter.
+
+Used in: method-params
+-->
+<!ELEMENT method-param (#PCDATA)>
+
+<!--
+Payara flag to include / exclude specific JARs for CDI scanning inside EAR files
+-->
+<!ELEMENT scanning-exclude (#PCDATA)>
+<!ELEMENT scanning-include (#PCDATA)>
+
+<!--
+Payara flag to enable / specify whitelist for extreme ClassLoader isolation
+-->
+<!ELEMENT whitelist-package (#PCDATA)>
+
+<!--
+Payara element to ignore the default support for the RolesAllowed annotation on JAX-RS resources.
+When this is disabled, RolesAllowed can still be activated by other means, e.g. by the Jersey
+specific method. 
+-->
+<!ELEMENT jaxrs-roles-allowed-enabled (#PCDATA)>
+
+<!--
+The keep-state element indicates whether the state information should be
+preserved across redeployment.
+-->
+<!ELEMENT keep-state (#PCDATA)>
+
+<!--
+The version-identifier element contains the version information. The value is
+ retrieved at deployment.
+-->
+<!ELEMENT version-identifier (#PCDATA)>
+
+<!--
+Payara element to ignore servlet initializers
+-->
+<!ELEMENT container-initializer-enabled (#PCDATA)>

--- a/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-ejb-jar_4_0-0.dtd
+++ b/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara6-ejb-jar_4_0-0.dtd
@@ -64,7 +64,7 @@ System unique object id. Automatically generated and updated at deployment/redep
 <!--
 This is the root element describing all the runtime of an ejb-jar in the application.
 -->
-<!ELEMENT enterprise-beans (name?, unique-id?, ejb*,
+<!ELEMENT enterprise-beans (name?, unique-id?, ejb*, pm-descriptors?, cmp-resource?,
 	message-destination*, webservice-description*, property*, webservice-default-login-config?)>
 
 <!--
@@ -81,7 +81,7 @@ Additional properties applicable to a stateful session bean:
     bean-cache, webservice-endpoint, checkpointed-methods?, checkpoint-at-end-of-method?
 
 Additional properties applicable to an entity bean:
-   is-read-only-bean?, refresh-period-in-seconds?, commit-option?, bean-cache?, bean-pool?, flush-at-end-of-method?
+   is-read-only-bean?, refresh-period-in-seconds?, cmp?, commit-option?, bean-cache?, bean-pool?, flush-at-end-of-method?
 
 Additional properties applicable to a message-driven bean:
    mdb-resource-adapter?, mdb-connection-factory?, jms-durable-subscription-name?, 
@@ -89,11 +89,11 @@ Additional properties applicable to a message-driven bean:
    ( In case of MDB, jndi-name is the jndi name of the associated jms destination )
 -->
 
-<!ELEMENT ejb (ejb-name, jndi-name?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, pass-by-reference?, 
-               principal?, mdb-connection-factory?, jms-durable-subscription-name?,
+<!ELEMENT ejb (ejb-name, jndi-name?, ejb-ref*, resource-ref*, resource-env-ref*, service-ref*, message-destination-ref*, pass-by-reference?,
+		       cmp?, principal?, mdb-connection-factory?, jms-durable-subscription-name?,
                jms-max-messages-load?, ior-security-config?, is-read-only-bean?, clustered-bean?, clustered-key-name?, clustered-lock-type?, clustered-attach-postconstruct?, clustered-detach-predestroy?,
                refresh-period-in-seconds?, commit-option?, cmt-timeout-in-seconds?, use-thread-pool-id?, gen-classes?, 
-               bean-pool?, bean-cache?, mdb-resource-adapter?, webservice-endpoint*, flush-at-end-of-method?, checkpoint-at-end-of-method?, per-request-load-balancing?)>
+               bean-pool?, bean-cache?, mdb-resource-adapter?, webservice-endpoint*, flush-at-end-of-method?, checkpointed-methods?, checkpoint-at-end-of-method?, per-request-load-balancing?)>
 
 <!-- 
 This attribute is only applicable for stateful session bean 
@@ -164,6 +164,44 @@ The ejb ref name locates the name of the ejb reference in the application.
 <!ELEMENT ejb-ref-name (#PCDATA)>
 
 <!--
+This element describes runtime information for a CMP EntityBean object for
+EJB1.1 and EJB2.0 beans.
+-->
+<!ELEMENT cmp (mapping-properties?, is-one-one-cmp?, one-one-finders?, prefetch-disabled?)>
+
+<!--
+This contains the location of the persistence vendor specific O/R mapping file
+-->
+<!ELEMENT mapping-properties (#PCDATA)>
+
+<!--
+This element in deprecated. It has been left in the DTD for validation purposes.
+Any value will be ignored by the runtime.
+-->
+<!ELEMENT is-one-one-cmp (#PCDATA)>
+
+<!--
+This root element contains the finders for CMP 1.1.
+-->
+<!ELEMENT one-one-finders (finder+ )>
+
+<!--
+This element allows to selectively disable relationship prefetching for finders of a bean.
+Used in: cmp
+-->
+<!ELEMENT prefetch-disabled (query-method+)>
+
+<!--
+Used in: prefetch-disabled
+-->
+<!ELEMENT query-method (method-name, method-params)>
+
+<!--
+This root element contains the finder for CMP 1.1 with a method-name and query parameters
+-->
+<!ELEMENT finder (method-name, query-params?, query-filter?, query-variables?,  query-ordering?)>
+
+<!--
 The method-name element contains a name of an enterprise bean method
 or the asterisk (*) character. The asterisk is used when the element
 denotes all the methods of an enterprise bean's component and home
@@ -172,6 +210,55 @@ interfaces.
 Used in: method, finder, query-method, java-method
 -->
 <!ELEMENT method-name (#PCDATA)>
+
+
+<!--
+This contains the query parameters for CMP 1.1 finder
+-->
+<!ELEMENT query-params (#PCDATA)>
+
+<!--
+This optional element contains the query filter for CMP 1.1 finder
+-->
+<!ELEMENT query-filter (#PCDATA)>
+
+<!--
+This optional element contains variables in query expression for CMP 1.1 finder
+-->
+<!ELEMENT query-variables (#PCDATA)>
+
+<!--
+This optional element contains the ordering specification for CMP 1.1 finder.
+-->
+
+<!ELEMENT query-ordering (#PCDATA)>
+
+<!--
+This element identifies the database and the policy for processing CMP beans
+storage. The jndi-name element identifies either the persistence-manager-
+factory-resource or the jdbc-resource as defined in the server configuration.
+-->
+<!ELEMENT cmp-resource (jndi-name, default-resource-principal?, property*,
+        create-tables-at-deploy?, drop-tables-at-undeploy?,
+        database-vendor-name?, schema-generator-properties?)>
+
+<!--
+This element contains the override properties for the schema generation
+from CMP beans in this module.
+-->
+<!ELEMENT schema-generator-properties (property*) >
+
+<!--
+This element specifies whether automatic creation of tables for the CMP beans
+is done at module deployment. Acceptable values are true or false
+-->
+<!ELEMENT create-tables-at-deploy ( #PCDATA )>
+
+<!--
+This element specifies whether automatic dropping of tables for the CMP beans
+is done at module undeployment. Acceptabel values are true of false
+-->
+<!ELEMENT drop-tables-at-undeploy ( #PCDATA )>
 
 <!--
 This element specifies the database vendor name for ddl files generated at
@@ -287,6 +374,23 @@ pseudo-random selection policy.
 <!ELEMENT victim-selection-policy (#PCDATA)>
 
 <!--
+Support backward compatibility with AS7.1
+Now deprecated in 8.1 and later releases
+Use checkpoint-at-end-of-method element instead
+
+The methods should be separated by semicolons.
+The param list should separated by commas.
+All method param types should be full qualified.
+Variable name is allowed for the param type.
+No return type or exception type.
+Example:
+foo(java.lang.String, a.b.c d); bar(java.lang.String s)
+
+Used in: ejb
+-->
+<!ELEMENT checkpointed-methods (#PCDATA)>
+
+<!--
 The equivalent element of checkpointed-methods for 8.1 and later releases
 
 Used in: ejb
@@ -297,7 +401,7 @@ Used in: ejb
 bean-pool is a root element containing the bean pool properties. Used
 for stateless session bean, entity bean, and message-driven bean pools.
 -->
-<!ELEMENT bean-pool (steady-pool-size?, resize-quantity?, max-pool-size?, pool-idle-timeout-in-seconds?)>
+<!ELEMENT bean-pool (steady-pool-size?, resize-quantity?, max-pool-size?, pool-idle-timeout-in-seconds?, max-wait-time-in-millis?)>
 
 <!--
 steady-pool-size specified the initial and minimum number of beans that must be maintained in the pool. 
@@ -340,6 +444,12 @@ Specifies the timeout for transactions started by the container. This value must
 Specifes the thread pool that will be used to process any invocation on this ejb
 -->
 <!ELEMENT use-thread-pool-id (#PCDATA)>
+
+<!--
+Specifies the maximum time that the caller is willing to wait to get a bean from the pool.
+Wait time is infinite, if the value specified is 0. Deprecated.
+-->
+<!ELEMENT max-wait-time-in-millis (#PCDATA)>
 
 <!--
 refresh-period-in-seconds specifies the rate at which the read-only-bean must be refreshed 
@@ -500,6 +610,52 @@ ejb modules. Allowed values are true and false. Default will be false.
 <!ELEMENT pass-by-reference (#PCDATA)>
 
 <!--
+PM descriptors contain one or more pm descriptors, but only one of them must
+be in use at any given time. If not specified, the Sun CMP is used.
+-->
+<!ELEMENT pm-descriptors ( pm-descriptor+, pm-inuse)>
+
+<!--
+pm-descriptor describes the pluggable vendor implementation for the CMP
+support of the CMP entity beans in this module.
+-->
+<!ELEMENT pm-descriptor ( pm-identifier, pm-version, pm-config?, pm-class-generator?, pm-mapping-factory?)>
+
+<!--
+pm-identifier element identifies the vendor who provides the CMP implementation
+-->
+<!ELEMENT pm-identifier (#PCDATA)>
+
+<!--
+pm-version further specifies which version of PM vendor product to be used
+-->
+<!ELEMENT pm-version (#PCDATA)>
+
+<!--
+pm-config specifies the vendor specific config file to be used
+-->
+<!ELEMENT pm-config (#PCDATA)>
+
+<!--
+pm-class-generator specifies the vendor specific class generator to be used
+at the module deploymant time. This is the name of the class specific to this
+vendor.
+-->
+<!ELEMENT pm-class-generator (#PCDATA)>
+
+<!--
+pm-mapping-factory specifies the vendor specific mapping factory
+This is the name of the class specific to a vendor.
+-->
+<!ELEMENT pm-mapping-factory (#PCDATA)>
+
+<!--
+pm-inuse specifies which CMP vendor is used.
+-->
+<!ELEMENT pm-inuse (pm-identifier, pm-version)>
+
+
+<!--
 This holds the runtime configuration properties of the message-driven bean 
 in its operation environment.  For example, this may include information 
 about the name of a physical JMS destination etc.
@@ -561,7 +717,7 @@ Used in: ejb
 
 
 <!--
-Used in: flush-at-end-of-method, checkpoint-at-end-of-method
+Used in: flush-at-end-of-method, checkpoint-at-end-of-method, prefetch-disabled
 -->
 <!ELEMENT method (description?, ejb-name?, method-name, method-intf?, method-params?)>
 
@@ -588,7 +744,7 @@ Used in: method
 The method-params element contains a list of the fully-qualified Java
 type names of the method parameters.
 
-Used in: method, java-method
+Used in: method, query-method, java-method
 -->
 <!ELEMENT method-params (method-param*)>
 

--- a/appserver/ejb/ejb-container/src/main/java/fish/payara/ejb/deployment/node/runtime/PayaraEjbBundleRuntimeNode.java
+++ b/appserver/ejb/ejb-container/src/main/java/fish/payara/ejb/deployment/node/runtime/PayaraEjbBundleRuntimeNode.java
@@ -86,6 +86,7 @@ public class PayaraEjbBundleRuntimeNode extends EjbBundleRuntimeNode {
      * @return the doctype tag name
      */
     public static String registerBundle(Map publicIDToDTD) {
+        publicIDToDTD.put(DTDRegistry.PAYARA5_EJBJAR_320_DTD_PUBLIC_ID, DTDRegistry.PAYARA5_EJBJAR_320_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA6_EJBJAR_400_DTD_PUBLIC_ID, DTDRegistry.PAYARA6_EJBJAR_400_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA_EJBJAR_400_DTD_PUBLIC_ID, DTDRegistry.PAYARA_EJBJAR_400_DTD_SYSTEM_ID);
         publicIDToDTD.put(DTDRegistry.PAYARA7_EJBJAR_401_DTD_PUBLIC_ID, DTDRegistry.PAYARA7_EJBJAR_401_DTD_SYSTEM_ID);

--- a/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara5-application.xml
+++ b/appserver/tests/functional/payara-application-xml/src/test/META-INF/payara5-application.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE payara-application PUBLIC "-//Payara.fish//DTD Payara Application Server 5 Jakarta EE Application 8//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/deployment/dtds/src/main/resources/glassfish/lib/dtds/payara5-application_8-0.dtd">
+<payara-application>
+    <web>
+        <!-- This aligns to the name of the WAR defined in the test itself -->
+        <web-uri>helloworld.war</web-uri>
+        <context-root>/au-revoir</context-root>
+    </web>
+</payara-application>

--- a/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
+++ b/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
@@ -116,6 +116,16 @@ public class HelloWorldIT {
                         .addAsWebInfResource(new File("src/test/webapp/WEB-INF", "beans.xml")));
     }
 
+    @Deployment(name = "helloPayara5")
+    public static EnterpriseArchive createPayara5ApplicationDeployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, "helloworld-payara5.ear")
+                .addAsManifestResource(new File("src/test/META-INF", "payara5-application.xml"),
+                        "payara-application.xml")
+                .addAsModule(ShrinkWrap.create(WebArchive.class, "helloworld.war")
+                        .addClasses(Resources.class, HelloWorld.class)
+                        .addAsWebInfResource(new File("src/test/webapp/WEB-INF", "beans.xml")));
+    }
+
     @Test
     @RunAsClient
     @OperateOnDeployment("helloPayara")
@@ -193,6 +203,23 @@ public class HelloWorldIT {
 
         System.out.println("Context root should be \"adios\" as defined by the EAR's payara-application.xml, " +
                 "overriding the default context root of \"helloworld-payara6\" obtained from the EAR's name: " + uri.getPath());
+
+        String message = response.readEntity(String.class);
+
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals("Hello World!", message);
+        Assert.assertTrue(uri.getPath().equals("/adios/"));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("helloPayara5")
+    public void checkContextRootVersionPayara5ApplicationXml() {
+        WebTarget target = ClientBuilder.newClient().target(uri).path("resources").path("hello");
+        Response response = target.request().get();
+
+        System.out.println("Context root should be \"au-revoir\" as defined by the EAR's payara-application.xml, " +
+                "overriding the default context root of \"helloworld-payara5\" obtained from the EAR's name: " + uri.getPath());
 
         String message = response.readEntity(String.class);
 

--- a/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
+++ b/appserver/tests/functional/payara-application-xml/src/test/java/fish/payara/tests/functional/payaraapplicationxml/HelloWorldIT.java
@@ -225,6 +225,6 @@ public class HelloWorldIT {
 
         Assert.assertEquals(200, response.getStatus());
         Assert.assertEquals("Hello World!", message);
-        Assert.assertTrue(uri.getPath().equals("/adios/"));
+        Assert.assertTrue(uri.getPath().equals("/au-revoir/"));
     }
 }

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/node/runtime/gf/PayaraWebBundleRuntimeNode.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/node/runtime/gf/PayaraWebBundleRuntimeNode.java
@@ -46,6 +46,8 @@ import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA7_WEBAPP_611_D
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA7_WEBAPP_611_DTD_SYSTEM_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_4_DTD_PUBLIC_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_4_DTD_SYSTEM_ID;
+import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA5_WEBAPP_400_DTD_PUBLIC_ID;
+import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA5_WEBAPP_400_DTD_SYSTEM_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA6_WEBAPP_600_DTD_PUBLIC_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA6_WEBAPP_600_DTD_SYSTEM_ID;
 import static com.sun.enterprise.deployment.xml.DTDRegistry.PAYARA_WEBAPP_610_DTD_PUBLIC_ID;
@@ -98,6 +100,7 @@ public class PayaraWebBundleRuntimeNode extends GFWebBundleRuntimeNode {
      */
     public static String registerBundle(Map<String, String> publicIDToDTD, Map<String, List<Class<?>>> versionUpgrades) {
         publicIDToDTD.put(PAYARA_WEBAPP_4_DTD_PUBLIC_ID, PAYARA_WEBAPP_4_DTD_SYSTEM_ID);
+        publicIDToDTD.put(PAYARA5_WEBAPP_400_DTD_PUBLIC_ID, PAYARA5_WEBAPP_400_DTD_SYSTEM_ID);
         publicIDToDTD.put(PAYARA6_WEBAPP_600_DTD_PUBLIC_ID, PAYARA6_WEBAPP_600_DTD_SYSTEM_ID);
         publicIDToDTD.put(PAYARA_WEBAPP_610_DTD_PUBLIC_ID, PAYARA_WEBAPP_610_DTD_SYSTEM_ID);
         publicIDToDTD.put(PAYARA7_WEBAPP_611_DTD_PUBLIC_ID, PAYARA7_WEBAPP_611_DTD_SYSTEM_ID);


### PR DESCRIPTION
## Description
Follow-up to https://github.com/payara/Payara/pull/8125 and https://github.com/payara/Payara/pull/8278
In a similar vein to what was added in those two PRs, we have added Payara 5 deployment descriptors.

This PR "forward-ports" support for these older descriptors.

Also fixes the incorrectly copied descriptor for Enterprise 6 EJBs. I'm leaving the version the same rather than creating a new revision because it's correct over in Enterprise 6 - it's only wrong here.

## Important Info
### Blockers
https://github.com/payara/Payara-Enterprise/pull/3215
https://github.com/payara/Payara-Enterprise/pull/3217
https://github.com/payara/Payara-Enterprise/pull/3216

These PRs must all be merged together

## Testing
### New tests
Extended the payara-application-xml functional test to check the Payara 5 application XML is still valid

### Testing Performed
Jenkins test please

### Testing Environment
Jenkins

## Documentation
https://gitlab.azulsystems.com/docs/payara/-/merge_requests/40

## Notes for Reviewers
See comments
