### PR TITLE
FISH-14117 FISH-14244 updating opentelemetry dependencies

### DIFF
--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -522,9 +522,9 @@
             </dependency>
 
             <dependency>
-                <groupId>io.opentelemetry.instrumentation</groupId>
-                <artifactId>opentelemetry-instrumentation-bom</artifactId>
-                <version>${opentelemetry-bom.version}</version>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -606,16 +606,6 @@
                 <artifactId>opentelemetry-exporter-common</artifactId>
                 <version>${opentelemetry.version}</version>
                 <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-api-incubator</artifactId>
-                <version>${opentelemetry.version}-alpha</version>
-            </dependency>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-sdk-testing</artifactId>
-                <version>${opentelemetry.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>

--- a/api/payara-bom/pom.xml
+++ b/api/payara-bom/pom.xml
@@ -608,6 +608,16 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api-incubator</artifactId>
+                <version>${opentelemetry.version}-alpha</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-testing</artifactId>
+                <version>${opentelemetry.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-annotations</artifactId>
                 <version>${opentelemetry-instrumentation-annotations.version}</version>

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
@@ -116,5 +116,10 @@
             <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api-incubator</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
+++ b/appserver/payara-appserver-modules/microprofile/fault-tolerance/pom.xml
@@ -116,10 +116,5 @@
             <artifactId>opentelemetry-sdk-testing</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-api-incubator</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/nucleus/packager/external/opentelemetry-repackaged/pom.xml
+++ b/nucleus/packager/external/opentelemetry-repackaged/pom.xml
@@ -170,6 +170,8 @@
                             !kotlin.*,
                             !org.bouncycastle.*,
                             !org.openjsse.*,
+                            !com.oracle.svm.*,
+                            !org.graalvm.*,
                             *
                         </Import-Package>
                         <!-- Embed the dependencies and then shade them in next step -->

--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,6 @@
         <mail.version>2.1.5</mail.version>
         <angus.mail.version>2.0.5</angus.mail.version>
         <opentelemetry.version>1.65.0</opentelemetry.version>
-        <opentelemetry-bom.version>2.30.0</opentelemetry-bom.version>
         <opentelemetry-semconv.version>1.43.0</opentelemetry-semconv.version>
         <opentelemetry-instrumentation-annotations.version>2.31.0</opentelemetry-instrumentation-annotations.version>
         <opentelemetry-instrumentation-annotation-support.version>2.31.0-alpha</opentelemetry-instrumentation-annotation-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -340,8 +340,8 @@
         <epicyro.version>3.1.1</epicyro.version>
         <mail.version>2.1.5</mail.version>
         <angus.mail.version>2.0.5</angus.mail.version>
-        <opentelemetry.version>1.64.0</opentelemetry.version>
-        <opentelemetry-bom.version>2.14.0</opentelemetry-bom.version>
+        <opentelemetry.version>1.65.0</opentelemetry.version>
+        <opentelemetry-bom.version>2.30.0</opentelemetry-bom.version>
         <opentelemetry-semconv.version>1.43.0</opentelemetry-semconv.version>
         <opentelemetry-instrumentation-annotations.version>2.31.0</opentelemetry-instrumentation-annotations.version>
         <opentelemetry-instrumentation-annotation-support.version>2.31.0-alpha</opentelemetry-instrumentation-annotation-support.version>


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->
Updating opentelemetry dependencies
## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This PR will update some dependencies from open telemetry that previously were reported to generate issues. When updating opentelemetry.version  from version 1.64.0 to 1.65.0 we got the following issues when building the server:

```
[ERROR] Errors:                                                                                                                                                                                                                  
  [ERROR] fish.payara.microprofile.faulttolerance.otel.OtelMetricRegistryTest.testCounterCreation                                                                                                                                  
  [ERROR]   Run 1: OtelMetricRegistryTest.testCounterCreation:89 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                         
  [ERROR]   Run 2: OtelMetricRegistryTest.testCounterCreation:89 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                         
  [ERROR]   Run 3: OtelMetricRegistryTest.testCounterCreation:89 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                         
  [ERROR]   Run 4: OtelMetricRegistryTest.testCounterCreation:89 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                         
  [INFO]                                                                                                                                                                                                                           
  [ERROR] fish.payara.microprofile.faulttolerance.otel.OtelMetricRegistryTest.testCounterWithTags                                                                                                                                  
  [ERROR]   Run 1: OtelMetricRegistryTest.testCounterWithTags:100 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                        
  [ERROR]   Run 2: OtelMetricRegistryTest.testCounterWithTags:100 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                        
  [ERROR]   Run 3: OtelMetricRegistryTest.testCounterWithTags:100 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                        
  [ERROR]   Run 4: OtelMetricRegistryTest.testCounterWithTags:100 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                        
  [INFO]                                                                                                                                                                                                                           
  [ERROR] fish.payara.microprofile.faulttolerance.otel.OtelMetricRegistryTest.testHistogramCreation                                                                                                                                
  [ERROR]   Run 1: OtelMetricRegistryTest.testHistogramCreation:110 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram                                                                                  
  [ERROR]   Run 2: OtelMetricRegistryTest.testHistogramCreation:110 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram                                                                                  
  [ERROR]   Run 3: OtelMetricRegistryTest.testHistogramCreation:110 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram                                                                                  
  [ERROR]   Run 4: OtelMetricRegistryTest.testHistogramCreation:110 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram                                                                                  
  [INFO]                                                                                                                                                                                                                           
  [ERROR] fish.payara.microprofile.faulttolerance.otel.OtelMetricRegistryTest.testHistogramSnapshot                                                                                                                                
  [ERROR]   Run 1: OtelMetricRegistryTest.testHistogramSnapshot:121 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram                                                                                  
  [ERROR]   Run 2: OtelMetricRegistryTest.testHistogramSnapshot:121 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram                                                                                  
  [ERROR]   Run 3: OtelMetricRegistryTest.testHistogramSnapshot:121 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram                                                                                  
  [ERROR]   Run 4: OtelMetricRegistryTest.testHistogramSnapshot:121 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundDoubleHistogram                                                                                  
  [INFO]                                                                                                                                                                                                                           
  [ERROR] fish.payara.microprofile.faulttolerance.otel.OtelMetricRegistryTest.testMetricRemoval                                                                                                                                    
  [ERROR]   Run 1: OtelMetricRegistryTest.testMetricRemoval:165 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                          
  [ERROR]   Run 2: OtelMetricRegistryTest.testMetricRemoval:165 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                          
  [ERROR]   Run 3: OtelMetricRegistryTest.testMetricRemoval:165 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                          
  [ERROR]   Run 4: OtelMetricRegistryTest.testMetricRemoval:165 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                          
  [INFO]                                                                                                                                                                                                                           
  [ERROR] fish.payara.microprofile.faulttolerance.otel.OtelMetricRegistryTest.testMetricRetrieval                                                                                                                                  
  [ERROR]   Run 1: OtelMetricRegistryTest.testMetricRetrieval:155 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                        
  [ERROR]   Run 2: OtelMetricRegistryTest.testMetricRetrieval:155 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                        
  [ERROR]   Run 3: OtelMetricRegistryTest.testMetricRetrieval:155 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                        
  [ERROR]   Run 4: OtelMetricRegistryTest.testMetricRetrieval:155 » NoClassDefFound io/opentelemetry/api/incubator/metrics/BoundLongCounter                                                                                        
  [INFO]                                                                                                                                                                                                                           
  [INFO]                                                                                                                                                                                                                           
  [ERROR] Tests run: 108, Failures: 0, Errors: 6, Skipped: 0    
```

Root cause: 

opentelemetry-sdk-metrics:1.65.0 (and sdk-testing) internally have classes (like SdkLongCounter, SdkDoubleHistogram) that implement interfaces from opentelemetry-api-incubator — specifically the Extended*
  hierarchy which references BoundLongCounter and BoundDoubleHistogram. The incubator jar was never on the test classpath, so loading those SDK classes at runtime threw NoClassDefFound.

To fix we need to include open telemetry-api-incubator and open telemetry-idk-testing on the root pom and include open telemetry-api-incubator with test scope to the fault-tolerance pom file

The other dependency update for opentelemetry-instrumentation-bom from version 2.14.0 to 2.30.0 caused the following osgi issue:

```
Caused by: org.osgi.framework.BundleException: Unable to resolve fish.payara.server.internal.webservices.connector [267](R 267.0): missing requirement [fish.payara.server.internal.webservices.connector [267](R 267.0)]        
  osgi.wiring.package; (&(osgi.wiring.package=org.glassfish.web.deployment.descriptor)(version>=7.2026.0)(!(version>=8.0.0))) [caused by: Unable to resolve fish.payara.server.internal.web.glue [148](R 148.0): missing           
  requirement [fish.payara.server.internal.web.glue [148](R 148.0)] osgi.wiring.package; (&(osgi.wiring.package=org.apache.catalina)(version>=7.2026.0)(!(version>=8.0.0))) [caused by: Unable to resolve                          
  fish.payara.server.internal.web.core [43](R 43.0): missing requirement [fish.payara.server.internal.web.core [43](R 43.0)] osgi.wiring.package;                                                                                  
  (&(osgi.wiring.package=io.opentelemetry.api)(version>=1.65.0)(!(version>=2.0.0))) [caused by: Unable to resolve fish.payara.server.internal.packager.opentelemetry-repackaged [141](R 141.0): missing requirement                
  [fish.payara.server.internal.packager.opentelemetry-repackaged [141](R 141.0)] osgi.wiring.package; (osgi.wiring.package=com.oracle.svm.core.annotate)]]] Unresolved requirements:                                               
  [[fish.payara.server.internal.webservices.connector [267](R 267.0)] osgi.wiring.package; (&(osgi.wiring.package=org.glassfish.web.deployment.descriptor)(version>=7.2026.0)(!(version>=8.0.0)))]                                 
      at org.apache.felix.framework.Felix.resolveBundleRevision(Felix.java:4398)                                                                                                                                                   
      at org.apache.felix.framework.Felix.startBundle(Felix.java:2308)                                                                                                                                                             
      at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:1006)                                                                                                                                                         
      at org.jvnet.hk2.osgiadapter.OSGiModuleImpl.startBundle(OSGiModuleImpl.java:228)                                                                                                                                             
      at org.jvnet.hk2.osgiadapter.OSGiModuleImpl.start(OSGiModuleImpl.java:177)                                                                                                                                                   
      ... 31 more                                                                                                                                                                                                                  
  Command start-domain failed. 
```

The fix adds !com.oracle.svm.* and !org.graalvm.* to the exclusion list before the catch-all *. These are GraalVM native image annotation packages that OpenTelemetry 2.30.0 started referencing (for native compilation hints),
  but they have no meaning at OSGi runtime and don't need to be imported.

## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->

## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->

### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->

Build and start server and pass Jenkins Pipelines and full TCK:

Results from full TCK:
https://jenkins.payara.fish/view/TCKs/job/TCKs/job/JakartaEE-11-TCK/362/

### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->

Mac OS, Azul JDK 21, Maven 3.9.16

## Documentation
<!-- Link documentation if a PR exists -->

## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
