### PR TITLE
FISH-14186 Improve isBehindProxyEnabled method to check per instance

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/GenericAdminAuthenticator.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/GenericAdminAuthenticator.java
@@ -44,6 +44,7 @@ package com.sun.enterprise.admin.util;
 
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.config.serverbeans.SecureAdmin;
+import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.security.auth.realm.NoSuchUserException;
 import com.sun.enterprise.security.auth.realm.Realm;
 import com.sun.enterprise.security.auth.realm.file.FileRealmUser;
@@ -351,7 +352,11 @@ public class GenericAdminAuthenticator implements AdminAccessController, JMXAuth
      * When enabled, the server trusts X-Real-IP and X-Forwarded-For headers.
      */
     private boolean isBehindProxyEnabled() {
-        Config config = domain.getServerNamed("server").getConfig();
+        Server server = domain.getServerNamed(serverEnv.getInstanceName());
+        if (server == null) {
+            return false;
+        }
+        Config config = server.getConfig();
         Protocol protocol = config.getAdminListener().findHttpProtocol();
         Http http = protocol != null ? protocol.getHttp() : null;
         return http != null && http.isBehindProxy();

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/GenericAdminAuthenticator.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/GenericAdminAuthenticator.java
@@ -58,6 +58,7 @@ import com.sun.enterprise.util.net.NetUtils;
 import java.io.File;
 import java.util.Enumeration;
 import java.util.Set;
+
 import java.util.logging.Level;
 
 import org.glassfish.api.container.Sniffer;
@@ -140,6 +141,8 @@ public class GenericAdminAuthenticator implements AdminAccessController, JMXAuth
     private AuthTokenManager authTokenManager;
     
     private SecureAdmin secureAdmin;
+
+    private volatile boolean behindProxyWarningLogged = false;
 
     @Inject
     ServerEnvironment serverEnv;
@@ -354,6 +357,14 @@ public class GenericAdminAuthenticator implements AdminAccessController, JMXAuth
     private boolean isBehindProxyEnabled() {
         Server server = domain.getServerNamed(serverEnv.getInstanceName());
         if (server == null) {
+            if (!behindProxyWarningLogged) {
+                behindProxyWarningLogged = true;
+                ADMSEC_LOGGER.log(Level.WARNING,
+                        "Server instance {0} not found in domain configuration; behind-proxy detection disabled for admin authentication. "
+                        + "If a reverse proxy is in use, all login attempts will be tracked under the proxy''s IP address rather than the real client IP, "
+                        + "reducing brute-force protection accuracy.",
+                        serverEnv.getInstanceName());
+            }
             return false;
         }
         Config config = server.getConfig();


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
When an instance on an SSH Node was created an error would occur due to an NPE when looking for the server config in isBehindProxyEnabled method. 

This PR resolves this issue by changing the logic to check per instance for if the isBehindProxy option is enabled.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
  DAS (default instance)

  1. Start the domain with debugging enabled.
  2. Set a breakpoint inside isBehindProxyEnabled() and attach the debugger.
  3. Send a request to http://localhost:4848/management/domain to trigger the breakpoint.
  4. Verify that isBehindProxyEnabled() returns false (proxy not yet configured).
  5. Enable behind-proxy on the DAS admin-listener configuration.
  6. Repeat step 3 and verify that isBehindProxyEnabled() now returns true.

  Standalone instance

  7. Create a standalone instance.
  8. Start the instance with debugging enabled.
  9. Attach the debugger to the standalone instance.
  10. Send a request to https://localhost:24848/management/domain to trigger the breakpoint.
  11. Verify that isBehindProxyEnabled() returns false (proxy not yet configured on this instance).
  12. Enable behind-proxy on the standalone instance's sec-admin-listener configuration.
  13. Repeat step 10 and verify that isBehindProxyEnabled() now returns true.

  SSH node instance

  14. Create an SSH node.
  15. Create an instance on the SSH node and start it with debugging enabled.
  16. Attach the debugger to the SSH node instance.
  17. Send a request to https://{node-host}:24848/management/domain to trigger the breakpoint.
  18. Verify that isBehindProxyEnabled() returns false (proxy not yet configured on this instance).
  19. Enable behind-proxy on the SSH node instance's sec-admin-listener configuration.
  20. Verify that isBehindProxyEnabled() now returns true.



### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 21.0.11, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/21.0.11-zulu
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "26.5.2", arch: "aarch64", family: "mac"


## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
n/a