### PR TITLE
FISH-14237 Export only the CDI extension package from agentic-ai-core

### DIFF
--- a/appserver/agentic-ai/agentic-ai-core/pom.xml
+++ b/appserver/agentic-ai/agentic-ai-core/pom.xml
@@ -121,14 +121,25 @@
                         <configuration>
                             <instructions>
                                 <!--
-                                    This is an internal implementation module
-                                    (fish.payara.server.internal.agentic-ai), so it must
-                                    not export any packages for OSGi consumption. An empty
-                                    Export-Package keeps every package private, instead of
-                                    letting bnd fall back to exporting the module's packages.
-                                    Mirrors the Jakarta Data implementation module (data-core).
+                                    The Jakarta Agentic AI CDI portable extension
+                                    (AgenticAIExtension) is discovered by a deployed
+                                    application's Weld bootstrap via ServiceLoader on the
+                                    application module class loader (see
+                                    DeploymentImpl.getExtensions -> WeldBootstrap.loadExtensions).
+                                    For that lookup to find and load the extension, the package
+                                    that declares it must be exported for OSGi consumption.
+                                    Everything else is internal implementation and stays
+                                    private; the exporting bundle resolves those packages
+                                    within its own class loader once the extension is loaded.
+
+                                    Note: an empty/self-closing <Export-Package/> does NOT
+                                    make packages private - the maven-bundle-plugin drops the
+                                    empty instruction and bnd then exports every package by
+                                    default. Private-Package is what actually keeps a package
+                                    off the export list.
                                 -->
-                                <Export-Package/>
+                                <Export-Package>fish.payara.ai.agent.extension</Export-Package>
+                                <Private-Package>fish.payara.ai.agent.*</Private-Package>
                             </instructions>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Description
Follow-up to review comments on #8331 (FISH-14237): review the OSGi package exports of the internal `agentic-ai-core` module.

Investigation finding: the module used an empty, self-closing `<Export-Package/>` bnd instruction with a comment claiming it "keeps every package private". That is incorrect — the maven-bundle-plugin drops the empty instruction and bnd then falls back to its default of exporting *every* package. So the module was actually exporting all four `fish.payara.ai.agent.*` packages (the same latent issue exists in `data-core`).

Not exporting is also wrong for this module specifically: unlike `data-core` (which registers its CDI extension programmatically via a HK2 deployer + `SNIFFER_EXTENSIONS`), `agentic-ai-core` has no sniffer/deployer. It registers `AgenticAIExtension` purely as a portable CDI extension via `META-INF/services/jakarta.enterprise.inject.spi.Extension`, which is discovered by the deployed application's Weld bootstrap (`DeploymentImpl.getExtensions` -> `WeldBootstrap.loadExtensions(moduleClassLoader)`). For that lookup to load the extension, its package must be exported.

Fix: export only `fish.payara.ai.agent.extension` (the extension entry point) and keep the implementation packages (`cdi`, `engine`, `llm`) private via `<Private-Package>`. The misleading comment was rewritten to document the bnd behaviour.

## Important Info
### Blockers
None. A related latent issue in `data-core` (same empty `<Export-Package/>`) is noted for a separate ticket.

## Testing
### New tests
None. This is a build/packaging (OSGi manifest) change; behaviour is covered by the existing agentic-ai sample integration tests (`AgenticTutorialIT`, `AgenticQuickstartIT`).

### Testing Performed
- Rebuilt the module (with upstream chain): `mvn -am -pl appserver/agentic-ai/agentic-ai-core install -DskipTests` -> BUILD SUCCESS.
- Inspected the generated `META-INF/MANIFEST.MF` of `agentic-ai-core.jar`:
  - `Export-Package` = `fish.payara.ai.agent.extension` only (`uses:="jakarta.enterprise.inject.spi"`).
  - `cdi`, `engine`, `llm` are no longer exported (private) but remain packaged in the jar, so the bundle resolves them within its own class loader.
- Verified the previous behaviour for comparison: with the empty `<Export-Package/>`, the built jars of both `agentic-ai-core` and `data-core` exported all their packages.
- Dependency-surface check: no other module or the samples import `fish.payara.ai.agent.*`; the samples use only the public `jakarta.ai.agent.*` API — confirming the minimal export is sufficient.
- NOT run: the agentic-ai Arquillian sample ITs against a full distribution (recommended as a CI validation step).

### Testing Environment
Azul Zulu JDK 21.0.1 on Windows 11, Apache Maven 3.9.9.

## Documentation
N/A

## Notes for Reviewers
Start at `appserver/agentic-ai/agentic-ai-core/pom.xml`. The key point: `<Export-Package>` must name the extension package explicitly — an empty instruction is a no-op that silently exports everything.

🤖 Generated by LLM
