### PR TITLE
FISH-14053 Improve Corba FOLB deployment group check

### DIFF
--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -217,6 +217,9 @@ public class IiopFolbGmsClient implements ClusterListener {
 
         // Check 2: The applications on the deployment group are deployed to all its instances
         List<ApplicationRef> dgAppRefs = myDG.getApplicationRef();
+        if (dgAppRefs.isEmpty()) {
+            return false;
+        }
         for (Server instance : dgInstances) {
             for (ApplicationRef dgAppRef : dgAppRefs) {
                 if (instance.getApplicationRef(dgAppRef.getRef()) == null) {

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -215,19 +215,10 @@ public class IiopFolbGmsClient implements ClusterListener {
         DeploymentGroup myDG = myDeploymentGroups.get(0);
         List<Server> dgInstances = myDG.getInstances();
 
-        // Check 2: The applications on the deployment group are deployed to all its instances
-        List<ApplicationRef> dgAppRefs = myDG.getApplicationRef();
-        if (dgAppRefs.isEmpty()) {
+        // Check 2: Only enable if at least one application is targetted to the deployment group
+        if (myDG.getApplicationRef().isEmpty()) {
+            fineLog("isDeploymentGroupsActive: no application is deployed to the deployment group");
             return false;
-        }
-        for (Server instance : dgInstances) {
-            for (ApplicationRef dgAppRef : dgAppRefs) {
-                if (instance.getApplicationRef(dgAppRef.getRef()) == null) {
-                    fineLog("isDeploymentGroupsActive: application {0} is not deployed to all targets of the deployment group",
-                            dgAppRef.getRef());
-                    return false;
-                }
-            }
         }
 
         // Check 3: No other instance in the deployment group is in any other deployment group

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -187,7 +187,9 @@ public class IiopFolbGmsClient implements ClusterListener {
     // Implementation
     //
     private boolean isDeploymentGroupsActive() {
-        return cluster != null && cluster.isEnabled() && cluster.getClusterMembers().size() > 1;
+        return cluster != null && cluster.isEnabled()
+                && myServer != null && !myServer.getDeploymentGroup().isEmpty()
+                && cluster.getClusterMembers().size() > 1;
     }
 
     private boolean isTraditionalClusterActive() {

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -48,6 +48,7 @@ import com.sun.corba.ee.spi.folb.GroupInfoServiceObserver;
 import com.sun.corba.ee.spi.folb.SocketInfo;
 import com.sun.corba.ee.spi.misc.ORBConstants;
 import com.sun.corba.ee.spi.orb.ORB;
+import com.sun.enterprise.config.serverbeans.ApplicationRef;
 import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.config.serverbeans.Configs;
@@ -56,6 +57,8 @@ import com.sun.enterprise.config.serverbeans.Node;
 import com.sun.enterprise.config.serverbeans.Nodes;
 import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.config.serverbeans.Servers;
+import fish.payara.enterprise.config.serverbeans.DeploymentGroup;
+import fish.payara.nucleus.hazelcast.HazelcastConfigSpecificConfiguration;
 import com.sun.logging.LogDomains;
 import fish.payara.nucleus.cluster.ClusterListener;
 import fish.payara.nucleus.cluster.MemberEvent;
@@ -73,7 +76,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -92,6 +97,10 @@ public class IiopFolbGmsClient implements ClusterListener {
     private Server myServer;
 
     private Nodes nodes;
+
+    private Servers servers;
+
+    private Configs configs;
 
     private Map<String, ClusterInstanceInfo> currentMembers;
 
@@ -120,8 +129,10 @@ public class IiopFolbGmsClient implements ClusterListener {
                 domain = services.getService(Domain.class);
                 fineLog("IiopFolbGmsClient: domain {0}", domain);
 
-                Servers servers = services.getService(Servers.class);
+                servers = services.getService(Servers.class);
                 fineLog("IiopFolbGmsClient: servers {0}", servers);
+
+                configs = services.getService(Configs.class);
 
                 nodes = services.getService(Nodes.class);
                 fineLog("IiopFolbGmsClient: nodes {0}", nodes);
@@ -187,9 +198,73 @@ public class IiopFolbGmsClient implements ClusterListener {
     // Implementation
     //
     private boolean isDeploymentGroupsActive() {
-        return cluster != null && cluster.isEnabled()
-                && myServer != null && !myServer.getDeploymentGroup().isEmpty()
-                && cluster.getClusterMembers().size() > 1;
+        if (cluster == null || !cluster.isEnabled() || myServer == null || cluster.getClusterMembers().size() <= 1) {
+            return false;
+        }
+        // Check 1: Instance is in exactly one deployment group
+        List<DeploymentGroup> myDeploymentGroups = myServer.getDeploymentGroup();
+        if (myDeploymentGroups.isEmpty()) {
+            fineLog("isDeploymentGroupsActive: instance is not in a deployment group");
+            return false;
+        }
+        if (myDeploymentGroups.size() > 1) {
+            fineLog("isDeploymentGroupsActive: instance belongs to more than one deployment group");
+            return false;
+        }
+
+        DeploymentGroup myDG = myDeploymentGroups.get(0);
+        List<Server> dgInstances = myDG.getInstances();
+
+        // Check 2: The applications on the deployment group are deployed to all its instances
+        List<ApplicationRef> dgAppRefs = myDG.getApplicationRef();
+        for (Server instance : dgInstances) {
+            for (ApplicationRef dgAppRef : dgAppRefs) {
+                if (instance.getApplicationRef(dgAppRef.getRef()) == null) {
+                    fineLog("isDeploymentGroupsActive: application {0} is not deployed to all targets of the deployment group",
+                            dgAppRef.getRef());
+                    return false;
+                }
+            }
+        }
+
+        // Check 3: No other instance in the deployment group is in any other deployment group
+        for (Server instance : dgInstances) {
+            if (!instance.getName().equals(myServer.getName()) && instance.getDeploymentGroup().size() > 1) {
+                fineLog("isDeploymentGroupsActive: instance {0} belongs to more than one deployment group", instance.getName());
+                return false;
+            }
+        }
+
+        // Check 4: All instances in the deployment group share the same Hazelcast instance group
+        String myMemberGroup = getMemberGroup(myServer);
+        for (Server instance : dgInstances) {
+            if (!myMemberGroup.equals(getMemberGroup(instance))) {
+                fineLog("isDeploymentGroupsActive: not all instances in the deployment group share the same Hazelcast instance group");
+                return false;
+            }
+        }
+
+        // Check 5: The instance group is not shared with any instance outside the deployment group.
+        Set<String> dgInstanceNames = dgInstances.stream().map(Server::getName).collect(Collectors.toSet());
+        for (UUID memberId : cluster.getClusterMembers()) {
+            String memberName = cluster.getMemberName(memberId);
+            if (!dgInstanceNames.contains(memberName) && myMemberGroup.equals(cluster.getMemberGroup(memberId))) {
+                fineLog("isDeploymentGroupsActive: Hazelcast instance group {0} is shared with an instance outside the deployment group",
+                        myMemberGroup);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private String getMemberGroup(Server server) {
+        Config config =  server.getConfig();
+        if (config == null) {
+            return "";
+        }
+        HazelcastConfigSpecificConfiguration hzConfig = config.getExtensionByType(HazelcastConfigSpecificConfiguration.class);
+        return hzConfig != null ? hzConfig.getMemberGroup() : "";
     }
 
     private boolean isTraditionalClusterActive() {
@@ -331,7 +406,6 @@ public class IiopFolbGmsClient implements ClusterListener {
         String configRef = server.getConfigRef();
         fineLog("getConfigForServer: configRef {0}", configRef);
 
-        Configs configs = services.getService(Configs.class);
         fineLog("getConfigForServer: configs {0}", configs);
 
         Config config = configs.getConfigByName(configRef);
@@ -364,9 +438,16 @@ public class IiopFolbGmsClient implements ClusterListener {
     private Map<String, ClusterInstanceInfo> getAllClusterInstanceInfo() {
         Map<String, ClusterInstanceInfo> result = new HashMap<>();
 
+        if (myServer == null) {
+            return result;
+        }
+
         final Config myConfig = getConfigForServer(myServer);
         fineLog("getAllClusterInstanceInfo: myConfig {0}", myConfig.getName());
-        result.put(myServer.getName(), getClusterInstanceInfo(myServer, myConfig, false));
+        ClusterInstanceInfo myCii = getClusterInstanceInfo(myServer, myConfig, false);
+        if (myCii != null) {
+            result.put(myServer.getName(), myCii);
+        }
 
         // Iterate over cluster or deployment group
         // When myServer is DAS's situation, myCluster is null - we check we're not adding the same server twice
@@ -434,7 +515,6 @@ public class IiopFolbGmsClient implements ClusterListener {
 
     @Override
     public void memberAdded(MemberEvent event) {
-        // if member added into my group
         if (cluster.getUnderlyingHazelcastService().getMemberGroup().equals(event.getServerGroup())) {
             addMember(event.getServer());
         }


### PR DESCRIPTION
<!--- Title your PR with a Jira reference (if available) followed by brief description - for example: "PAYARA-1234 Add readme file" -->

## Description
<!-- Is this a fix or a feature? Does it address a GH issue? This section should be understandable by any developer without much background reading -->
This PR improves the check for deployment groups by verifying that the instance is actually in a deployment group.
## Important Info
### Blockers
<!--- Link any related or dependant PRs or issues here with brief description why -->
n/a
## Testing
### New tests
<!-- Link tests if they can be found in another repository or another PR -->
n/a
### Testing Performed
<!--- Please describe how you tested these changes. Which test suites did you run?  -->
Prerequisite for all: enable FINE logging on the instance before starting it:
  asadmin set-log-levels --target <instance> javax.enterprise.resource.corba=FINE
  Then check <domain>/nodes/<node>/<instance>/logs/server.log for isDeploymentGroupsActive: messages, and look for GMS available and enabled from GlassFishORBManager to confirm
  FOLB activated.
- - -
Test 1 — Happy path (FOLB activates)

  Setup:
  1. Create two instances, add both to one deployment group
  2. Set a custom Hazelcast member group (e.g. myFolbGroup) on both instances' configs via Admin Console → Configurations → <config> → Hazelcast → Member Group
  3. Deploy an application to the deployment group: asadmin deploy --target <dg> myapp.war 
  4. Start both instances
  
  Verify: No isDeploymentGroupsActive: failure log appears. GMS available and enabled is logged. Both instance endpoints appear in the CORBA log line iiop instance info =.

  ---

  Test 2 — Instance not in any deployment group 

  Setup:
  1. Start a standalone instance not added to any deployment group
  
  Verify: Log shows isDeploymentGroupsActive: instance is not in a deployment group. GMS available and enabled does not appear (unless it falls into traditional cluster path).

  ---

  Test 3 — Default MicroShoal group shared with DAS 

  Setup:
  1. Create two instances in a deployment group
  2. Leave their Hazelcast member group as the default (MicroShoal)
  3. DAS also uses MicroShoal by default
  4. Deploy an app to the DG and start the instances
  
  Verify: Log shows isDeploymentGroupsActive: Hazelcast instance group MicroShoal is shared with an instance outside the deployment group. GMS available and enabled does not
  appear.

  ---
  
  Test 4 — Instances have different Hazelcast member groups 

  Setup:
  1. Two instances in the same deployment group
  2. Set member group groupA on instance1's config, groupB on instance2's config
  3. Deploy app to DG and start both
  
  Verify: Log on each instance shows isDeploymentGroupsActive: not all instances in the deployment group share the same Hazelcast instance group.

  ---

  Test 5 — Instance in two deployment groups

  Setup:
  1. Create two deployment groups dg1 and dg2
  2. Add instance1 to both 
  3. Deploy app, start instance1
  
  Verify: Log shows isDeploymentGroupsActive: instance belongs to more than one deployment group.

  ---

  Test 6 — App not deployed to all DG instances 

  Setup:
  1. Two instances in one DG with a custom shared member group
  2. Deploy the app directly to only one instance (not via the DG target): asadmin deploy --target <instance1> myapp.war
  3. Start both instances

  Verify: Log shows isDeploymentGroupsActive: application myapp is not deployed to all targets of the deployment group.
### Testing Environment
<!--- Which OS, JDK, Maven version did you use? - for example "Zulu JDK 11.0.11 on Ubuntu 18.04 with Maven 3.6.0"-->
Apache Maven 3.9.8 (36645f6c9b5079805ea5009217e36f2cffd34256)
Maven home: /Users/kalinchan/Library/apache-maven-3.9.8
Java version: 1.8.0_472, vendor: Azul Systems, Inc., runtime: /Users/kalinchan/.sdkman/candidates/java/8.0.472-zulu/zulu-8.jdk/Contents/Home/jre
Default locale: en_GB, platform encoding: UTF-8
OS name: "mac os x", version: "26.5.2", arch: "aarch64", family: "mac"

For the JIRA reproducer, I required a Windows VM to reproduce the original issue.
## Documentation
<!-- Link documentation if a PR exists -->
n/a
## Notes for Reviewers
<!-- Any further information for reviewers such as where to start reviewing. Commits should already be clean and the code should already be understandable without this. -->
I used remoteview to test this 
[remoteview.zip](https://github.com/user-attachments/files/31788538/remoteview.zip)
