### PR TITLE
FISH-14238 Add missing copyright to Agentic AI samples

### DIFF
--- a/appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/resources/META-INF/microprofile-config.properties
+++ b/appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/resources/META-INF/microprofile-config.properties
@@ -1,3 +1,43 @@
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/main/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+
 # LLM backend selection for the Payara Jakarta Agentic AI runtime.
 # The quickstart uses a small local model via Ollama (no API key, no cost).
 payara.agentic.llm.provider=ollama

--- a/appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/webapp/WEB-INF/beans.xml
+++ b/appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/webapp/WEB-INF/beans.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"

--- a/appserver/tests/payara-samples/samples/agentic-ai/src/main/resources/META-INF/microprofile-config.properties
+++ b/appserver/tests/payara-samples/samples/agentic-ai/src/main/resources/META-INF/microprofile-config.properties
@@ -1,3 +1,43 @@
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+#
+# The contents of this file are subject to the terms of either the GNU
+# General Public License Version 2 only ("GPL") or the Common Development
+# and Distribution License("CDDL") (collectively, the "License").  You
+# may not use this file except in compliance with the License.  You can
+# obtain a copy of the License at
+# https://github.com/payara/Payara/blob/main/LICENSE.txt
+# See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing the software, include this License Header Notice in each
+# file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+#
+# GPL Classpath Exception:
+# The Payara Foundation designates this particular file as subject to the "Classpath"
+# exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+# file that accompanied this code.
+#
+# Modifications:
+# If applicable, add the following below the License Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyright [year] [name of copyright owner]"
+#
+# Contributor(s):
+# If you wish your version of this file to be governed by only the CDDL or
+# only the GPL Version 2, indicate your decision by adding "[Contributor]
+# elects to include this software in this distribution under the [CDDL or GPL
+# Version 2] license."  If you don't indicate a single choice of license, a
+# recipient has the option to distribute your version of this file under
+# either the CDDL, the GPL Version 2 or to extend the choice of license to
+# its licensees as provided above.  However, if you add GPL Version 2 code
+# and therefore, elected the GPL Version 2 license, then the option applies
+# only if the new code is made subject to such option by the copyright
+# holder.
+#
+
 # LLM backend selection for the Payara Jakarta Agentic AI runtime.
 # "vertex" uses Claude on Google Cloud Vertex AI authenticated via ADC (gcloud).
 # Project ID and region fall back to the ANTHROPIC_VERTEX_PROJECT_ID and

--- a/appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/WEB-INF/beans.xml
+++ b/appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/WEB-INF/beans.xml
@@ -1,4 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"

--- a/appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/index.html
+++ b/appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/index.html
@@ -1,7 +1,42 @@
 <!DOCTYPE html>
 <!--
-  Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
-  Licensed under the GPL v2 with Classpath Exception / CDDL. See the project LICENSE.
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
 -->
 <html lang="en">
 <head>


### PR DESCRIPTION
Add the full Payara license header to files flagged in review of PR #8331:
- agentic-ai and agentic-ai-quickstart WEB-INF/beans.xml
- agentic-ai and agentic-ai-quickstart META-INF/microprofile-config.properties
- replace the abbreviated header in agentic-ai index.html with the full block

## Description
Follow-up to review comments on https://github.com/payara/Payara/pull/8331. Several files in the Agentic AI samples were missing the Payara copyright/license header (and `index.html` carried only an abbreviated version). This PR adds the full Payara license header, matching the style already used by the sample `.java` and `pom.xml` files.

Files updated:
- `appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/index.html` — abbreviated header replaced with the full block
- `appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/WEB-INF/beans.xml`
- `appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/webapp/WEB-INF/beans.xml`
- `appserver/tests/payara-samples/samples/agentic-ai/src/main/resources/META-INF/microprofile-config.properties`
- `appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/resources/META-INF/microprofile-config.properties`

The `agentic-ai` `microprofile-config.properties` was not explicitly flagged in review but had the identical gap, so it was fixed for consistency.

## Important Info
### Blockers
None. Follow-up to PR #8331 (FISH-14238).

## Testing
### New tests
None — license-header-only change, no functional code affected.

### Testing Performed
N/A — comment/header-only changes; no build or runtime behaviour is altered.

### Testing Environment
N/A

## Documentation
N/A

## Notes for Reviewers
Header text is copied verbatim from the existing sample `pom.xml` / `.java` headers, adjusted only for each file's comment syntax (`<!-- -->` for XML/HTML, `#` for properties). The `index.html` change addresses review comment r3729937138 ("use the full thing").

🤖 Generated with [Claude Code](https://claude.com/claude-code)