### PR TITLE
FISH-14239 Remove "Temporary" Dependencies from agentic samples

### DIFF
--- a/appserver/tests/payara-samples/samples/agentic-ai-quickstart/pom.xml
+++ b/appserver/tests/payara-samples/samples/agentic-ai-quickstart/pom.xml
@@ -69,23 +69,6 @@
             <version>${jakarta.agentic-ai-api.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!-- Temporary dependencies while EE11 in development, remove once EE11 fully released -->
-        <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- End of temporary dependencies -->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>

--- a/appserver/tests/payara-samples/samples/agentic-ai/pom.xml
+++ b/appserver/tests/payara-samples/samples/agentic-ai/pom.xml
@@ -69,23 +69,6 @@
             <version>${jakarta.agentic-ai-api.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!-- Temporary dependencies while EE11 in development, remove once EE11 fully released -->
-        <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- End of temporary dependencies -->
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>


### PR DESCRIPTION
## FISH-14239

Follow-up to review comments on PR #8331:
- https://github.com/payara/Payara/pull/8331#discussion_r3729922502
- https://github.com/payara/Payara/pull/8331#discussion_r3729932106

### What

Removes the block of "Temporary dependencies while EE11 in development" from the two agentic-ai samples:
- `appserver/tests/payara-samples/samples/agentic-ai/pom.xml`
- `appserver/tests/payara-samples/samples/agentic-ai-quickstart/pom.xml`

The removed dependencies were:
- `jakarta.ws.rs:jakarta.ws.rs-api`
- `jakarta.enterprise:jakarta.enterprise.cdi-api`
- `jakarta.inject:jakarta.inject-api`

### Why

As @Pandrex247 noted, these APIs are all already provided by the `jakarta.platform:jakarta.jakartaee-api` umbrella dependency that both samples already declare, so the explicit entries were redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)