### PR TITLE
FISH-13750 FISH-14203 Jersey 4.0.2.payara-p2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
         <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <jaxb-api.version>4.0.5</jaxb-api.version>
         <jackson.version>2.22.2</jackson.version>
-        <jersey.version>4.0.2.payara-p1</jersey.version>
+        <jersey.version>4.0.2.payara-p2</jersey.version>
         <jakarta.validation.version>3.1.1</jakarta.validation.version>
         <jakarta.validation.osgi.version>3.1</jakarta.validation.osgi.version>
         <jakarta.validation.osgi.version.upperbound>4</jakarta.validation.osgi.version.upperbound>


### PR DESCRIPTION
## Description
Upgrades Jersey to 4.0.2.payara-p2, backporting an unreleased fix from upstream, and removing our previous fix for FISH-11911 as it's a competing fix (and we shouldn't be diverged - we previously intended to push our fix to upstream).

## Important Info
### Blockers
https://github.com/payara/patched-src-jersey/pull/254

## Testing
### New tests
None

### Testing Performed
Jenkins test please

Will also rerun the reproducer we have for FISH-11911 to ensure everything is still fixed.

### Testing Environment
Jenkins (for now)

## Documentation
N/A

## Notes for Reviewers
None
