### PR TITLE
FISH-14241 Update Agentic AI samples beans.xml to EE 11 (CDI 4.1)

### DIFF
--- a/appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/webapp/WEB-INF/beans.xml
+++ b/appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/webapp/WEB-INF/beans.xml
@@ -40,6 +40,6 @@
 -->
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
-       version="4.0" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+       version="4.1" bean-discovery-mode="all">
 </beans>

--- a/appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/WEB-INF/beans.xml
+++ b/appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/WEB-INF/beans.xml
@@ -40,6 +40,6 @@
 -->
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
-       version="4.0" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+       version="4.1" bean-discovery-mode="all">
 </beans>


### PR DESCRIPTION
## Description
Follow-up to review comments on #8331. The `beans.xml` files in the Agentic AI samples were using the Jakarta EE 10 (CDI 4.0) descriptor, but these samples target Jakarta EE 11, which uses CDI 4.1. This PR updates both sample `beans.xml` files to the EE 11 / CDI 4.1 versions.

Changes in each file:
- Schema location: `beans_4_0.xsd` → `beans_4_1.xsd`
- `version="4.0"` → `version="4.1"`

Affected files:
- `appserver/tests/payara-samples/samples/agentic-ai/src/main/webapp/WEB-INF/beans.xml`
- `appserver/tests/payara-samples/samples/agentic-ai-quickstart/src/main/webapp/WEB-INF/beans.xml`

Addresses:
- https://github.com/payara/Payara/pull/8331#discussion_r3729947043
- https://github.com/payara/Payara/pull/8331#discussion_r3729942823

## Important Info
### Blockers
None.

## Testing
### New tests
None. This is a descriptor version update to existing sample applications; no new tests required.

### Testing Performed
Verified the updated descriptors match the EE 11 / CDI 4.1 `beans.xml` convention already used elsewhere in the repo (e.g. `appserver/tests/payara-samples/samples/data/src/main/resources/META-INF/beans.xml`).

### Testing Environment
N/A — XML descriptor change only.

## Documentation
N/A

## Notes for Reviewers
Straightforward two-line change per file, directly addressing the two beans.xml review comments from #8331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
