### PR TITLE
FISH-13664: Fix redirects in Admin GUI

### DIFF
--- a/appserver/admingui/common/src/main/resources/removeFrame.jsf
+++ b/appserver/admingui/common/src/main/resources/removeFrame.jsf
@@ -39,11 +39,13 @@
     holder.
 
 -->
+<!--
+    Portions Copyright 2026 Payara Foundation and/or its affiliates.
+-->
 
 <f:verbatim>
 <html>
 <head>
-    <script type="text/javascript" src="#{request.contextPath}/resource/common/js/adminjsf.js" ></script>
     <script type="text/javascript">
 	function redirectToQS() {
 	    var loc = window.location.href;
@@ -56,7 +58,7 @@
 		    loc = loc.substring(0, idx) + '?' + loc.substring(idx + 1);
 		}
 	    }
-	    admingui.ajax.loadPage(
+	    top.admingui.ajax.loadPage(
 		{
 		    url: loc,
 		    target: top.document.getElementById('content')

--- a/appserver/admingui/war/src/main/resources/META-INF/0.2-final/com_sun_faces_ajax.js
+++ b/appserver/admingui/war/src/main/resources/META-INF/0.2-final/com_sun_faces_ajax.js
@@ -1,0 +1,49 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Payara Foundation designates this particular file as subject to the
+ * "Classpath" exception as provided by the Payara Foundation in the GPL
+ * Version 2 section of the License file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+/*
+ * This file is intentionally empty. The JSF Ajax library (formerly bundled
+ * by Mojarra as com_sun_faces_ajax.js) is now served via the standard
+ * Jakarta Faces resource mechanism (<h:outputScript name="jsf.js">).
+ *
+ * This stub exists solely to prevent a 404 from the Woodstock ThemeServlet,
+ * which requests /theme/META-INF/0.2-final/com_sun_faces_ajax.js based on
+ * the jsfx entry in the suntheme javascript.properties.
+ */


### PR DESCRIPTION
## Description

After updates to how `adminjsf.js` is initiated we started having issues with redirects between screens from iframes.
Utilizing top-level instance was proven as the most stable solution to this.

Also planted a file that `ThemeServlet` insists on fetching despite it doesn't exist anymore, so that we aren't distracted by 404s in the dev console of Admin GUI.

Fixes #8221 

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### Testing Performed

Manual testing of documented faulty case -- empty page after deployment over admin gui no longer happens. Also there are no 404s in the dev console.

### Testing Environment
```
Apache Maven 3.9.16 (2bdd9fddda4b155ebf8000e807eb73fd829a51d5)
Maven home: /opt/homebrew/Cellar/maven/3.9.16/libexec
Java version: 21, vendor: Azul Systems, Inc., runtime: /Users/pdudits/.sdkman/candidates/java/21-zulu/zulu-21.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "26.5.2", arch: "aarch64", family: "mac"
```
