### PR TITLE
FISH-14383 Align Resources DTD Versioning and Fix Precedence

### DIFF
--- a/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara5-resources_1_7-1.dtd
+++ b/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara5-resources_1_7-1.dtd
@@ -1,0 +1,1095 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<!-- Portions Copyright 2018-2026 Payara Foundation and/or affiliates -->
+
+<!--  
+  A resources instance document referring to this DTD should have a DOCTYPE as follows:
+ <!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 5 Resource Definitions//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara5-resources_1_7-1.dtd">-->
+<!-- ENTITIES -->
+<!-- boolean
+
+  Used in:
+    admin-object-resource, connector-connection-pool,                 
+    connector-resource, custom-resource, external-jndi-resource,      
+    jdbc-connection-pool, jdbc-resource, mail-resource,
+    work-security-map, managed-executor-service         
+-->
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+
+<!-- isolation
+
+  Used in:
+    jdbc-connection-pool                                              
+-->
+<!ENTITY % isolation
+    "(read-uncommitted | read-committed | repeatable-read | serializable | snapshot)">    
+
+
+<!-- object-type
+    defines the type of the resource. It can be:                      
+    system-all                                                                 
+        These are system resources for all instances and DAS          
+    system-admin                                                               
+        These are system resources only in DAS                        
+    system-instance                                                            
+        These are system resources only in instances (and not DAS)    
+    user                                                                       
+        User resources (This is the default for all elements)         
+
+  Used in:
+    admin-object-resource, connector-resource, custom-resource,       
+    external-jndi-resource, jdbc-resource, mail-resource,             
+    resource-adapter-config, work-security-map     
+-->
+<!ENTITY % object-type "(system-all | system-admin | system-instance | user)">
+
+<!-- ELEMENTS -->
+
+<!-- resources
+    J2EE Applications look up resources registered with the           
+    Application server, using portable JNDI names.                    
+-->
+<!ELEMENT resources
+    ((custom-resource | external-jndi-resource | jdbc-resource | mail-resource 
+    | admin-object-resource | connector-resource
+    | resource-adapter-config | jdbc-connection-pool      
+    | connector-connection-pool | work-security-map
+    | managed-executor-service | managed-scheduled-executor-service
+    | managed-thread-factory)*)>                                              
+
+
+
+<!-- description
+    Textual description of a configured entity                        
+
+  Used in:
+    admin-object-resource, connector-connection-pool,                 
+    connector-resource, custom-resource, external-jndi-resource,      
+    jdbc-connection-pool, jdbc-resource, mail-resource,               
+    work-security-map, property, managed-executor-service,
+    managed-scheduled-executor-service, managed-thread-factory             
+-->
+<!ELEMENT description (#PCDATA)>
+
+
+<!-- custom-resource
+    custom (or generic) resource managed by a user-written factory    
+    class.                                                            
+
+  attributes
+    jndi-name                                                                  
+        JNDI name for generic resource, the fully qualified type of   
+        the resource and whether it is enabled at runtime             
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT custom-resource (description?, property*)>
+
+<!ATTLIST custom-resource
+    jndi-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    factory-class CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- external-jndi-resource
+    resource residing in an external JNDI repository                  
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT external-jndi-resource (description?, property*)>
+
+<!ATTLIST external-jndi-resource
+    jndi-name CDATA #REQUIRED
+    jndi-lookup-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    factory-class CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- jdbc-resource
+    JDBC javax.sql.(XA)DataSource resource definition                 
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT jdbc-resource (description?, property*)>
+
+<!ATTLIST jdbc-resource
+    jndi-name CDATA #REQUIRED
+    pool-name CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- mail-resource
+    The mail-resource element describes a javax.mail.Session resource 
+
+  attributes
+    host                                                                       
+        ip V6 or V4 address or hostname.                              
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT mail-resource (description?, property*)>
+
+<!ATTLIST mail-resource
+    jndi-name CDATA #REQUIRED
+    store-protocol CDATA "imap"
+    store-protocol-class CDATA "com.sun.mail.imap.IMAPStore"
+    transport-protocol CDATA "smtp"
+    transport-protocol-class CDATA "com.sun.mail.smtp.SMTPTransport"
+    host CDATA #REQUIRED
+    user CDATA #REQUIRED
+    from CDATA #REQUIRED
+    debug %boolean; "false"
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+<!-- admin-object-resource
+    The admin-object-resource element describes a administered object 
+    for a inbound resource adapter.                                   
+
+  attributes
+    jndi-name                                                                  
+        JNDI name for this resource                                   
+    res-adapter                                                                
+        Name of the inbound resource adapter.                         
+    res-type                                                                   
+        Interface definition for the administered object              
+    class-name
+        admin-object class-name (when more than one implementation class
+        is specified for same res-type in the resource-adapter,
+        class-name must be specified)
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT admin-object-resource (description?, property*)>
+
+<!ATTLIST admin-object-resource
+    jndi-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    class-name CDATA #IMPLIED
+    res-adapter CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- connector-resource
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT connector-resource (description?, property*)>
+
+<!ATTLIST connector-resource
+    jndi-name CDATA #REQUIRED
+    pool-name CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- resource-adapter-config
+    This element is for configuring the resource adapter. These       
+    values (properties) over-rides the default values present in      
+    ra.xml. The name attribute has to be unique . It is optional for  
+    PE. It is used mainly for EE.                                     
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT resource-adapter-config (property*)>
+
+<!ATTLIST resource-adapter-config
+    name CDATA #IMPLIED
+    thread-pool-ids CDATA #IMPLIED
+    object-type %object-type; "user"
+    resource-adapter-name CDATA #REQUIRED>
+
+
+<!-- jdbc-connection-pool
+    jdbc-connection-pool defines configuration used to create and     
+    manage a pool physical database connections. Pool definition is   
+    named, and can be referred to by multiple jdbc-resource elements  
+    (See <jdbc-resource>).                                            
+
+    Each named pool definition results in a pool instantiated at server        
+    start-up. Pool is populated when accessed for the first time. If two or    
+    more jdbc-resource elements point to the same jdbc-connection-pool         
+    element, they are using the same pool of connections, at run time.         
+
+
+  children
+    property                                                                   
+        Most JDBC 2.0 drivers permit use of standard property lists,  
+        to specify User, Password and other resource configuration.   
+        While these are optional properties, according to the         
+        specification, several of these properties may be necessary   
+        for most databases. See Section 5.3 of JDBC 2.0 Standard      
+        Extension API.                                                
+
+        The following are the names and corresponding values for these         
+        properties                                                             
+
+        databaseName                                                           
+            Name of the Database                                      
+        serverName                                                             
+            Database Server name.                                     
+        port                                                                   
+            Port where a Database server is listening for requests.   
+        networkProtocol                                                        
+            Communication Protocol used.                              
+        user                                                                   
+            default name of the database user with which connections  
+            will be stablished. Programmatic database authentication  
+            or default-resource-principal specified in vendor         
+            specific web and ejb deployment descriptors will take     
+            precedence, over this default. The details and caveats    
+            are described in detail in the Administrator's guide.     
+        password                                                               
+            password for default database user                        
+        roleName                                                               
+            The initial SQL role name.                                
+        datasourceName                                                         
+            used to name an underlying XADataSource, or               
+            ConnectionPoolDataSource when pooling of connections is   
+            done                                                      
+        description                                                            
+            Textual Description                                       
+
+        When one or more of these properties are specified, they are passed as 
+        is using set<Name>(<Value>) methods to the vendors Datasource class    
+        (specified in datasource-classname). User and Password properties are  
+        used as default principal, if Container Managed authentication is      
+        specified and a default-resource-principal is not found in application 
+        deployment descriptors.                                                
+
+
+  attributes
+    allow-non-component-callers                                                
+        A pool with this property set to true, can be used by         
+        non-J2EE components (i.e components other than EJBs or        
+        Servlets). The returned connection is enlisted automatically  
+        with the transaction context obtained from the transaction    
+        manager. This property is to enable the pool to be used by    
+        non-component callers such as ServletFilters, Lifecycle       
+        modules, and 3rd party persistence managers. Standard J2EE    
+        components can continue to use such pools. Connections        
+        obtained by non-component callers are not automatically       
+        cleaned at the end of a transaction by the container. They    
+        need to be explicitly closed by the the caller.               
+    associate-with-thread                                                      
+        Associate a connection with the thread such that when the     
+        same thread is in need of a connection, it can reuse the      
+        connection already associated with that thread, thereby not   
+        incurring the overhead of getting a connection from the pool. 
+        Default value is false.                                       
+    connection-creation-retry-attempts                                         
+        The number of attempts to create a new connection. Default is 
+        0, which implies no retries.                                  
+    connection-creation-retry-interval-in-seconds                              
+        The time interval between retries while attempting to create  
+        a connection. Default is 10 seconds. Effective when           
+        connection-creation-retry-attempts is greater than 0.         
+    connection-leak-reclaim                                                    
+        If enabled, connection will be reusable (put back into pool)  
+        after connection-leak-timeout-in-seconds occurs. Default      
+        value is false.                                               
+    connection-leak-timeout-in-seconds                                         
+        To aid user in detecting potential connection leaks by the    
+        application. When a connection is not returned back to the    
+        pool by the application within the specified period, it is    
+        assumed to be a potential leak and stack trace of the caller  
+        will be logged. Default is 0, which implies there is no leak  
+        detection, by default. A positive non-zero value turns on     
+        leak detection. Note however that, this attribute only        
+        detects if there is a connection leak. The connection can be  
+        reclaimed only if connection-leak-reclaim is set to true.     
+    connection-validation-method                                               
+        specifies the type of validation to be performed when         
+        is-connection-validation-required is true. Default value of
+	this attribute is table. (see validation-table-name). The following      
+        types of validation are supported:                            
+        auto-commit                                                            
+            using connection.autoCommit()                             
+        meta-data                                                              
+            using connection.getMetaData()                            
+        table                                                                  
+            performing a query on a user specified table (see         
+            validation-table-name).                           
+        custom-validation
+            validation based on user specified validation mechanism (see
+            validation-classname).
+    datasource-classname                                                       
+        Name of the vendor supplied JDBC datasource resource manager. 
+        An XA or global transactions capable datasource class will    
+        implement javax.sql.XADatasource interface. Non XA or Local   
+        transactions only datasources will implement                  
+        javax.sql.Datasource interface.                               
+    driver-classname
+        Name of the vendor supplied JDBC driver class name. The 
+        specified driver should implement the java.sql.Driver interface.	
+    fail-all-connections                                                       
+        indicates if all connections in the pool must be closed       
+        should a single validation check fail. The default is false.  
+        One attempt will be made to re-establish failed connections.  
+    idle-timeout-in-seconds                                                    
+        maximum time in seconds, that a connection can remain idle in 
+        the pool. After this time, the pool implementation can close  
+        this connection. Note that this does not control connection   
+        timeouts enforced at the database server side. Adminsitrators 
+        are advised to keep this timeout shorter than the database    
+        server side timeout (if such timeouts are configured on the   
+        specific vendor's database), to prevent accumulation of       
+        unusable connection in Application Server.                    
+    init-sql
+        Used to specify a SQL string by the user, to be executed 
+        whenever a connection is created from the pool (not the 
+        connections that are reused). This is executed to initialize
+        the state of the connection.
+        This is an optional attribute and should carry a value when 
+        a initialization SQL is to be executed.
+    is-connection-validation-required                                          
+        if true, connections are validated (checked to find out if    
+        they are usable) before giving out to the application. The    
+        default is false.                                             
+    is-isolation-level-guaranteed                                              
+        Applicable only when a particular isolation level is          
+        specified for transaction-isolation-level. The default value  
+        is true. This assures that every time a connection is         
+        obtained from the pool, it is guaranteed to have the          
+        isolation set to the desired value. This could have some      
+        performance impact on some JDBC drivers. Can be set to false  
+        by that administrator when they are certain that the          
+        application does not change the isolation level before        
+        returning the connection.                                     
+    lazy-connection-association                                                
+        Connections are lazily associated when an operation is        
+        performed on them. Also, they are disassociated when the      
+        transaction is completed and a component method ends, which   
+        helps reuse of the physical connections. Default value is     
+        false.                                                        
+    lazy-connection-enlistment                                                 
+        Enlist a resource to the transaction only when it is actually 
+        used in a method, which avoids enlistment of connections that 
+        are not used in a transaction. This also prevents unnecessary 
+        enlistment of connections cached in the calling components.   
+        Default value is false.
+    log-jdbc-calls
+        Log all SQL calls made through a JDBC connection pool, with 
+        the time taken to execute the call also recorded and logged to
+        the server at the FINE level. Default value is false.
+    match-connections                                                          
+        To switch on/off connection matching for the pool. It can be  
+        set to false if the administrator knows that the connections  
+        in the pool will always be homogeneous and hence a connection 
+        picked from the pool need not be matched by the resource      
+        adapter. Default value is false.                              
+    max-connection-usage-count                                                 
+        When specified, connections will be re-used by the pool for   
+        the specified number of times after which it will be closed.  
+        This is useful for instance, to avoid statement-leaks.        
+        Default value is 0, which implies the feature is not enabled. 
+    max-pool-size                                                              
+        maximum number of conections that can be created              
+    max-wait-time-in-millis                                                    
+        amount of time the caller will wait before getting a          
+        connection timeout. The default is 60 seconds. A value of 0   
+        will force caller to wait indefinitely.                       
+    name                                                                       
+        unique name of the pool definition.                           
+    non-transactional-connections                                              
+        A pool with this property set to true returns                 
+        non-transactional connections. This connection does not get   
+        automatically enlisted with the transaction manager.          
+    ping
+        A pool with this attribute set to true is pinged during the pool
+        creation or reconfiguration to identify and warn of any erroneous
+        values for the its attributes. Default value of this attribute 
+        is false.
+    pool-resize-quantity                                                       
+        number of connections to be removed when                      
+        idle-timeout-in-seconds timer expires. Connections that have  
+        idled for longer than the timeout are candidates for removal. 
+        When the pool size reaches steady-pool-size, the connection   
+        removal stops.                                                
+    pooling
+        When set to false, this attribute disables connection pooling. 
+        Default value of this attribute is true.
+    res-type                                                                   
+        DataSource implementation class could implement one of of     
+        javax.sql.DataSource, javax.sql.XADataSource or               
+        javax.sql.ConnectionPoolDataSource interfaces. To support 
+        configuration of JDBC drivers and applications that use
+        java.sql.Driver implementations, set this attribute to
+        java.sql.Driver. This optional attribute must be specified to 
+	disambiguate when a Datasource class implements two or more of 
+	these interfaces or when a driver classname is to be provided. 
+	An error is produced when this attribute has a legal value and the        
+        indicated interface is not implemented by the datasource      
+        class. This attribute has no default value. (see also driver-classname).
+    sql-trace-listeners
+        Used to set if the SQL statements executed by applications need to be traced, 
+	enabling easy filtering of SQL statements executed as log messages. 
+        Aids administrators in analysing the statements. Multiple listeners can be
+        specified as comma separated list of listener implementation class names,
+	to enable different means of recording the SQL trace records.
+    statement-cache-size
+        Specifies the number of statements to be cached. The only cache
+	eviction strategy supported in this release is "Least Recently Used".
+	The default value is 0 and statement caching is not enabled. Specify a
+	non-zero integer value to enable statement caching.
+    statement-timeout-in-seconds                                               
+        Sets the timeout property of a connection to enable           
+        termination of abnormally long running queries. Default value 
+        of -1 implies that it is not enabled.                         
+    statement-leak-reclaim
+        If enabled, statement is reclaimed after the statement-leak-timeout-
+        in-seconds occurs. Default value is false.
+    statement-leak-timeout-in-seconds                                               
+        To aid user in detecting the statement leaks by applications.
+        When a statement is not closed by the application within the specified
+        period, it is assumed to be a statement leak. Default is 0, which 
+        implies there is no statement leak detection, by default. A 
+        positive non-zero value turns on statement leak detection.
+        Note however that, this attribute only detects if there is
+        a statement leak. The statement can be reclaimed only is
+        statement-leak-reclaim is set to true.     
+    steady-pool-size                                                           
+        minimum and initial number of connections maintained in the   
+        pool.                                                         
+    transaction-isolation-level                                                
+        Specifies the Transaction Isolation Level on the pooled       
+        database connections. Optional. Has no default. If left       
+        unspecified the pool operates with default isolation level    
+        provided by the JDBC Driver. A desired isolation level can be 
+        set using one of the standard transaction isolation levels,   
+        which see.                                                    
+
+        Applications that change the Isolation level on a pooled connection    
+        programmatically, risk polluting the pool and this could lead to       
+        program errors. Also see: is-isolation-level-guaranteed                
+
+    validate-atmost-once-period-in-seconds                                     
+        Used to set the time-interval within which a connection is    
+        validated atmost once. Default is 0 which implies that it is  
+        not enabled. TBD: Documentation is to be corrected.           
+    validation-classname
+        Specifies the custom validation implementation class name to be used
+	for validation. This parameter is mandatory if the 
+	connection-validation-type is set to custom-validation. The specified
+	class must implement the org.glassfish.api.jdbc.ConnectionValidation
+	interface and must be accessible by the application server.
+    validation-table-name                                                      
+        specifies the table name to be used to perform a query to     
+        validate a connection. This parameter is mandatory, if        
+	is-connection-validation-required is set to true and 
+	connection-validation-type set to table. Verification by      
+        accessing a user specified table may become necessary for     
+        connection validation, particularly if database driver caches 
+        calls to setAutoCommit() and getMetaData().                   
+    wrap-jdbc-objects                                                          
+        When set to true, application will get wrapped jdbc objects   
+        for Statement, PreparedStatement, CallableStatement,          
+        ResultSet, DatabaseMetaData. Defaults to true.               
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT jdbc-connection-pool (description?, property*)>
+
+<!ATTLIST jdbc-connection-pool
+    name CDATA #REQUIRED
+    datasource-classname CDATA #IMPLIED
+    res-type (javax.sql.DataSource | javax.sql.XADataSource | javax.sql.ConnectionPoolDataSource | java.sql.Driver) #IMPLIED
+    driver-classname CDATA #IMPLIED
+    ping %boolean; "false"   
+    steady-pool-size CDATA "8"
+    max-pool-size CDATA "32"
+    max-wait-time-in-millis CDATA "60000"
+    pool-resize-quantity CDATA "2"
+    idle-timeout-in-seconds CDATA "300"
+    transaction-isolation-level %isolation; #IMPLIED
+    is-isolation-level-guaranteed %boolean; "true"
+    is-connection-validation-required %boolean; "false"
+    connection-validation-method (auto-commit | meta-data | table | custom-validation) "table"
+    validation-table-name CDATA #IMPLIED
+    validation-classname CDATA #IMPLIED
+    init-sql CDATA #IMPLIED	      
+    fail-all-connections %boolean; "false"
+    non-transactional-connections %boolean; "false"
+    allow-non-component-callers %boolean; "false"
+    validate-atmost-once-period-in-seconds CDATA "0"
+    connection-leak-timeout-in-seconds CDATA "0"
+    connection-leak-reclaim %boolean; "false"
+    connection-creation-retry-attempts CDATA "0"
+    connection-creation-retry-interval-in-seconds CDATA "10"
+    statement-leak-timeout-in-seconds CDATA "0"
+    statement-leak-reclaim %boolean; "false"
+    statement-timeout-in-seconds CDATA "-1"
+    lazy-connection-enlistment %boolean; "false"
+    lazy-connection-association %boolean; "false"
+    log-jdbc-calls %boolean; "false"
+    associate-with-thread %boolean; "false"
+    match-connections %boolean; "false"
+    max-connection-usage-count CDATA "0"
+    sql-trace-listeners CDATA #IMPLIED 
+    statement-cache-size CDATA "0"
+    pooling %boolean; "true"
+    wrap-jdbc-objects %boolean; "true">
+
+
+<!-- connector-connection-pool
+    connector-connection-pool defines configuration used to create    
+    and manage a pool of connections to a EIS. Pool definition is     
+    named, and can be referred to by multiple connector-resource      
+    elements (See connector-resource).                                
+
+    Each named pool definition results in a pool instantiated at server        
+    start-up. Pool is populated when accessed for the first time. If two or    
+    more connector-resource elements point to the same                         
+    connector-connection-pool element, they are using the same pool of         
+    connections, at run time.                                                  
+
+    There can be more than one pool for one connection-definition in one       
+    resource-adapter.                                                          
+
+
+  children
+    property                                                                   
+        Properties are used to override the ManagedConnectionFactory  
+        javabean configuration settings.                              
+
+        When one or more of these properties are specified, they are passed as 
+        is using set<Name>(<Value>) methods to the Resource Adapter's          
+        ManagedConnectionfactory class (specified in ra.xml).                  
+
+
+  attributes
+    associate-with-thread                                                      
+        Associate a connection with the thread such that when the     
+        same thread is in need of a connection, it can reuse the      
+        connection already associated with that thread, thereby not   
+        incurring the overhead of getting a connection from the pool. 
+        Default value is false.                                       
+    connection-creation-retry-attempts                                         
+        The number of attempts to create a new connection. Default is 
+        0, which implies no retries.                                  
+    connection-creation-retry-interval-in-seconds                              
+        The time interval between retries while attempting to create  
+        a connection. Default is 10 seconds. Effective when           
+        connection-creation-retry-attempts is greater than 0.         
+    connection-definition-name                                                 
+        unique name, identifying one connection-definition in a       
+        Resource Adapter. Currently this is ConnectionFactory type.   
+    connection-leak-reclaim                                                    
+        If enabled, connection will be reusable (put back into pool)  
+        after connection-leak-timeout-in-seconds occurs. Default      
+        value is false.                                               
+    connection-leak-timeout-in-seconds                                         
+        To aid user in detecting potential connection leaks by the    
+        application. When a connection is not returned back to the    
+        pool by the application within the specified period, it is    
+        assumed to be a potential leak and stack trace of the caller  
+        will be logged. Default is 0, which implies there is no leak  
+        detection, by default. A positive non-zero value turns on     
+        leak detection. Note however that, this attribute only        
+        detects if there is a connection leak. The connection can be  
+        reclaimed only if connection-leak-reclaim is set to true.     
+    fail-all-connections                                                       
+        indicates if all connections in the pool must be closed       
+        should a single connection fail validation. The default is    
+        false. One attempt will be made to re-establish failed        
+        connections.                                                  
+    idle-timeout-in-seconds                                                    
+        maximum time in seconds, that a connection can remain idle in 
+        the pool. After this time, the pool implementation can close  
+        this connection. Note that this does not control connection   
+        timeouts enforced at the database server side. Adminsitrators 
+        are advised to keep this timeout shorter than the EIS         
+        connection timeout (if such timeouts are configured on the    
+        specific EIS), to prevent accumulation of unusable connection 
+        in Application Server.                                        
+    is-connection-validation-required                                          
+        This attribute specifies if the connection that is about to   
+        be returned is to be validated by the container,              
+    lazy-connection-association                                                
+        Connections are lazily associated when an operation is        
+        performed on them. Also, they are disassociated when the      
+        transaction is completed and a component method ends, which   
+        helps reuse of the physical connections. Default value is     
+        false.                                                        
+    lazy-connection-enlistment                                                 
+        Enlist a resource to the transaction only when it is actually 
+        used in a method, which avoids enlistment of connections that 
+        are not used in a transaction. This also prevents unnecessary 
+        enlistment of connections cached in the calling components.   
+        Default value is false.                                       
+    match-connections                                                          
+        To switch on/off connection matching for the pool. It can be  
+        set to false if the administrator knows that the connections  
+        in the pool will always be homogeneous and hence a connection 
+        picked from the pool need not be matched by the resource      
+        adapter. Default value is true.                               
+    max-connection-usage-count                                                 
+        When specified, connections will be re-used by the pool for   
+        the specified number of times after which it will be closed.  
+        This is useful for instance, to avoid statement-leaks.        
+        Default value is 0, which implies the feature is not enabled. 
+    max-pool-size                                                              
+        maximum number of conections that can be created              
+    max-wait-time-in-millis                                                    
+        amount of time the caller will wait before getting a          
+        connection timeout. The default is 60 seconds. A value of 0   
+        will force caller to wait indefinitely.                       
+    name                                                                       
+        unique name of the pool definition.                           
+    ping
+        A pool with this attribute set to true is pinged during the pool
+        creation or reconfiguration to identify and warn of any erroneous
+        values for the its attributes. Default value of this attribute 
+        is false.
+    pool-resize-quantity                                                       
+        number of connections to be removed when                      
+        idle-timeout-in-seconds timer expires. Connections that have  
+        idled for longer than the timeout are candidates for removal. 
+        When the pool size reaches steady-pool-size, the connection   
+        removal stops.                                                
+    pooling
+       When set to false, this attribute disables connection pooling.
+       Default value of this attribute is true.	
+    resource-adapter-name                                                      
+        This is the name of resource adapter. Name of .rar file is    
+        taken as the unique name for the resource adapter.            
+    steady-pool-size                                                           
+        minimum and initial number of connections maintained in the   
+        pool.                                                         
+    transaction-support                                                        
+        Indicates the level of transaction support that this pool     
+        will have. Possible values are "XATransaction",               
+        "LocalTransaction" and "NoTransaction". This attribute will   
+        override that transaction support attribute in the Resource   
+        Adapter in a downward compatible way, i.e it can support a    
+        lower/equal transaction level than specified in the RA, but   
+        not a higher level.                                           
+    validate-atmost-once-period-in-seconds                                     
+        Used to set the time-interval within which a connection is    
+        validated atmost once. Default is 0 which implies that it is  
+        not enabled. TBD: Documentation is to be corrected.           
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT connector-connection-pool (description?, security-map*, property*)>
+
+<!ATTLIST connector-connection-pool
+    name CDATA #REQUIRED
+    resource-adapter-name CDATA #REQUIRED
+    connection-definition-name CDATA #REQUIRED
+    steady-pool-size CDATA "8"
+    max-pool-size CDATA "32"
+    max-wait-time-in-millis CDATA "60000"
+    pool-resize-quantity CDATA "2"
+    idle-timeout-in-seconds CDATA "300"
+    fail-all-connections %boolean; "false"
+    transaction-support (XATransaction | LocalTransaction | NoTransaction) #IMPLIED
+    is-connection-validation-required %boolean; "false"
+    validate-atmost-once-period-in-seconds CDATA "0"
+    connection-leak-timeout-in-seconds CDATA "0"
+    connection-leak-reclaim %boolean; "false"
+    connection-creation-retry-attempts CDATA "0"
+    connection-creation-retry-interval-in-seconds CDATA "10"
+    lazy-connection-enlistment %boolean; "false"
+    lazy-connection-association %boolean; "false"
+    associate-with-thread %boolean; "false"
+    match-connections %boolean; "true"
+    max-connection-usage-count CDATA "0"
+    ping %boolean; "false"
+    pooling %boolean; "true">
+
+
+
+<!-- property
+    Syntax for supplying properties as name value pairs               
+
+  Used in:
+    admin-object-resource, connector-connection-pool,                 
+    connector-resource, custom-resource, external-jndi-resource,      
+    jdbc-connection-pool, jdbc-resource, mail-resource,               
+    work-security-map, resource-adapter-config     
+-->
+<!ELEMENT property (description?)>
+
+<!ATTLIST property
+    name CDATA #REQUIRED
+    value CDATA #REQUIRED>
+
+
+<!-- security-map
+    Perform mapping from principal received during Servlet/EJB        
+    authentication, to credentials accepted by the EIS. This mapping  
+    is optional.It is possible to map multiple (server) principal to  
+    the same backend principal.                                       
+
+  Used in:
+    connector-connection-pool                                         
+-->
+<!ELEMENT security-map ((principal | user-group)+, backend-principal)>
+
+<!ATTLIST security-map
+    name CDATA #REQUIRED>
+
+
+<!-- principal
+    Principal of the Servlet and EJB client                           
+
+  Used in:
+    security-map                                                      
+-->
+<!ELEMENT principal (#PCDATA)>
+
+
+<!-- user-group
+
+  Used in:
+    security-map                                                      
+-->
+<!ELEMENT user-group (#PCDATA)>
+
+
+<!-- backend-principal
+
+  Used in:
+    security-map                                                      
+-->
+<!ELEMENT backend-principal EMPTY>
+
+<!ATTLIST backend-principal
+    user-name CDATA #REQUIRED
+    password CDATA #IMPLIED>
+
+<!-- work-security-map
+  Perform mapping from Principal associated with an incoming Work
+  instance to a Principal in the application server's security domain. The 
+  security-map element, on the other hand, performs mapping from
+  Principals in the application server security domain to a Principal
+  accepted by the EIS. It is possible to map multiple EIS Group and/or
+  User Principals to the same application server (server) Principal.
+
+ Used in:
+   resources
+-->
+
+<!ELEMENT work-security-map (description?, (principal-map*, group-map*)+) >
+
+<!ATTLIST work-security-map 
+name CDATA #REQUIRED
+resource-adapter-name CDATA #REQUIRED
+object-type %object-type; "user"
+enabled %boolean; "true">
+
+<!-- principal-map
+  Performs mapping from a Principal in the EIS security domain to
+  a Principal accepted by the application server security domain
+
+  attributes 
+    eis-principal 
+        A Principal in the EIS security domain that is being mapped to 
+        a Principal in the application server's security domain.
+    mapped-principal
+        A Principal that is valid in the application server's security domain
+
+  Used in:
+    work-security-map
+-->
+<!ELEMENT principal-map EMPTY >
+
+<!ATTLIST principal-map
+eis-principal CDATA #REQUIRED
+mapped-principal CDATA #REQUIRED>
+
+<!-- group-map
+  Group map to map eis-group name to application server domain's group name
+
+  attributes 
+    eis-group 
+        A Group in the EIS security domain that is being mapped to 
+        a Group in the application server's security domain
+    mapped-group
+        A Group that is valid in the application server's security domain
+
+  Used in:
+    work-security-map
+-->
+<!ELEMENT group-map EMPTY >
+
+<!ATTLIST group-map
+eis-group CDATA #REQUIRED
+mapped-group CDATA #REQUIRED>
+
+<!-- managed-executor-service
+    ManagedExecutorService resource definition                 
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+    long-runnings-tasks
+        Specifies whether the resource should be used for long-running
+        tasks. The default value is false. If set to true, long-running
+        tasks are not reported as stuck.
+
+    hung-after-seconds
+        Specifies the number of seconds that a task can execute before it
+        is considered unresponsive. The default value is 0, which means
+        that tasks are never considered unresponsive.
+
+    core-pool-size
+        Specifies the number of threads to keep in a thread pool, even if
+        they are idle. The default value is 0.
+
+        When a new task is submitted and the number of running threads is
+        less than corepoolsize, a new thread is created to handle the
+        request. When the value for corepoolsize is 0 (the default), new
+        threads are never created unless the task queue is full or the
+        resource is using direct queuing. Direct queuing occurs when
+        taskqueuecapacity is 0, or when taskqueuecapacity is 2147483647 and
+        corepoolsize is 0.
+
+    maximum-pool-size
+        Specifies the maximum number of threads that a thread pool can
+        contain. The default value is 2147483647, which means that the
+        thread pool is essentially unbounded and can contain any number of
+        threads.
+
+    keep-alive-seconds
+        Specifies the number of seconds that threads can remain idle when
+        the number of threads is greater than corepoolsize. The default
+        value is 60.
+
+    thread-lifetime-seconds
+        Specifies the number of seconds that threads can remain in a thread
+        pool before being purged, regardless of whether the number of
+        threads is greater than corepoolsize or whether the threads are
+        idle. The default value is 0, which means that threads are never
+        purged.
+
+    task-queue-capacity
+        Specifies the number of submitted tasks that can be stored in the
+        task queue awaiting execution. The default value is 2147483647,
+        which means that the task queue is essentially unbounded and can
+        store any number of submitted tasks.
+
+  children
+        description                                                            
+            Textual Description                                       
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT managed-executor-service (description?)>
+
+<!ATTLIST managed-executor-service
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    maximum-pool-size CDATA "2147483647"
+    thread-priority CDATA "5"
+    long-runnings-tasks %boolean; "false"
+    hung-after-seconds CDATA "0"
+    core-pool-size CDATA "0"
+    keep-alive-seconds CDATA "60"
+    thread-lifetime-seconds CDATA "0"
+    task-queue-capacity CDATA "2147483647"
+    >
+
+<!-- managed-scheduled-executor-service
+    ManagedScheduledExecutorService resource definition                 
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+    long-runnings-tasks
+        Specifies whether the resource should be used for long-running
+        tasks. The default value is false. If set to true, long-running
+        tasks are not reported as stuck.
+
+    hung-after-seconds
+        Specifies the number of seconds that a task can execute before it
+        is considered unresponsive. The default value is 0, which means
+        that tasks are never considered unresponsive.
+
+    core-pool-size
+        Specifies the number of threads to keep in a thread pool, even if
+        they are idle. The default value is 0, which means that a thread is
+        created when the first task is scheduled.
+
+    keep-alive-seconds
+        Specifies the number of seconds that threads can remain idle when
+        the number of threads is greater than corepoolsize. The default
+        value is 60.
+
+    thread-lifetime-seconds
+        Specifies the number of seconds that threads can remain in a thread
+        pool before being purged, regardless of whether the number of
+        threads is greater than corepoolsize or whether the threads are
+        idle. The default value is 0, which means that threads are never
+        purged.
+
+  children
+        description                                                            
+            Textual Description                                       
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT managed-scheduled-executor-service (description?)>
+
+<!ATTLIST managed-scheduled-executor-service
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    thread-priority CDATA "5"
+    long-runnings-tasks %boolean; "false"
+    hung-after-seconds CDATA "0"
+    core-pool-size CDATA "0"
+    keep-alive-seconds CDATA "60"
+    thread-lifetime-seconds CDATA "0"
+    >
+
+<!-- managed-thread-factory
+    ManagedThreadFactory resource definition                 
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+  children
+        description                                                            
+            Textual Description                                       
+
+  Used in:
+    resources                                                         
+-->
+<!ELEMENT managed-thread-factory (description?)>
+
+<!ATTLIST managed-thread-factory
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    thread-priority CDATA "5"
+    >
+

--- a/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara6-resources_1_8-1.dtd
+++ b/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara6-resources_1_8-1.dtd
@@ -1,0 +1,1095 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<!-- Portions Copyright 2024-2026 Payara Foundation and/or affiliates -->
+
+<!--
+  A resources instance document referring to this DTD should have a DOCTYPE as follows:
+ <!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 6 Resource Definitions//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara6-resources_1_8-1.dtd">-->
+<!-- ENTITIES -->
+<!-- boolean
+
+  Used in:
+    admin-object-resource, connector-connection-pool,
+    connector-resource, custom-resource, external-jndi-resource,
+    jdbc-connection-pool, jdbc-resource, mail-resource,
+    work-security-map, managed-executor-service
+-->
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+
+<!-- isolation
+
+  Used in:
+    jdbc-connection-pool
+-->
+<!ENTITY % isolation
+    "(read-uncommitted | read-committed | repeatable-read | serializable | snapshot)">
+
+
+<!-- object-type
+    defines the type of the resource. It can be:
+    system-all
+        These are system resources for all instances and DAS
+    system-admin
+        These are system resources only in DAS
+    system-instance
+        These are system resources only in instances (and not DAS)
+    user
+        User resources (This is the default for all elements)
+
+  Used in:
+    admin-object-resource, connector-resource, custom-resource,
+    external-jndi-resource, jdbc-resource, mail-resource,
+    resource-adapter-config, work-security-map
+-->
+<!ENTITY % object-type "(system-all | system-admin | system-instance | user)">
+
+<!-- ELEMENTS -->
+
+<!-- resources
+    J2EE Applications look up resources registered with the
+    Application server, using portable JNDI names.
+-->
+<!ELEMENT resources
+    ((custom-resource | external-jndi-resource | jdbc-resource | mail-resource
+        | admin-object-resource | connector-resource
+        | resource-adapter-config | jdbc-connection-pool
+        | connector-connection-pool | work-security-map
+        | managed-executor-service | managed-scheduled-executor-service
+        | managed-thread-factory)*)>
+
+
+
+<!-- description
+    Textual description of a configured entity
+
+  Used in:
+    admin-object-resource, connector-connection-pool,
+    connector-resource, custom-resource, external-jndi-resource,
+    jdbc-connection-pool, jdbc-resource, mail-resource,
+    work-security-map, property, managed-executor-service,
+    managed-scheduled-executor-service, managed-thread-factory
+-->
+<!ELEMENT description (#PCDATA)>
+
+
+<!-- custom-resource
+    custom (or generic) resource managed by a user-written factory
+    class.
+
+  attributes
+    jndi-name
+        JNDI name for generic resource, the fully qualified type of
+        the resource and whether it is enabled at runtime
+
+  Used in:
+    resources
+-->
+<!ELEMENT custom-resource (description?, property*)>
+
+<!ATTLIST custom-resource
+    jndi-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    factory-class CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- external-jndi-resource
+    resource residing in an external JNDI repository
+
+  Used in:
+    resources
+-->
+<!ELEMENT external-jndi-resource (description?, property*)>
+
+<!ATTLIST external-jndi-resource
+    jndi-name CDATA #REQUIRED
+    jndi-lookup-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    factory-class CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- jdbc-resource
+    JDBC javax.sql.(XA)DataSource resource definition
+
+  Used in:
+    resources
+-->
+<!ELEMENT jdbc-resource (description?, property*)>
+
+<!ATTLIST jdbc-resource
+    jndi-name CDATA #REQUIRED
+    pool-name CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- mail-resource
+    The mail-resource element describes a javax.mail.Session resource
+
+  attributes
+    host
+        ip V6 or V4 address or hostname.
+
+  Used in:
+    resources
+-->
+<!ELEMENT mail-resource (description?, property*)>
+
+<!ATTLIST mail-resource
+    jndi-name CDATA #REQUIRED
+    store-protocol CDATA "imap"
+    store-protocol-class CDATA "org.eclipse.angus.mail.imap.IMAPStore"
+    transport-protocol CDATA "smtp"
+    transport-protocol-class CDATA "org.eclipse.angus.mail.smtp.SMTPTransport"
+    host CDATA #REQUIRED
+    user CDATA #REQUIRED
+    from CDATA #REQUIRED
+    debug %boolean; "false"
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+<!-- admin-object-resource
+    The admin-object-resource element describes a administered object
+    for a inbound resource adapter.
+
+  attributes
+    jndi-name
+        JNDI name for this resource
+    res-adapter
+        Name of the inbound resource adapter.
+    res-type
+        Interface definition for the administered object
+    class-name
+        admin-object class-name (when more than one implementation class
+        is specified for same res-type in the resource-adapter,
+        class-name must be specified)
+
+  Used in:
+    resources
+-->
+<!ELEMENT admin-object-resource (description?, property*)>
+
+<!ATTLIST admin-object-resource
+    jndi-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    class-name CDATA #IMPLIED
+    res-adapter CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- connector-resource
+
+  Used in:
+    resources
+-->
+<!ELEMENT connector-resource (description?, property*)>
+
+<!ATTLIST connector-resource
+    jndi-name CDATA #REQUIRED
+    pool-name CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- resource-adapter-config
+    This element is for configuring the resource adapter. These
+    values (properties) over-rides the default values present in
+    ra.xml. The name attribute has to be unique . It is optional for
+    PE. It is used mainly for EE.
+
+  Used in:
+    resources
+-->
+<!ELEMENT resource-adapter-config (property*)>
+
+<!ATTLIST resource-adapter-config
+    name CDATA #IMPLIED
+    thread-pool-ids CDATA #IMPLIED
+    object-type %object-type; "user"
+    resource-adapter-name CDATA #REQUIRED>
+
+
+<!-- jdbc-connection-pool
+    jdbc-connection-pool defines configuration used to create and
+    manage a pool physical database connections. Pool definition is
+    named, and can be referred to by multiple jdbc-resource elements
+    (See <jdbc-resource>).
+
+    Each named pool definition results in a pool instantiated at server
+    start-up. Pool is populated when accessed for the first time. If two or
+    more jdbc-resource elements point to the same jdbc-connection-pool
+    element, they are using the same pool of connections, at run time.
+
+
+  children
+    property
+        Most JDBC 2.0 drivers permit use of standard property lists,
+        to specify User, Password and other resource configuration.
+        While these are optional properties, according to the
+        specification, several of these properties may be necessary
+        for most databases. See Section 5.3 of JDBC 2.0 Standard
+        Extension API.
+
+        The following are the names and corresponding values for these
+        properties
+
+        databaseName
+            Name of the Database
+        serverName
+            Database Server name.
+        port
+            Port where a Database server is listening for requests.
+        networkProtocol
+            Communication Protocol used.
+        user
+            default name of the database user with which connections
+            will be stablished. Programmatic database authentication
+            or default-resource-principal specified in vendor
+            specific web and ejb deployment descriptors will take
+            precedence, over this default. The details and caveats
+            are described in detail in the Administrator's guide.
+        password
+            password for default database user
+        roleName
+            The initial SQL role name.
+        datasourceName
+            used to name an underlying XADataSource, or
+            ConnectionPoolDataSource when pooling of connections is
+            done
+        description
+            Textual Description
+
+        When one or more of these properties are specified, they are passed as
+        is using set<Name>(<Value>) methods to the vendors Datasource class
+        (specified in datasource-classname). User and Password properties are
+        used as default principal, if Container Managed authentication is
+        specified and a default-resource-principal is not found in application
+        deployment descriptors.
+
+
+  attributes
+    allow-non-component-callers
+        A pool with this property set to true, can be used by
+        non-J2EE components (i.e components other than EJBs or
+        Servlets). The returned connection is enlisted automatically
+        with the transaction context obtained from the transaction
+        manager. This property is to enable the pool to be used by
+        non-component callers such as ServletFilters, Lifecycle
+        modules, and 3rd party persistence managers. Standard J2EE
+        components can continue to use such pools. Connections
+        obtained by non-component callers are not automatically
+        cleaned at the end of a transaction by the container. They
+        need to be explicitly closed by the the caller.
+    associate-with-thread
+        Associate a connection with the thread such that when the
+        same thread is in need of a connection, it can reuse the
+        connection already associated with that thread, thereby not
+        incurring the overhead of getting a connection from the pool.
+        Default value is false.
+    connection-creation-retry-attempts
+        The number of attempts to create a new connection. Default is
+        0, which implies no retries.
+    connection-creation-retry-interval-in-seconds
+        The time interval between retries while attempting to create
+        a connection. Default is 10 seconds. Effective when
+        connection-creation-retry-attempts is greater than 0.
+    connection-leak-reclaim
+        If enabled, connection will be reusable (put back into pool)
+        after connection-leak-timeout-in-seconds occurs. Default
+        value is false.
+    connection-leak-timeout-in-seconds
+        To aid user in detecting potential connection leaks by the
+        application. When a connection is not returned back to the
+        pool by the application within the specified period, it is
+        assumed to be a potential leak and stack trace of the caller
+        will be logged. Default is 0, which implies there is no leak
+        detection, by default. A positive non-zero value turns on
+        leak detection. Note however that, this attribute only
+        detects if there is a connection leak. The connection can be
+        reclaimed only if connection-leak-reclaim is set to true.
+    connection-validation-method
+        specifies the type of validation to be performed when
+        is-connection-validation-required is true. Default value of
+    this attribute is table. (see validation-table-name). The following
+        types of validation are supported:
+        auto-commit
+            using connection.autoCommit()
+        meta-data
+            using connection.getMetaData()
+        table
+            performing a query on a user specified table (see
+            validation-table-name).
+        custom-validation
+            validation based on user specified validation mechanism (see
+            validation-classname).
+    datasource-classname
+        Name of the vendor supplied JDBC datasource resource manager.
+        An XA or global transactions capable datasource class will
+        implement javax.sql.XADatasource interface. Non XA or Local
+        transactions only datasources will implement
+        javax.sql.Datasource interface.
+    driver-classname
+        Name of the vendor supplied JDBC driver class name. The
+        specified driver should implement the java.sql.Driver interface.
+    fail-all-connections
+        indicates if all connections in the pool must be closed
+        should a single validation check fail. The default is false.
+        One attempt will be made to re-establish failed connections.
+    idle-timeout-in-seconds
+        maximum time in seconds, that a connection can remain idle in
+        the pool. After this time, the pool implementation can close
+        this connection. Note that this does not control connection
+        timeouts enforced at the database server side. Adminsitrators
+        are advised to keep this timeout shorter than the database
+        server side timeout (if such timeouts are configured on the
+        specific vendor's database), to prevent accumulation of
+        unusable connection in Application Server.
+    init-sql
+        Used to specify a SQL string by the user, to be executed
+        whenever a connection is created from the pool (not the
+        connections that are reused). This is executed to initialize
+        the state of the connection.
+        This is an optional attribute and should carry a value when
+        a initialization SQL is to be executed.
+    is-connection-validation-required
+        if true, connections are validated (checked to find out if
+        they are usable) before giving out to the application. The
+        default is false.
+    is-isolation-level-guaranteed
+        Applicable only when a particular isolation level is
+        specified for transaction-isolation-level. The default value
+        is true. This assures that every time a connection is
+        obtained from the pool, it is guaranteed to have the
+        isolation set to the desired value. This could have some
+        performance impact on some JDBC drivers. Can be set to false
+        by that administrator when they are certain that the
+        application does not change the isolation level before
+        returning the connection.
+    lazy-connection-association
+        Connections are lazily associated when an operation is
+        performed on them. Also, they are disassociated when the
+        transaction is completed and a component method ends, which
+        helps reuse of the physical connections. Default value is
+        false.
+    lazy-connection-enlistment
+        Enlist a resource to the transaction only when it is actually
+        used in a method, which avoids enlistment of connections that
+        are not used in a transaction. This also prevents unnecessary
+        enlistment of connections cached in the calling components.
+        Default value is false.
+    log-jdbc-calls
+        Log all SQL calls made through a JDBC connection pool, with
+        the time taken to execute the call also recorded and logged to
+        the server at the FINE level. Default value is false.
+    match-connections
+        To switch on/off connection matching for the pool. It can be
+        set to false if the administrator knows that the connections
+        in the pool will always be homogeneous and hence a connection
+        picked from the pool need not be matched by the resource
+        adapter. Default value is false.
+    max-connection-usage-count
+        When specified, connections will be re-used by the pool for
+        the specified number of times after which it will be closed.
+        This is useful for instance, to avoid statement-leaks.
+        Default value is 0, which implies the feature is not enabled.
+    max-pool-size
+        maximum number of conections that can be created
+    max-wait-time-in-millis
+        amount of time the caller will wait before getting a
+        connection timeout. The default is 60 seconds. A value of 0
+        will force caller to wait indefinitely.
+    name
+        unique name of the pool definition.
+    non-transactional-connections
+        A pool with this property set to true returns
+        non-transactional connections. This connection does not get
+        automatically enlisted with the transaction manager.
+    ping
+        A pool with this attribute set to true is pinged during the pool
+        creation or reconfiguration to identify and warn of any erroneous
+        values for the its attributes. Default value of this attribute
+        is false.
+    pool-resize-quantity
+        number of connections to be removed when
+        idle-timeout-in-seconds timer expires. Connections that have
+        idled for longer than the timeout are candidates for removal.
+        When the pool size reaches steady-pool-size, the connection
+        removal stops.
+    pooling
+        When set to false, this attribute disables connection pooling.
+        Default value of this attribute is true.
+    res-type
+        DataSource implementation class could implement one of of
+        javax.sql.DataSource, javax.sql.XADataSource or
+        javax.sql.ConnectionPoolDataSource interfaces. To support
+        configuration of JDBC drivers and applications that use
+        java.sql.Driver implementations, set this attribute to
+        java.sql.Driver. This optional attribute must be specified to
+    disambiguate when a Datasource class implements two or more of
+    these interfaces or when a driver classname is to be provided.
+    An error is produced when this attribute has a legal value and the
+        indicated interface is not implemented by the datasource
+        class. This attribute has no default value. (see also driver-classname).
+    sql-trace-listeners
+        Used to set if the SQL statements executed by applications need to be traced,
+    enabling easy filtering of SQL statements executed as log messages.
+        Aids administrators in analysing the statements. Multiple listeners can be
+        specified as comma separated list of listener implementation class names,
+    to enable different means of recording the SQL trace records.
+    statement-cache-size
+        Specifies the number of statements to be cached. The only cache
+    eviction strategy supported in this release is "Least Recently Used".
+    The default value is 0 and statement caching is not enabled. Specify a
+    non-zero integer value to enable statement caching.
+    statement-timeout-in-seconds
+        Sets the timeout property of a connection to enable
+        termination of abnormally long running queries. Default value
+        of -1 implies that it is not enabled.
+    statement-leak-reclaim
+        If enabled, statement is reclaimed after the statement-leak-timeout-
+        in-seconds occurs. Default value is false.
+    statement-leak-timeout-in-seconds
+        To aid user in detecting the statement leaks by applications.
+        When a statement is not closed by the application within the specified
+        period, it is assumed to be a statement leak. Default is 0, which
+        implies there is no statement leak detection, by default. A
+        positive non-zero value turns on statement leak detection.
+        Note however that, this attribute only detects if there is
+        a statement leak. The statement can be reclaimed only is
+        statement-leak-reclaim is set to true.
+    steady-pool-size
+        minimum and initial number of connections maintained in the
+        pool.
+    transaction-isolation-level
+        Specifies the Transaction Isolation Level on the pooled
+        database connections. Optional. Has no default. If left
+        unspecified the pool operates with default isolation level
+        provided by the JDBC Driver. A desired isolation level can be
+        set using one of the standard transaction isolation levels,
+        which see.
+
+        Applications that change the Isolation level on a pooled connection
+        programmatically, risk polluting the pool and this could lead to
+        program errors. Also see: is-isolation-level-guaranteed
+
+    validate-atmost-once-period-in-seconds
+        Used to set the time-interval within which a connection is
+        validated atmost once. Default is 0 which implies that it is
+        not enabled. TBD: Documentation is to be corrected.
+    validation-classname
+        Specifies the custom validation implementation class name to be used
+    for validation. This parameter is mandatory if the
+    connection-validation-type is set to custom-validation. The specified
+    class must implement the org.glassfish.api.jdbc.ConnectionValidation
+    interface and must be accessible by the application server.
+    validation-table-name
+        specifies the table name to be used to perform a query to
+        validate a connection. This parameter is mandatory, if
+    is-connection-validation-required is set to true and
+    connection-validation-type set to table. Verification by
+        accessing a user specified table may become necessary for
+        connection validation, particularly if database driver caches
+        calls to setAutoCommit() and getMetaData().
+    wrap-jdbc-objects
+        When set to true, application will get wrapped jdbc objects
+        for Statement, PreparedStatement, CallableStatement,
+        ResultSet, DatabaseMetaData. Defaults to true.
+
+  Used in:
+    resources
+-->
+<!ELEMENT jdbc-connection-pool (description?, property*)>
+
+<!ATTLIST jdbc-connection-pool
+    name CDATA #REQUIRED
+    datasource-classname CDATA #IMPLIED
+    res-type (javax.sql.DataSource | javax.sql.XADataSource | javax.sql.ConnectionPoolDataSource | java.sql.Driver) #IMPLIED
+    driver-classname CDATA #IMPLIED
+    ping %boolean; "false"
+    steady-pool-size CDATA "8"
+    max-pool-size CDATA "32"
+    max-wait-time-in-millis CDATA "60000"
+    pool-resize-quantity CDATA "2"
+    idle-timeout-in-seconds CDATA "300"
+    transaction-isolation-level %isolation; #IMPLIED
+    is-isolation-level-guaranteed %boolean; "true"
+    is-connection-validation-required %boolean; "false"
+    connection-validation-method (auto-commit | meta-data | table | custom-validation) "table"
+    validation-table-name CDATA #IMPLIED
+    validation-classname CDATA #IMPLIED
+    init-sql CDATA #IMPLIED
+    fail-all-connections %boolean; "false"
+    non-transactional-connections %boolean; "false"
+    allow-non-component-callers %boolean; "false"
+    validate-atmost-once-period-in-seconds CDATA "0"
+    connection-leak-timeout-in-seconds CDATA "0"
+    connection-leak-reclaim %boolean; "false"
+    connection-creation-retry-attempts CDATA "0"
+    connection-creation-retry-interval-in-seconds CDATA "10"
+    statement-leak-timeout-in-seconds CDATA "0"
+    statement-leak-reclaim %boolean; "false"
+    statement-timeout-in-seconds CDATA "-1"
+    lazy-connection-enlistment %boolean; "false"
+    lazy-connection-association %boolean; "false"
+    log-jdbc-calls %boolean; "false"
+    associate-with-thread %boolean; "false"
+    match-connections %boolean; "false"
+    max-connection-usage-count CDATA "0"
+    sql-trace-listeners CDATA #IMPLIED
+    statement-cache-size CDATA "0"
+    pooling %boolean; "true"
+    wrap-jdbc-objects %boolean; "true">
+
+
+<!-- connector-connection-pool
+    connector-connection-pool defines configuration used to create
+    and manage a pool of connections to a EIS. Pool definition is
+    named, and can be referred to by multiple connector-resource
+    elements (See connector-resource).
+
+    Each named pool definition results in a pool instantiated at server
+    start-up. Pool is populated when accessed for the first time. If two or
+    more connector-resource elements point to the same
+    connector-connection-pool element, they are using the same pool of
+    connections, at run time.
+
+    There can be more than one pool for one connection-definition in one
+    resource-adapter.
+
+
+  children
+    property
+        Properties are used to override the ManagedConnectionFactory
+        javabean configuration settings.
+
+        When one or more of these properties are specified, they are passed as
+        is using set<Name>(<Value>) methods to the Resource Adapter's
+        ManagedConnectionfactory class (specified in ra.xml).
+
+
+  attributes
+    associate-with-thread
+        Associate a connection with the thread such that when the
+        same thread is in need of a connection, it can reuse the
+        connection already associated with that thread, thereby not
+        incurring the overhead of getting a connection from the pool.
+        Default value is false.
+    connection-creation-retry-attempts
+        The number of attempts to create a new connection. Default is
+        0, which implies no retries.
+    connection-creation-retry-interval-in-seconds
+        The time interval between retries while attempting to create
+        a connection. Default is 10 seconds. Effective when
+        connection-creation-retry-attempts is greater than 0.
+    connection-definition-name
+        unique name, identifying one connection-definition in a
+        Resource Adapter. Currently this is ConnectionFactory type.
+    connection-leak-reclaim
+        If enabled, connection will be reusable (put back into pool)
+        after connection-leak-timeout-in-seconds occurs. Default
+        value is false.
+    connection-leak-timeout-in-seconds
+        To aid user in detecting potential connection leaks by the
+        application. When a connection is not returned back to the
+        pool by the application within the specified period, it is
+        assumed to be a potential leak and stack trace of the caller
+        will be logged. Default is 0, which implies there is no leak
+        detection, by default. A positive non-zero value turns on
+        leak detection. Note however that, this attribute only
+        detects if there is a connection leak. The connection can be
+        reclaimed only if connection-leak-reclaim is set to true.
+    fail-all-connections
+        indicates if all connections in the pool must be closed
+        should a single connection fail validation. The default is
+        false. One attempt will be made to re-establish failed
+        connections.
+    idle-timeout-in-seconds
+        maximum time in seconds, that a connection can remain idle in
+        the pool. After this time, the pool implementation can close
+        this connection. Note that this does not control connection
+        timeouts enforced at the database server side. Adminsitrators
+        are advised to keep this timeout shorter than the EIS
+        connection timeout (if such timeouts are configured on the
+        specific EIS), to prevent accumulation of unusable connection
+        in Application Server.
+    is-connection-validation-required
+        This attribute specifies if the connection that is about to
+        be returned is to be validated by the container,
+    lazy-connection-association
+        Connections are lazily associated when an operation is
+        performed on them. Also, they are disassociated when the
+        transaction is completed and a component method ends, which
+        helps reuse of the physical connections. Default value is
+        false.
+    lazy-connection-enlistment
+        Enlist a resource to the transaction only when it is actually
+        used in a method, which avoids enlistment of connections that
+        are not used in a transaction. This also prevents unnecessary
+        enlistment of connections cached in the calling components.
+        Default value is false.
+    match-connections
+        To switch on/off connection matching for the pool. It can be
+        set to false if the administrator knows that the connections
+        in the pool will always be homogeneous and hence a connection
+        picked from the pool need not be matched by the resource
+        adapter. Default value is true.
+    max-connection-usage-count
+        When specified, connections will be re-used by the pool for
+        the specified number of times after which it will be closed.
+        This is useful for instance, to avoid statement-leaks.
+        Default value is 0, which implies the feature is not enabled.
+    max-pool-size
+        maximum number of conections that can be created
+    max-wait-time-in-millis
+        amount of time the caller will wait before getting a
+        connection timeout. The default is 60 seconds. A value of 0
+        will force caller to wait indefinitely.
+    name
+        unique name of the pool definition.
+    ping
+        A pool with this attribute set to true is pinged during the pool
+        creation or reconfiguration to identify and warn of any erroneous
+        values for the its attributes. Default value of this attribute
+        is false.
+    pool-resize-quantity
+        number of connections to be removed when
+        idle-timeout-in-seconds timer expires. Connections that have
+        idled for longer than the timeout are candidates for removal.
+        When the pool size reaches steady-pool-size, the connection
+        removal stops.
+    pooling
+       When set to false, this attribute disables connection pooling.
+       Default value of this attribute is true.
+    resource-adapter-name
+        This is the name of resource adapter. Name of .rar file is
+        taken as the unique name for the resource adapter.
+    steady-pool-size
+        minimum and initial number of connections maintained in the
+        pool.
+    transaction-support
+        Indicates the level of transaction support that this pool
+        will have. Possible values are "XATransaction",
+        "LocalTransaction" and "NoTransaction". This attribute will
+        override that transaction support attribute in the Resource
+        Adapter in a downward compatible way, i.e it can support a
+        lower/equal transaction level than specified in the RA, but
+        not a higher level.
+    validate-atmost-once-period-in-seconds
+        Used to set the time-interval within which a connection is
+        validated atmost once. Default is 0 which implies that it is
+        not enabled. TBD: Documentation is to be corrected.
+
+  Used in:
+    resources
+-->
+<!ELEMENT connector-connection-pool (description?, security-map*, property*)>
+
+<!ATTLIST connector-connection-pool
+    name CDATA #REQUIRED
+    resource-adapter-name CDATA #REQUIRED
+    connection-definition-name CDATA #REQUIRED
+    steady-pool-size CDATA "8"
+    max-pool-size CDATA "32"
+    max-wait-time-in-millis CDATA "60000"
+    pool-resize-quantity CDATA "2"
+    idle-timeout-in-seconds CDATA "300"
+    fail-all-connections %boolean; "false"
+    transaction-support (XATransaction | LocalTransaction | NoTransaction) #IMPLIED
+    is-connection-validation-required %boolean; "false"
+    validate-atmost-once-period-in-seconds CDATA "0"
+    connection-leak-timeout-in-seconds CDATA "0"
+    connection-leak-reclaim %boolean; "false"
+    connection-creation-retry-attempts CDATA "0"
+    connection-creation-retry-interval-in-seconds CDATA "10"
+    lazy-connection-enlistment %boolean; "false"
+    lazy-connection-association %boolean; "false"
+    associate-with-thread %boolean; "false"
+    match-connections %boolean; "true"
+    max-connection-usage-count CDATA "0"
+    ping %boolean; "false"
+    pooling %boolean; "true">
+
+
+
+<!-- property
+    Syntax for supplying properties as name value pairs
+
+  Used in:
+    admin-object-resource, connector-connection-pool,
+    connector-resource, custom-resource, external-jndi-resource,
+    jdbc-connection-pool, jdbc-resource, mail-resource,
+    work-security-map, resource-adapter-config
+-->
+<!ELEMENT property (description?)>
+
+<!ATTLIST property
+    name CDATA #REQUIRED
+    value CDATA #REQUIRED>
+
+
+<!-- security-map
+    Perform mapping from principal received during Servlet/EJB
+    authentication, to credentials accepted by the EIS. This mapping
+    is optional.It is possible to map multiple (server) principal to
+    the same backend principal.
+
+  Used in:
+    connector-connection-pool
+-->
+<!ELEMENT security-map ((principal | user-group)+, backend-principal)>
+
+<!ATTLIST security-map
+    name CDATA #REQUIRED>
+
+
+<!-- principal
+    Principal of the Servlet and EJB client
+
+  Used in:
+    security-map
+-->
+<!ELEMENT principal (#PCDATA)>
+
+
+<!-- user-group
+
+  Used in:
+    security-map
+-->
+<!ELEMENT user-group (#PCDATA)>
+
+
+<!-- backend-principal
+
+  Used in:
+    security-map
+-->
+<!ELEMENT backend-principal EMPTY>
+
+<!ATTLIST backend-principal
+    user-name CDATA #REQUIRED
+    password CDATA #IMPLIED>
+
+<!-- work-security-map
+  Perform mapping from Principal associated with an incoming Work
+  instance to a Principal in the application server's security domain. The
+  security-map element, on the other hand, performs mapping from
+  Principals in the application server security domain to a Principal
+  accepted by the EIS. It is possible to map multiple EIS Group and/or
+  User Principals to the same application server (server) Principal.
+
+ Used in:
+   resources
+-->
+
+<!ELEMENT work-security-map (description?, (principal-map*, group-map*)+) >
+
+<!ATTLIST work-security-map
+    name CDATA #REQUIRED
+    resource-adapter-name CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+<!-- principal-map
+  Performs mapping from a Principal in the EIS security domain to
+  a Principal accepted by the application server security domain
+
+  attributes
+    eis-principal
+        A Principal in the EIS security domain that is being mapped to
+        a Principal in the application server's security domain.
+    mapped-principal
+        A Principal that is valid in the application server's security domain
+
+  Used in:
+    work-security-map
+-->
+<!ELEMENT principal-map EMPTY >
+
+<!ATTLIST principal-map
+    eis-principal CDATA #REQUIRED
+    mapped-principal CDATA #REQUIRED>
+
+<!-- group-map
+  Group map to map eis-group name to application server domain's group name
+
+  attributes
+    eis-group
+        A Group in the EIS security domain that is being mapped to
+        a Group in the application server's security domain
+    mapped-group
+        A Group that is valid in the application server's security domain
+
+  Used in:
+    work-security-map
+-->
+<!ELEMENT group-map EMPTY >
+
+<!ATTLIST group-map
+    eis-group CDATA #REQUIRED
+    mapped-group CDATA #REQUIRED>
+
+<!-- managed-executor-service
+    ManagedExecutorService resource definition
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+    long-runnings-tasks
+        Specifies whether the resource should be used for long-running
+        tasks. The default value is false. If set to true, long-running
+        tasks are not reported as stuck.
+
+    hung-after-seconds
+        Specifies the number of seconds that a task can execute before it
+        is considered unresponsive. The default value is 0, which means
+        that tasks are never considered unresponsive.
+
+    core-pool-size
+        Specifies the number of threads to keep in a thread pool, even if
+        they are idle. The default value is 0.
+
+        When a new task is submitted and the number of running threads is
+        less than corepoolsize, a new thread is created to handle the
+        request. When the value for corepoolsize is 0 (the default), new
+        threads are never created unless the task queue is full or the
+        resource is using direct queuing. Direct queuing occurs when
+        taskqueuecapacity is 0, or when taskqueuecapacity is 2147483647 and
+        corepoolsize is 0.
+
+    maximum-pool-size
+        Specifies the maximum number of threads that a thread pool can
+        contain. The default value is 2147483647, which means that the
+        thread pool is essentially unbounded and can contain any number of
+        threads.
+
+    keep-alive-seconds
+        Specifies the number of seconds that threads can remain idle when
+        the number of threads is greater than corepoolsize. The default
+        value is 60.
+
+    thread-lifetime-seconds
+        Specifies the number of seconds that threads can remain in a thread
+        pool before being purged, regardless of whether the number of
+        threads is greater than corepoolsize or whether the threads are
+        idle. The default value is 0, which means that threads are never
+        purged.
+
+    task-queue-capacity
+        Specifies the number of submitted tasks that can be stored in the
+        task queue awaiting execution. The default value is 2147483647,
+        which means that the task queue is essentially unbounded and can
+        store any number of submitted tasks.
+
+  children
+        description
+            Textual Description
+
+  Used in:
+    resources
+-->
+<!ELEMENT managed-executor-service (description?)>
+
+<!ATTLIST managed-executor-service
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    maximum-pool-size CDATA "2147483647"
+    thread-priority CDATA "5"
+    long-runnings-tasks %boolean; "false"
+    hung-after-seconds CDATA "0"
+    core-pool-size CDATA "0"
+    keep-alive-seconds CDATA "60"
+    thread-lifetime-seconds CDATA "0"
+    task-queue-capacity CDATA "2147483647"
+    >
+
+<!-- managed-scheduled-executor-service
+    ManagedScheduledExecutorService resource definition
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+    long-runnings-tasks
+        Specifies whether the resource should be used for long-running
+        tasks. The default value is false. If set to true, long-running
+        tasks are not reported as stuck.
+
+    hung-after-seconds
+        Specifies the number of seconds that a task can execute before it
+        is considered unresponsive. The default value is 0, which means
+        that tasks are never considered unresponsive.
+
+    core-pool-size
+        Specifies the number of threads to keep in a thread pool, even if
+        they are idle. The default value is 0, which means that a thread is
+        created when the first task is scheduled.
+
+    keep-alive-seconds
+        Specifies the number of seconds that threads can remain idle when
+        the number of threads is greater than corepoolsize. The default
+        value is 60.
+
+    thread-lifetime-seconds
+        Specifies the number of seconds that threads can remain in a thread
+        pool before being purged, regardless of whether the number of
+        threads is greater than corepoolsize or whether the threads are
+        idle. The default value is 0, which means that threads are never
+        purged.
+
+  children
+        description
+            Textual Description
+
+  Used in:
+    resources
+-->
+<!ELEMENT managed-scheduled-executor-service (description?)>
+
+<!ATTLIST managed-scheduled-executor-service
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    thread-priority CDATA "5"
+    long-runnings-tasks %boolean; "false"
+    hung-after-seconds CDATA "0"
+    core-pool-size CDATA "0"
+    keep-alive-seconds CDATA "60"
+    thread-lifetime-seconds CDATA "0"
+    >
+
+<!-- managed-thread-factory
+    ManagedThreadFactory resource definition
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+  children
+        description
+            Textual Description
+
+  Used in:
+    resources
+-->
+<!ELEMENT managed-thread-factory (description?)>
+
+<!ATTLIST managed-thread-factory
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    thread-priority CDATA "5"
+    >
+

--- a/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara7-resources_1_8-1.dtd
+++ b/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara7-resources_1_8-1.dtd
@@ -1,0 +1,1095 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 2010 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://github.com/payara/Payara/blob/main/LICENSE.txt
+    See the License for the specific
+    language governing permissions and limitations under the License.
+
+    When distributing the software, include this License Header Notice in each
+    file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+    GPL Classpath Exception:
+    Oracle designates this particular file as subject to the "Classpath"
+    exception as provided by Oracle in the GPL Version 2 section of the License
+    file that accompanied this code.
+
+    Modifications:
+    If applicable, add the following below the License Header, with the fields
+    enclosed by brackets [] replaced by your own identifying information:
+    "Portions Copyright [year] [name of copyright owner]"
+
+    Contributor(s):
+    If you wish your version of this file to be governed by only the CDDL or
+    only the GPL Version 2, indicate your decision by adding "[Contributor]
+    elects to include this software in this distribution under the [CDDL or GPL
+    Version 2] license."  If you don't indicate a single choice of license, a
+    recipient has the option to distribute your version of this file under
+    either the CDDL, the GPL Version 2 or to extend the choice of license to
+    its licensees as provided above.  However, if you add GPL Version 2 code
+    and therefore, elected the GPL Version 2 license, then the option applies
+    only if the new code is made subject to such option by the copyright
+    holder.
+
+-->
+<!-- Portions Copyright 2024-2026 Payara Foundation and/or affiliates -->
+
+<!--
+  A resources instance document referring to this DTD should have a DOCTYPE as follows:
+ <!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 7 Resource Definitions//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara7-resources_1_8-1.dtd">-->
+<!-- ENTITIES -->
+<!-- boolean
+
+  Used in:
+    admin-object-resource, connector-connection-pool,
+    connector-resource, custom-resource, external-jndi-resource,
+    jdbc-connection-pool, jdbc-resource, mail-resource,
+    work-security-map, managed-executor-service
+-->
+<!ENTITY % boolean "(yes | no | on | off | 1 | 0 | true | false)">
+
+<!-- isolation
+
+  Used in:
+    jdbc-connection-pool
+-->
+<!ENTITY % isolation
+    "(read-uncommitted | read-committed | repeatable-read | serializable | snapshot)">
+
+
+<!-- object-type
+    defines the type of the resource. It can be:
+    system-all
+        These are system resources for all instances and DAS
+    system-admin
+        These are system resources only in DAS
+    system-instance
+        These are system resources only in instances (and not DAS)
+    user
+        User resources (This is the default for all elements)
+
+  Used in:
+    admin-object-resource, connector-resource, custom-resource,
+    external-jndi-resource, jdbc-resource, mail-resource,
+    resource-adapter-config, work-security-map
+-->
+<!ENTITY % object-type "(system-all | system-admin | system-instance | user)">
+
+<!-- ELEMENTS -->
+
+<!-- resources
+    J2EE Applications look up resources registered with the
+    Application server, using portable JNDI names.
+-->
+<!ELEMENT resources
+    ((custom-resource | external-jndi-resource | jdbc-resource | mail-resource
+        | admin-object-resource | connector-resource
+        | resource-adapter-config | jdbc-connection-pool
+        | connector-connection-pool | work-security-map
+        | managed-executor-service | managed-scheduled-executor-service
+        | managed-thread-factory)*)>
+
+
+
+<!-- description
+    Textual description of a configured entity
+
+  Used in:
+    admin-object-resource, connector-connection-pool,
+    connector-resource, custom-resource, external-jndi-resource,
+    jdbc-connection-pool, jdbc-resource, mail-resource,
+    work-security-map, property, managed-executor-service,
+    managed-scheduled-executor-service, managed-thread-factory
+-->
+<!ELEMENT description (#PCDATA)>
+
+
+<!-- custom-resource
+    custom (or generic) resource managed by a user-written factory
+    class.
+
+  attributes
+    jndi-name
+        JNDI name for generic resource, the fully qualified type of
+        the resource and whether it is enabled at runtime
+
+  Used in:
+    resources
+-->
+<!ELEMENT custom-resource (description?, property*)>
+
+<!ATTLIST custom-resource
+    jndi-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    factory-class CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- external-jndi-resource
+    resource residing in an external JNDI repository
+
+  Used in:
+    resources
+-->
+<!ELEMENT external-jndi-resource (description?, property*)>
+
+<!ATTLIST external-jndi-resource
+    jndi-name CDATA #REQUIRED
+    jndi-lookup-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    factory-class CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- jdbc-resource
+    JDBC javax.sql.(XA)DataSource resource definition
+
+  Used in:
+    resources
+-->
+<!ELEMENT jdbc-resource (description?, property*)>
+
+<!ATTLIST jdbc-resource
+    jndi-name CDATA #REQUIRED
+    pool-name CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- mail-resource
+    The mail-resource element describes a javax.mail.Session resource
+
+  attributes
+    host
+        ip V6 or V4 address or hostname.
+
+  Used in:
+    resources
+-->
+<!ELEMENT mail-resource (description?, property*)>
+
+<!ATTLIST mail-resource
+    jndi-name CDATA #REQUIRED
+    store-protocol CDATA "imap"
+    store-protocol-class CDATA "org.eclipse.angus.mail.imap.IMAPStore"
+    transport-protocol CDATA "smtp"
+    transport-protocol-class CDATA "org.eclipse.angus.mail.smtp.SMTPTransport"
+    host CDATA #REQUIRED
+    user CDATA #REQUIRED
+    from CDATA #REQUIRED
+    debug %boolean; "false"
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+<!-- admin-object-resource
+    The admin-object-resource element describes a administered object
+    for a inbound resource adapter.
+
+  attributes
+    jndi-name
+        JNDI name for this resource
+    res-adapter
+        Name of the inbound resource adapter.
+    res-type
+        Interface definition for the administered object
+    class-name
+        admin-object class-name (when more than one implementation class
+        is specified for same res-type in the resource-adapter,
+        class-name must be specified)
+
+  Used in:
+    resources
+-->
+<!ELEMENT admin-object-resource (description?, property*)>
+
+<!ATTLIST admin-object-resource
+    jndi-name CDATA #REQUIRED
+    res-type CDATA #REQUIRED
+    class-name CDATA #IMPLIED
+    res-adapter CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- connector-resource
+
+  Used in:
+    resources
+-->
+<!ELEMENT connector-resource (description?, property*)>
+
+<!ATTLIST connector-resource
+    jndi-name CDATA #REQUIRED
+    pool-name CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+
+<!-- resource-adapter-config
+    This element is for configuring the resource adapter. These
+    values (properties) over-rides the default values present in
+    ra.xml. The name attribute has to be unique . It is optional for
+    PE. It is used mainly for EE.
+
+  Used in:
+    resources
+-->
+<!ELEMENT resource-adapter-config (property*)>
+
+<!ATTLIST resource-adapter-config
+    name CDATA #IMPLIED
+    thread-pool-ids CDATA #IMPLIED
+    object-type %object-type; "user"
+    resource-adapter-name CDATA #REQUIRED>
+
+
+<!-- jdbc-connection-pool
+    jdbc-connection-pool defines configuration used to create and
+    manage a pool physical database connections. Pool definition is
+    named, and can be referred to by multiple jdbc-resource elements
+    (See <jdbc-resource>).
+
+    Each named pool definition results in a pool instantiated at server
+    start-up. Pool is populated when accessed for the first time. If two or
+    more jdbc-resource elements point to the same jdbc-connection-pool
+    element, they are using the same pool of connections, at run time.
+
+
+  children
+    property
+        Most JDBC 2.0 drivers permit use of standard property lists,
+        to specify User, Password and other resource configuration.
+        While these are optional properties, according to the
+        specification, several of these properties may be necessary
+        for most databases. See Section 5.3 of JDBC 2.0 Standard
+        Extension API.
+
+        The following are the names and corresponding values for these
+        properties
+
+        databaseName
+            Name of the Database
+        serverName
+            Database Server name.
+        port
+            Port where a Database server is listening for requests.
+        networkProtocol
+            Communication Protocol used.
+        user
+            default name of the database user with which connections
+            will be stablished. Programmatic database authentication
+            or default-resource-principal specified in vendor
+            specific web and ejb deployment descriptors will take
+            precedence, over this default. The details and caveats
+            are described in detail in the Administrator's guide.
+        password
+            password for default database user
+        roleName
+            The initial SQL role name.
+        datasourceName
+            used to name an underlying XADataSource, or
+            ConnectionPoolDataSource when pooling of connections is
+            done
+        description
+            Textual Description
+
+        When one or more of these properties are specified, they are passed as
+        is using set<Name>(<Value>) methods to the vendors Datasource class
+        (specified in datasource-classname). User and Password properties are
+        used as default principal, if Container Managed authentication is
+        specified and a default-resource-principal is not found in application
+        deployment descriptors.
+
+
+  attributes
+    allow-non-component-callers
+        A pool with this property set to true, can be used by
+        non-J2EE components (i.e components other than EJBs or
+        Servlets). The returned connection is enlisted automatically
+        with the transaction context obtained from the transaction
+        manager. This property is to enable the pool to be used by
+        non-component callers such as ServletFilters, Lifecycle
+        modules, and 3rd party persistence managers. Standard J2EE
+        components can continue to use such pools. Connections
+        obtained by non-component callers are not automatically
+        cleaned at the end of a transaction by the container. They
+        need to be explicitly closed by the the caller.
+    associate-with-thread
+        Associate a connection with the thread such that when the
+        same thread is in need of a connection, it can reuse the
+        connection already associated with that thread, thereby not
+        incurring the overhead of getting a connection from the pool.
+        Default value is false.
+    connection-creation-retry-attempts
+        The number of attempts to create a new connection. Default is
+        0, which implies no retries.
+    connection-creation-retry-interval-in-seconds
+        The time interval between retries while attempting to create
+        a connection. Default is 10 seconds. Effective when
+        connection-creation-retry-attempts is greater than 0.
+    connection-leak-reclaim
+        If enabled, connection will be reusable (put back into pool)
+        after connection-leak-timeout-in-seconds occurs. Default
+        value is false.
+    connection-leak-timeout-in-seconds
+        To aid user in detecting potential connection leaks by the
+        application. When a connection is not returned back to the
+        pool by the application within the specified period, it is
+        assumed to be a potential leak and stack trace of the caller
+        will be logged. Default is 0, which implies there is no leak
+        detection, by default. A positive non-zero value turns on
+        leak detection. Note however that, this attribute only
+        detects if there is a connection leak. The connection can be
+        reclaimed only if connection-leak-reclaim is set to true.
+    connection-validation-method
+        specifies the type of validation to be performed when
+        is-connection-validation-required is true. Default value of
+    this attribute is table. (see validation-table-name). The following
+        types of validation are supported:
+        auto-commit
+            using connection.autoCommit()
+        meta-data
+            using connection.getMetaData()
+        table
+            performing a query on a user specified table (see
+            validation-table-name).
+        custom-validation
+            validation based on user specified validation mechanism (see
+            validation-classname).
+    datasource-classname
+        Name of the vendor supplied JDBC datasource resource manager.
+        An XA or global transactions capable datasource class will
+        implement javax.sql.XADatasource interface. Non XA or Local
+        transactions only datasources will implement
+        javax.sql.Datasource interface.
+    driver-classname
+        Name of the vendor supplied JDBC driver class name. The
+        specified driver should implement the java.sql.Driver interface.
+    fail-all-connections
+        indicates if all connections in the pool must be closed
+        should a single validation check fail. The default is false.
+        One attempt will be made to re-establish failed connections.
+    idle-timeout-in-seconds
+        maximum time in seconds, that a connection can remain idle in
+        the pool. After this time, the pool implementation can close
+        this connection. Note that this does not control connection
+        timeouts enforced at the database server side. Adminsitrators
+        are advised to keep this timeout shorter than the database
+        server side timeout (if such timeouts are configured on the
+        specific vendor's database), to prevent accumulation of
+        unusable connection in Application Server.
+    init-sql
+        Used to specify a SQL string by the user, to be executed
+        whenever a connection is created from the pool (not the
+        connections that are reused). This is executed to initialize
+        the state of the connection.
+        This is an optional attribute and should carry a value when
+        a initialization SQL is to be executed.
+    is-connection-validation-required
+        if true, connections are validated (checked to find out if
+        they are usable) before giving out to the application. The
+        default is false.
+    is-isolation-level-guaranteed
+        Applicable only when a particular isolation level is
+        specified for transaction-isolation-level. The default value
+        is true. This assures that every time a connection is
+        obtained from the pool, it is guaranteed to have the
+        isolation set to the desired value. This could have some
+        performance impact on some JDBC drivers. Can be set to false
+        by that administrator when they are certain that the
+        application does not change the isolation level before
+        returning the connection.
+    lazy-connection-association
+        Connections are lazily associated when an operation is
+        performed on them. Also, they are disassociated when the
+        transaction is completed and a component method ends, which
+        helps reuse of the physical connections. Default value is
+        false.
+    lazy-connection-enlistment
+        Enlist a resource to the transaction only when it is actually
+        used in a method, which avoids enlistment of connections that
+        are not used in a transaction. This also prevents unnecessary
+        enlistment of connections cached in the calling components.
+        Default value is false.
+    log-jdbc-calls
+        Log all SQL calls made through a JDBC connection pool, with
+        the time taken to execute the call also recorded and logged to
+        the server at the FINE level. Default value is false.
+    match-connections
+        To switch on/off connection matching for the pool. It can be
+        set to false if the administrator knows that the connections
+        in the pool will always be homogeneous and hence a connection
+        picked from the pool need not be matched by the resource
+        adapter. Default value is false.
+    max-connection-usage-count
+        When specified, connections will be re-used by the pool for
+        the specified number of times after which it will be closed.
+        This is useful for instance, to avoid statement-leaks.
+        Default value is 0, which implies the feature is not enabled.
+    max-pool-size
+        maximum number of conections that can be created
+    max-wait-time-in-millis
+        amount of time the caller will wait before getting a
+        connection timeout. The default is 60 seconds. A value of 0
+        will force caller to wait indefinitely.
+    name
+        unique name of the pool definition.
+    non-transactional-connections
+        A pool with this property set to true returns
+        non-transactional connections. This connection does not get
+        automatically enlisted with the transaction manager.
+    ping
+        A pool with this attribute set to true is pinged during the pool
+        creation or reconfiguration to identify and warn of any erroneous
+        values for the its attributes. Default value of this attribute
+        is false.
+    pool-resize-quantity
+        number of connections to be removed when
+        idle-timeout-in-seconds timer expires. Connections that have
+        idled for longer than the timeout are candidates for removal.
+        When the pool size reaches steady-pool-size, the connection
+        removal stops.
+    pooling
+        When set to false, this attribute disables connection pooling.
+        Default value of this attribute is true.
+    res-type
+        DataSource implementation class could implement one of of
+        javax.sql.DataSource, javax.sql.XADataSource or
+        javax.sql.ConnectionPoolDataSource interfaces. To support
+        configuration of JDBC drivers and applications that use
+        java.sql.Driver implementations, set this attribute to
+        java.sql.Driver. This optional attribute must be specified to
+    disambiguate when a Datasource class implements two or more of
+    these interfaces or when a driver classname is to be provided.
+    An error is produced when this attribute has a legal value and the
+        indicated interface is not implemented by the datasource
+        class. This attribute has no default value. (see also driver-classname).
+    sql-trace-listeners
+        Used to set if the SQL statements executed by applications need to be traced,
+    enabling easy filtering of SQL statements executed as log messages.
+        Aids administrators in analysing the statements. Multiple listeners can be
+        specified as comma separated list of listener implementation class names,
+    to enable different means of recording the SQL trace records.
+    statement-cache-size
+        Specifies the number of statements to be cached. The only cache
+    eviction strategy supported in this release is "Least Recently Used".
+    The default value is 0 and statement caching is not enabled. Specify a
+    non-zero integer value to enable statement caching.
+    statement-timeout-in-seconds
+        Sets the timeout property of a connection to enable
+        termination of abnormally long running queries. Default value
+        of -1 implies that it is not enabled.
+    statement-leak-reclaim
+        If enabled, statement is reclaimed after the statement-leak-timeout-
+        in-seconds occurs. Default value is false.
+    statement-leak-timeout-in-seconds
+        To aid user in detecting the statement leaks by applications.
+        When a statement is not closed by the application within the specified
+        period, it is assumed to be a statement leak. Default is 0, which
+        implies there is no statement leak detection, by default. A
+        positive non-zero value turns on statement leak detection.
+        Note however that, this attribute only detects if there is
+        a statement leak. The statement can be reclaimed only is
+        statement-leak-reclaim is set to true.
+    steady-pool-size
+        minimum and initial number of connections maintained in the
+        pool.
+    transaction-isolation-level
+        Specifies the Transaction Isolation Level on the pooled
+        database connections. Optional. Has no default. If left
+        unspecified the pool operates with default isolation level
+        provided by the JDBC Driver. A desired isolation level can be
+        set using one of the standard transaction isolation levels,
+        which see.
+
+        Applications that change the Isolation level on a pooled connection
+        programmatically, risk polluting the pool and this could lead to
+        program errors. Also see: is-isolation-level-guaranteed
+
+    validate-atmost-once-period-in-seconds
+        Used to set the time-interval within which a connection is
+        validated atmost once. Default is 0 which implies that it is
+        not enabled. TBD: Documentation is to be corrected.
+    validation-classname
+        Specifies the custom validation implementation class name to be used
+    for validation. This parameter is mandatory if the
+    connection-validation-type is set to custom-validation. The specified
+    class must implement the org.glassfish.api.jdbc.ConnectionValidation
+    interface and must be accessible by the application server.
+    validation-table-name
+        specifies the table name to be used to perform a query to
+        validate a connection. This parameter is mandatory, if
+    is-connection-validation-required is set to true and
+    connection-validation-type set to table. Verification by
+        accessing a user specified table may become necessary for
+        connection validation, particularly if database driver caches
+        calls to setAutoCommit() and getMetaData().
+    wrap-jdbc-objects
+        When set to true, application will get wrapped jdbc objects
+        for Statement, PreparedStatement, CallableStatement,
+        ResultSet, DatabaseMetaData. Defaults to true.
+
+  Used in:
+    resources
+-->
+<!ELEMENT jdbc-connection-pool (description?, property*)>
+
+<!ATTLIST jdbc-connection-pool
+    name CDATA #REQUIRED
+    datasource-classname CDATA #IMPLIED
+    res-type (javax.sql.DataSource | javax.sql.XADataSource | javax.sql.ConnectionPoolDataSource | java.sql.Driver) #IMPLIED
+    driver-classname CDATA #IMPLIED
+    ping %boolean; "false"
+    steady-pool-size CDATA "8"
+    max-pool-size CDATA "32"
+    max-wait-time-in-millis CDATA "60000"
+    pool-resize-quantity CDATA "2"
+    idle-timeout-in-seconds CDATA "300"
+    transaction-isolation-level %isolation; #IMPLIED
+    is-isolation-level-guaranteed %boolean; "true"
+    is-connection-validation-required %boolean; "false"
+    connection-validation-method (auto-commit | meta-data | table | custom-validation) "table"
+    validation-table-name CDATA #IMPLIED
+    validation-classname CDATA #IMPLIED
+    init-sql CDATA #IMPLIED
+    fail-all-connections %boolean; "false"
+    non-transactional-connections %boolean; "false"
+    allow-non-component-callers %boolean; "false"
+    validate-atmost-once-period-in-seconds CDATA "0"
+    connection-leak-timeout-in-seconds CDATA "0"
+    connection-leak-reclaim %boolean; "false"
+    connection-creation-retry-attempts CDATA "0"
+    connection-creation-retry-interval-in-seconds CDATA "10"
+    statement-leak-timeout-in-seconds CDATA "0"
+    statement-leak-reclaim %boolean; "false"
+    statement-timeout-in-seconds CDATA "-1"
+    lazy-connection-enlistment %boolean; "false"
+    lazy-connection-association %boolean; "false"
+    log-jdbc-calls %boolean; "false"
+    associate-with-thread %boolean; "false"
+    match-connections %boolean; "false"
+    max-connection-usage-count CDATA "0"
+    sql-trace-listeners CDATA #IMPLIED
+    statement-cache-size CDATA "0"
+    pooling %boolean; "true"
+    wrap-jdbc-objects %boolean; "true">
+
+
+<!-- connector-connection-pool
+    connector-connection-pool defines configuration used to create
+    and manage a pool of connections to a EIS. Pool definition is
+    named, and can be referred to by multiple connector-resource
+    elements (See connector-resource).
+
+    Each named pool definition results in a pool instantiated at server
+    start-up. Pool is populated when accessed for the first time. If two or
+    more connector-resource elements point to the same
+    connector-connection-pool element, they are using the same pool of
+    connections, at run time.
+
+    There can be more than one pool for one connection-definition in one
+    resource-adapter.
+
+
+  children
+    property
+        Properties are used to override the ManagedConnectionFactory
+        javabean configuration settings.
+
+        When one or more of these properties are specified, they are passed as
+        is using set<Name>(<Value>) methods to the Resource Adapter's
+        ManagedConnectionfactory class (specified in ra.xml).
+
+
+  attributes
+    associate-with-thread
+        Associate a connection with the thread such that when the
+        same thread is in need of a connection, it can reuse the
+        connection already associated with that thread, thereby not
+        incurring the overhead of getting a connection from the pool.
+        Default value is false.
+    connection-creation-retry-attempts
+        The number of attempts to create a new connection. Default is
+        0, which implies no retries.
+    connection-creation-retry-interval-in-seconds
+        The time interval between retries while attempting to create
+        a connection. Default is 10 seconds. Effective when
+        connection-creation-retry-attempts is greater than 0.
+    connection-definition-name
+        unique name, identifying one connection-definition in a
+        Resource Adapter. Currently this is ConnectionFactory type.
+    connection-leak-reclaim
+        If enabled, connection will be reusable (put back into pool)
+        after connection-leak-timeout-in-seconds occurs. Default
+        value is false.
+    connection-leak-timeout-in-seconds
+        To aid user in detecting potential connection leaks by the
+        application. When a connection is not returned back to the
+        pool by the application within the specified period, it is
+        assumed to be a potential leak and stack trace of the caller
+        will be logged. Default is 0, which implies there is no leak
+        detection, by default. A positive non-zero value turns on
+        leak detection. Note however that, this attribute only
+        detects if there is a connection leak. The connection can be
+        reclaimed only if connection-leak-reclaim is set to true.
+    fail-all-connections
+        indicates if all connections in the pool must be closed
+        should a single connection fail validation. The default is
+        false. One attempt will be made to re-establish failed
+        connections.
+    idle-timeout-in-seconds
+        maximum time in seconds, that a connection can remain idle in
+        the pool. After this time, the pool implementation can close
+        this connection. Note that this does not control connection
+        timeouts enforced at the database server side. Adminsitrators
+        are advised to keep this timeout shorter than the EIS
+        connection timeout (if such timeouts are configured on the
+        specific EIS), to prevent accumulation of unusable connection
+        in Application Server.
+    is-connection-validation-required
+        This attribute specifies if the connection that is about to
+        be returned is to be validated by the container,
+    lazy-connection-association
+        Connections are lazily associated when an operation is
+        performed on them. Also, they are disassociated when the
+        transaction is completed and a component method ends, which
+        helps reuse of the physical connections. Default value is
+        false.
+    lazy-connection-enlistment
+        Enlist a resource to the transaction only when it is actually
+        used in a method, which avoids enlistment of connections that
+        are not used in a transaction. This also prevents unnecessary
+        enlistment of connections cached in the calling components.
+        Default value is false.
+    match-connections
+        To switch on/off connection matching for the pool. It can be
+        set to false if the administrator knows that the connections
+        in the pool will always be homogeneous and hence a connection
+        picked from the pool need not be matched by the resource
+        adapter. Default value is true.
+    max-connection-usage-count
+        When specified, connections will be re-used by the pool for
+        the specified number of times after which it will be closed.
+        This is useful for instance, to avoid statement-leaks.
+        Default value is 0, which implies the feature is not enabled.
+    max-pool-size
+        maximum number of conections that can be created
+    max-wait-time-in-millis
+        amount of time the caller will wait before getting a
+        connection timeout. The default is 60 seconds. A value of 0
+        will force caller to wait indefinitely.
+    name
+        unique name of the pool definition.
+    ping
+        A pool with this attribute set to true is pinged during the pool
+        creation or reconfiguration to identify and warn of any erroneous
+        values for the its attributes. Default value of this attribute
+        is false.
+    pool-resize-quantity
+        number of connections to be removed when
+        idle-timeout-in-seconds timer expires. Connections that have
+        idled for longer than the timeout are candidates for removal.
+        When the pool size reaches steady-pool-size, the connection
+        removal stops.
+    pooling
+       When set to false, this attribute disables connection pooling.
+       Default value of this attribute is true.
+    resource-adapter-name
+        This is the name of resource adapter. Name of .rar file is
+        taken as the unique name for the resource adapter.
+    steady-pool-size
+        minimum and initial number of connections maintained in the
+        pool.
+    transaction-support
+        Indicates the level of transaction support that this pool
+        will have. Possible values are "XATransaction",
+        "LocalTransaction" and "NoTransaction". This attribute will
+        override that transaction support attribute in the Resource
+        Adapter in a downward compatible way, i.e it can support a
+        lower/equal transaction level than specified in the RA, but
+        not a higher level.
+    validate-atmost-once-period-in-seconds
+        Used to set the time-interval within which a connection is
+        validated atmost once. Default is 0 which implies that it is
+        not enabled. TBD: Documentation is to be corrected.
+
+  Used in:
+    resources
+-->
+<!ELEMENT connector-connection-pool (description?, security-map*, property*)>
+
+<!ATTLIST connector-connection-pool
+    name CDATA #REQUIRED
+    resource-adapter-name CDATA #REQUIRED
+    connection-definition-name CDATA #REQUIRED
+    steady-pool-size CDATA "8"
+    max-pool-size CDATA "32"
+    max-wait-time-in-millis CDATA "60000"
+    pool-resize-quantity CDATA "2"
+    idle-timeout-in-seconds CDATA "300"
+    fail-all-connections %boolean; "false"
+    transaction-support (XATransaction | LocalTransaction | NoTransaction) #IMPLIED
+    is-connection-validation-required %boolean; "false"
+    validate-atmost-once-period-in-seconds CDATA "0"
+    connection-leak-timeout-in-seconds CDATA "0"
+    connection-leak-reclaim %boolean; "false"
+    connection-creation-retry-attempts CDATA "0"
+    connection-creation-retry-interval-in-seconds CDATA "10"
+    lazy-connection-enlistment %boolean; "false"
+    lazy-connection-association %boolean; "false"
+    associate-with-thread %boolean; "false"
+    match-connections %boolean; "true"
+    max-connection-usage-count CDATA "0"
+    ping %boolean; "false"
+    pooling %boolean; "true">
+
+
+
+<!-- property
+    Syntax for supplying properties as name value pairs
+
+  Used in:
+    admin-object-resource, connector-connection-pool,
+    connector-resource, custom-resource, external-jndi-resource,
+    jdbc-connection-pool, jdbc-resource, mail-resource,
+    work-security-map, resource-adapter-config
+-->
+<!ELEMENT property (description?)>
+
+<!ATTLIST property
+    name CDATA #REQUIRED
+    value CDATA #REQUIRED>
+
+
+<!-- security-map
+    Perform mapping from principal received during Servlet/EJB
+    authentication, to credentials accepted by the EIS. This mapping
+    is optional.It is possible to map multiple (server) principal to
+    the same backend principal.
+
+  Used in:
+    connector-connection-pool
+-->
+<!ELEMENT security-map ((principal | user-group)+, backend-principal)>
+
+<!ATTLIST security-map
+    name CDATA #REQUIRED>
+
+
+<!-- principal
+    Principal of the Servlet and EJB client
+
+  Used in:
+    security-map
+-->
+<!ELEMENT principal (#PCDATA)>
+
+
+<!-- user-group
+
+  Used in:
+    security-map
+-->
+<!ELEMENT user-group (#PCDATA)>
+
+
+<!-- backend-principal
+
+  Used in:
+    security-map
+-->
+<!ELEMENT backend-principal EMPTY>
+
+<!ATTLIST backend-principal
+    user-name CDATA #REQUIRED
+    password CDATA #IMPLIED>
+
+<!-- work-security-map
+  Perform mapping from Principal associated with an incoming Work
+  instance to a Principal in the application server's security domain. The
+  security-map element, on the other hand, performs mapping from
+  Principals in the application server security domain to a Principal
+  accepted by the EIS. It is possible to map multiple EIS Group and/or
+  User Principals to the same application server (server) Principal.
+
+ Used in:
+   resources
+-->
+
+<!ELEMENT work-security-map (description?, (principal-map*, group-map*)+) >
+
+<!ATTLIST work-security-map
+    name CDATA #REQUIRED
+    resource-adapter-name CDATA #REQUIRED
+    object-type %object-type; "user"
+    enabled %boolean; "true">
+
+<!-- principal-map
+  Performs mapping from a Principal in the EIS security domain to
+  a Principal accepted by the application server security domain
+
+  attributes
+    eis-principal
+        A Principal in the EIS security domain that is being mapped to
+        a Principal in the application server's security domain.
+    mapped-principal
+        A Principal that is valid in the application server's security domain
+
+  Used in:
+    work-security-map
+-->
+<!ELEMENT principal-map EMPTY >
+
+<!ATTLIST principal-map
+    eis-principal CDATA #REQUIRED
+    mapped-principal CDATA #REQUIRED>
+
+<!-- group-map
+  Group map to map eis-group name to application server domain's group name
+
+  attributes
+    eis-group
+        A Group in the EIS security domain that is being mapped to
+        a Group in the application server's security domain
+    mapped-group
+        A Group that is valid in the application server's security domain
+
+  Used in:
+    work-security-map
+-->
+<!ELEMENT group-map EMPTY >
+
+<!ATTLIST group-map
+    eis-group CDATA #REQUIRED
+    mapped-group CDATA #REQUIRED>
+
+<!-- managed-executor-service
+    ManagedExecutorService resource definition
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+    long-runnings-tasks
+        Specifies whether the resource should be used for long-running
+        tasks. The default value is false. If set to true, long-running
+        tasks are not reported as stuck.
+
+    hung-after-seconds
+        Specifies the number of seconds that a task can execute before it
+        is considered unresponsive. The default value is 0, which means
+        that tasks are never considered unresponsive.
+
+    core-pool-size
+        Specifies the number of threads to keep in a thread pool, even if
+        they are idle. The default value is 0.
+
+        When a new task is submitted and the number of running threads is
+        less than corepoolsize, a new thread is created to handle the
+        request. When the value for corepoolsize is 0 (the default), new
+        threads are never created unless the task queue is full or the
+        resource is using direct queuing. Direct queuing occurs when
+        taskqueuecapacity is 0, or when taskqueuecapacity is 2147483647 and
+        corepoolsize is 0.
+
+    maximum-pool-size
+        Specifies the maximum number of threads that a thread pool can
+        contain. The default value is 2147483647, which means that the
+        thread pool is essentially unbounded and can contain any number of
+        threads.
+
+    keep-alive-seconds
+        Specifies the number of seconds that threads can remain idle when
+        the number of threads is greater than corepoolsize. The default
+        value is 60.
+
+    thread-lifetime-seconds
+        Specifies the number of seconds that threads can remain in a thread
+        pool before being purged, regardless of whether the number of
+        threads is greater than corepoolsize or whether the threads are
+        idle. The default value is 0, which means that threads are never
+        purged.
+
+    task-queue-capacity
+        Specifies the number of submitted tasks that can be stored in the
+        task queue awaiting execution. The default value is 2147483647,
+        which means that the task queue is essentially unbounded and can
+        store any number of submitted tasks.
+
+  children
+        description
+            Textual Description
+
+  Used in:
+    resources
+-->
+<!ELEMENT managed-executor-service (description?)>
+
+<!ATTLIST managed-executor-service
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    maximum-pool-size CDATA "2147483647"
+    thread-priority CDATA "5"
+    long-runnings-tasks %boolean; "false"
+    hung-after-seconds CDATA "0"
+    core-pool-size CDATA "0"
+    keep-alive-seconds CDATA "60"
+    thread-lifetime-seconds CDATA "0"
+    task-queue-capacity CDATA "2147483647"
+    >
+
+<!-- managed-scheduled-executor-service
+    ManagedScheduledExecutorService resource definition
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+    long-runnings-tasks
+        Specifies whether the resource should be used for long-running
+        tasks. The default value is false. If set to true, long-running
+        tasks are not reported as stuck.
+
+    hung-after-seconds
+        Specifies the number of seconds that a task can execute before it
+        is considered unresponsive. The default value is 0, which means
+        that tasks are never considered unresponsive.
+
+    core-pool-size
+        Specifies the number of threads to keep in a thread pool, even if
+        they are idle. The default value is 0, which means that a thread is
+        created when the first task is scheduled.
+
+    keep-alive-seconds
+        Specifies the number of seconds that threads can remain idle when
+        the number of threads is greater than corepoolsize. The default
+        value is 60.
+
+    thread-lifetime-seconds
+        Specifies the number of seconds that threads can remain in a thread
+        pool before being purged, regardless of whether the number of
+        threads is greater than corepoolsize or whether the threads are
+        idle. The default value is 0, which means that threads are never
+        purged.
+
+  children
+        description
+            Textual Description
+
+  Used in:
+    resources
+-->
+<!ELEMENT managed-scheduled-executor-service (description?)>
+
+<!ATTLIST managed-scheduled-executor-service
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    thread-priority CDATA "5"
+    long-runnings-tasks %boolean; "false"
+    hung-after-seconds CDATA "0"
+    core-pool-size CDATA "0"
+    keep-alive-seconds CDATA "60"
+    thread-lifetime-seconds CDATA "0"
+    >
+
+<!-- managed-thread-factory
+    ManagedThreadFactory resource definition
+
+  attributes
+    jndi_name
+        The JNDI name of this resource.
+
+    enabled
+        Determines whether the resource is enabled at runtime. The default
+        value is true.
+
+    context-info-enabled
+        Determines whether container contexts are propagated to threads. If
+        set to true, the contexts specified in the contextinfo option are
+        propagated. If set to false, no contexts are propagated and the
+        contextinfo option is ignored. The default value is true.
+
+    context-info
+        Specifies individual container contexts to propagate to threads.
+        Valid values are Classloader, JNDI, Security, and WorkArea. Values
+        are specified in a comma-separated list and are case-insensitive.
+        All contexts are propagated by default.
+
+    thread-priority
+        Specifies the priority to assign to created threads. The default
+        value is 5.
+
+  children
+        description
+            Textual Description
+
+  Used in:
+    resources
+-->
+<!ELEMENT managed-thread-factory (description?)>
+
+<!ATTLIST managed-thread-factory
+    jndi-name CDATA #REQUIRED
+    enabled %boolean; "true"
+    context-info-enabled %boolean; "true"
+    context-info CDATA "Classloader,JNDI,Security,WorkArea"
+    core-pool-size CDATA "0"
+    thread-priority CDATA "5"
+    >
+

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/LocalStrings.properties
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/LocalStrings.properties
@@ -37,8 +37,11 @@
 # only if the new code is made subject to such option by the copyright
 # holder.
 #
+# Portions Copyright 2026 Payara Foundation and/or its affiliates
 
-deprecated.resources.dtd=Sun specific deployment descriptor (sun-resources*.dtd used in {0} ) is deprecated, please use Glassfish specific deployment descriptor (glassfish-resources*.dtd) in the future.
+deprecated.resources.dtd=Sun specific deployment descriptor (sun-resources*.dtd used in {0}) is deprecated, please use a payara-resources.xml with the current Payara Resources DTD instead.
+deprecated.glassfish.resources.dtd=GlassFish specific deployment descriptor (glassfish-resources*.dtd used in {0}) is deprecated, please use a payara-resources.xml with the current Payara Resources DTD instead.
+deprecated.old.payara.resources.dtd=Older Payara deployment descriptor (payara-resources 1.x DTD used in {0}) is deprecated, please update to a payara-resources.xml using the current Payara Resources DTD instead.
 invalid.scope.defined.for.resource=Resource [ {0} ] is not allowed to specify the scope [ {1} ]. Acceptable scope for this resource is [ {2} ]
 resources.parser.doctype_not_present_in_xml=Error Parsing the xml ({0}), doctype is not present
 resources.parser.no_resource_file=Resource file [ {0} ] does not exist.

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXML.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXML.java
@@ -37,6 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
+// Portions copyright 2026 Payara Foundation and/or its affiliates
 
 package org.glassfish.resources.admin.cli;
 
@@ -45,18 +46,18 @@ import org.glassfish.resources.api.Resource;
 import java.util.List;
 
 /**
- * This class encapsulates the information of a sun-resources.xml
+ * This class encapsulates the information of a sun-resources.xml, glassfish-resources.xml, or payara-resources.xml
  * packaged inside an application.
  */
 
-public class SunResourcesXML {
+public class ResourcesXML {
     /** the relative path of this sun-resources.xml to the application root */
     private String xmlPath;
 
     /** the parsed resources list from this sun-resources.xml  */
     private List<org.glassfish.resources.api.Resource> resourcesList;
 
-    public SunResourcesXML(String xPath, List<Resource> rList) {
+    public ResourcesXML(String xPath, List<Resource> rList) {
         xmlPath = xPath;
         resourcesList = rList;
     }

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
@@ -124,6 +124,7 @@ public class ResourcesXMLParser implements EntityResolver
     private static final Logger _logger  = Logger.getLogger(ResourcesXMLParser.class.getName());
 
     private static final String SUN_RESOURCES = "sun-resources";
+    private static final String GLASSFISH_RESOURCES = "glassfish-resources";
 
     public static final String JAVA_APP_SCOPE_PREFIX = "java:app/";
     public static final String JAVA_COMP_SCOPE_PREFIX = "java:comp/";
@@ -354,16 +355,27 @@ public class ResourcesXMLParser implements EntityResolver
     }
 
     /**
-     * detects and logs a warning if any of the deprecated descriptor (sun-resources*.dtd) is specified
+     * detects and logs a warning if any of the deprecated descriptors (sun-resources*.dtd,
+     * glassfish-resources*.dtd, or older payara-resources*.dtd) are specified
      */
     private void detectDeprecatedDescriptor() {
         String publicId = document.getDoctype().getPublicId();
         String systemId = document.getDoctype().getSystemId();
-        if( (publicId != null && publicId.contains(SUN_RESOURCES)) ||
-                (systemId != null && systemId.contains(SUN_RESOURCES))){
-            String msg = localStrings.getString(
-                    "deprecated.resources.dtd", resourceFile.getAbsolutePath() );
-            _logger.log(Level.FINEST, msg);
+        if ((publicId != null && publicId.contains(SUN_RESOURCES)) ||
+                (systemId != null && systemId.contains(SUN_RESOURCES))) {
+            _logger.log(Level.WARNING, localStrings.getString(
+                    "deprecated.resources.dtd", resourceFile.getAbsolutePath()));
+        } else if ((publicId != null && (publicId.contains(publicID_ges30) || publicId.contains(publicID_ges31))) ||
+                (systemId != null && systemId.contains(GLASSFISH_RESOURCES))) {
+            _logger.log(Level.WARNING, localStrings.getString(
+                    "deprecated.glassfish.resources.dtd", resourceFile.getAbsolutePath()));
+        } else if ((publicId != null && (publicId.contains(publicId_py4) || publicId.contains(PUBLIC_ID_DTD_PAYARA5_1_7_1)
+                        || publicId.contains(PUBLIC_ID_DTD_PAYARA6_1_8_1))) ||
+                (systemId != null && (systemId.contains(DTD_1_6) || systemId.contains(DTD_1_7) ||
+                        systemId.contains(DTD_1_8) || systemId.contains(DTD_PAYARA5_1_7_1) ||
+                        systemId.contains(DTD_PAYARA6_1_8_1)))) {
+            _logger.log(Level.WARNING, localStrings.getString(
+                    "deprecated.old.payara.resources.dtd", resourceFile.getAbsolutePath()));
         }
     }
 

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourcesXMLParser.java
@@ -37,7 +37,7 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-// Portions Copyright 2017-2025 [Payara Foundation and/or its affiliates]
+// Portions Copyright 2017-2026 Payara Foundation and/or its affiliates7
 
 package org.glassfish.resources.admin.cli;
 
@@ -141,24 +141,50 @@ public class ResourcesXMLParser implements EntityResolver
                 JAVA_GLOBAL_SCOPE_PREFIX
             ));
 
+    @Deprecated
     private static final String publicID_sjsas90 = "Sun Microsystems, Inc.//DTD Application Server 9.0 Resource Definitions";
+    @Deprecated
     private static final String publicID_ges30 = "Sun Microsystems, Inc.//DTD GlassFish Application Server 3.0 Resource Definitions";
+    @Deprecated
     private static final String publicID_ges31 = "GlassFish.org//DTD GlassFish Application Server 3.1 Resource Definitions";
+    @Deprecated
     private static final String publicId_py4 = "Payara.fish//DTD Payara Server 4 Resource Definitions";
+    @Deprecated
+    private static final String PUBLIC_ID_DTD_PAYARA5_1_7_1 = "Payara.fish//DTD Payara Server 5 Resource Definitions";
+    @Deprecated
+    private static final String PUBLIC_ID_DTD_PAYARA6_1_8_1 = "Payara.fish//DTD Payara Server 6 Resource Definitions";
+    private static final String PUBLIC_ID_DTD_PAYARA7_1_8_1 = "Payara.fish//DTD Payara Server 7 Resource Definitions";
 
+    private static final String DTD_PAYARA7_1_8_1 = "payara7-resources_1_8-1.dtd";
+    @Deprecated
+    private static final String DTD_PAYARA6_1_8_1 = "payara6-resources_1_8-1.dtd";
+    @Deprecated
+    private static final String DTD_PAYARA5_1_7_1 = "payara5-resources_1_7-1.dtd";
+    @Deprecated
     private static final String DTD_1_8 = "payara-resources_1_8.dtd";
+    @Deprecated
     private static final String DTD_1_7 = "payara-resources_1_7.dtd";
+    @Deprecated
     private static final String DTD_1_6 = "payara-resources_1_6.dtd";
+    @Deprecated
     private static final String DTD_1_5 = "glassfish-resources_1_5.dtd";
+    @Deprecated
     private static final String DTD_1_4 = "sun-resources_1_4.dtd";
+    @Deprecated
     private static final String DTD_1_3 = "sun-resources_1_3.dtd";
+    @Deprecated
     private static final String DTD_1_2 = "sun-resources_1_2.dtd";
+    @Deprecated
     private static final String DTD_1_1 = "sun-resources_1_1.dtd";
+    @Deprecated
     private static final String DTD_1_0 = "sun-resources_1_0.dtd";
 
     private static final List<String> systemIDs = Collections.unmodifiableList(
             Arrays.asList(
+                    DTD_PAYARA7_1_8_1,
+                    DTD_PAYARA6_1_8_1,
                     DTD_1_8,
+                    DTD_PAYARA5_1_7_1,
                     DTD_1_7,
                     DTD_1_6,
                     DTD_1_5,
@@ -1869,15 +1895,21 @@ public class ResourcesXMLParser implements EntityResolver
             }
         }
 
-        if (!foundMatchingDTD && publicId != null){
-            if(publicId.contains(publicID_sjsas90)){
+        if (!foundMatchingDTD && publicId != null) {
+            if (publicId.contains(publicID_sjsas90)) {
                 dtdFileName = DTD_1_3;
-            }else if(publicId.contains(publicID_ges30)){
+            } else if(publicId.contains(publicID_ges30)) {
                 dtdFileName = DTD_1_4;
-            }else if(publicId.contains(publicID_ges31)){
+            } else if(publicId.contains(publicID_ges31)) {
                 dtdFileName = DTD_1_5;
             } else if (publicId.contains(publicId_py4)) {
                 dtdFileName = DTD_1_8;
+            } else if (publicId.contains(PUBLIC_ID_DTD_PAYARA5_1_7_1)) {
+                dtdFileName = DTD_PAYARA5_1_7_1;
+            } else if (publicId.contains(PUBLIC_ID_DTD_PAYARA6_1_8_1)) {
+                dtdFileName = DTD_PAYARA6_1_8_1;
+            } else if (publicId.contains(PUBLIC_ID_DTD_PAYARA7_1_8_1)) {
+                dtdFileName = DTD_PAYARA7_1_8_1;
             }
         }
 

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/util/ResourceUtil.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/util/ResourceUtil.java
@@ -48,7 +48,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 
 import java.io.IOException;
 import java.util.Enumeration;
-import java.util.logging.Logger;
 
 /**
  * @author Jagadish Ramu
@@ -69,8 +68,6 @@ public class ResourceUtil {
                 if(DeploymentUtils.isArchiveOfType(archive, DOLUtils.earType(), locator)){
                     //handle top-level META-INF/glassfish-resources.xml
                     if(archive.exists(RESOURCES_XML_META_INF)){
-                        Logger.getAnonymousLogger().warning("The glassfish-resources.xml file is deprecated and support"
-                            + " will be removed in the future. It is recommended to use payara-resources.xml instead.");
                         return true;
                     }
 
@@ -101,11 +98,6 @@ public class ResourceUtil {
             }catch(IOException ioe){
                 //ignore
             }
-        }
-        
-        if (hasResourcesXML) {
-            Logger.getAnonymousLogger().warning("The glassfish-resources.xml file is deprecated and support will be "
-                + "removed in the future. It is recommended to use payara-resources.xml instead.");
         }
         
         return hasResourcesXML;

--- a/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourceUtilities.java
+++ b/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourceUtilities.java
@@ -45,6 +45,7 @@ import com.sun.enterprise.config.serverbeans.Resources;
 import com.sun.enterprise.util.i18n.StringManager;
 import com.sun.logging.LogDomains;
 import org.glassfish.resourcebase.resources.api.ResourceConflictException;
+import org.glassfish.resources.admin.cli.ResourcesXML;
 import org.glassfish.resources.api.Resource;
 
 import java.util.*;
@@ -141,60 +142,60 @@ public class ResourceUtilities {
       * We currently do not handle any resource conflicts found within the archive
       * and the method throws an exception when this condition is detected.
       *
-      * @param sunResList a list of <code>SunResourcesXML</code> corresponding to
-      * sun-resources.xml found within an archive.
+      * @param resXmlList a list of <code>ResourcesXML</code> corresponding to
+      * payara-resources.xml, glassfish-resources.xml, or sun-resources.xml found within an archive.
       *
       * @return a Set of <code>Resource</code>s that have been resolved of
       * duplicates and conflicts.
       *
-      * @throws org.glassfish.resources.api.ResourceConflictException an exception is thrown when an archive is found to
+      * @throws ResourceConflictException an exception is thrown when an archive is found to
       * have two or more resources that conflict with each other.
       */
      public static Set<org.glassfish.resources.api.Resource> resolveResourceDuplicatesConflictsWithinArchive(
-             List<org.glassfish.resources.admin.cli.SunResourcesXML> sunResList) throws ResourceConflictException {
-         boolean conflictExist = false;
+             List<ResourcesXML> resXmlList) throws ResourceConflictException {
          StringBuilder conflictingResources = new StringBuilder();
-         Set<org.glassfish.resources.api.Resource> resourceSet = new HashSet<org.glassfish.resources.api.Resource>();
-         Iterator<org.glassfish.resources.admin.cli.SunResourcesXML> sunResourcesXMLIter = sunResList.iterator();
-         while(sunResourcesXMLIter.hasNext()){
-             //get list of resources from one sun-resources.xml file
-             org.glassfish.resources.admin.cli.SunResourcesXML sunResXML = sunResourcesXMLIter.next();
-             List<org.glassfish.resources.api.Resource> resources = sunResXML.getResourcesList();
+         Set<org.glassfish.resources.api.Resource> resourceSet = new HashSet<>();
+         Iterator<ResourcesXML> resourcesXmlIter = resXmlList.iterator();
+         while(resourcesXmlIter.hasNext()){
+             // Get list of resources from one *-resources.xml file
+             ResourcesXML resourcesXml = resourcesXmlIter.next();
+             List<org.glassfish.resources.api.Resource> resources = resourcesXml.getResourcesList();
              Iterator<org.glassfish.resources.api.Resource> resourcesIter = resources.iterator();
-             //for each resource mentioned
+             // For each resource mentioned
              while(resourcesIter.hasNext()){
                  org.glassfish.resources.api.Resource res = resourcesIter.next();
                  Iterator<org.glassfish.resources.api.Resource> resSetIter = resourceSet.iterator();
                  boolean addResource = true;
-                 //check if a duplicate has already been added
+                 // Check if a duplicate has already been added
                  while(resSetIter.hasNext()){
                      Resource existingRes = resSetIter.next();
                      if(existingRes.equals(res)){
                          //duplicate within an archive
                          addResource = false;
                          _logger.warning(localStrings.getString("duplicate.resource.sun.resource.xml",
-                                 getIdToCompare(res), sunResXML.getXMLPath()));
+                                 getIdToCompare(res), resourcesXml.getXMLPath()));
                          break;
                      }
                      //check if another existing resource conflicts with the
                      //resource being added
-                     if(existingRes.isAConflict(res)){
+                     if (existingRes.isAConflict(res)) {
                          //conflict within an archive
                          addResource = false;
                          conflictingResources.append("\n");
                          String message = localStrings.getString("conflict.resource.sun.resource.xml",
-                                 getIdToCompare(res), sunResXML.getXMLPath());
+                                 getIdToCompare(res), resourcesXml.getXMLPath());
                          conflictingResources.append(message);
                          _logger.warning(message);
                          if(_logger.isLoggable(Level.FINE))
                              logAttributes(res);
                      }
                  }
-                 if(addResource)
+                 if (addResource) {
                      resourceSet.add(res);
+                 }
              }
          }
-         if(conflictingResources.toString().length() > 0){
+         if (conflictingResources.toString().length() > 0) {
              throw new ResourceConflictException(conflictingResources.toString());
          }
          return resourceSet;

--- a/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourcesDeployer.java
+++ b/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourcesDeployer.java
@@ -722,69 +722,62 @@ public class ResourcesDeployer extends JavaEEDeployer<ResourcesContainer, Resour
     }
 
     /**
-     * Puts all glassfish-resources.xml files of an archive into a map
+     * Puts all glassfish-resources.xml or payara-resources.xml files of an archive into a map
      * <p>
      * If the archive is an ear all sub archives will be searched as well
-     * @param fileNames Map of all glassfish-resources files.
-     * All found glassfish-resource files will be added to it
-     * @param archive The archive to search for glassfish-resources.xml files
+     * @param fileNames Map of all glassfish-resources or payara-resources files.
+     * All found glassfish-resource or payara-resources files will be added to it
+     * @param archive The archive to search for glassfish-resources.xml or payara-resources.xml files
      * @param actualArchiveName The path of the archive
      * @throws IOException 
      */
-    public void retrieveAllResourcesXMLs(Map<String, String> fileNames, ReadableArchive archive,
-                                         String actualArchiveName) throws IOException {
-
-        if(DeploymentUtils.isArchiveOfType(archive, DOLUtils.earType(), locator)){
-            //Look for top-level META-INF/payara-resources.xml
+    public void retrieveAllResourcesXMLs(Map<String, String> fileNames, ReadableArchive archive, String actualArchiveName) throws IOException {
+        if (DeploymentUtils.isArchiveOfType(archive, DOLUtils.earType(), locator)) {
+            // Look for top-level META-INF/payara-resources.xml
             if (archive.exists(PAYARA_RESOURCES_XML_META_INF)) {
                 String archivePath = archive.getURI().getPath();
                 String fileName = archivePath + PAYARA_RESOURCES_XML_META_INF;
-                if(_logger.isLoggable(Level.FINEST)){
+                if (_logger.isLoggable(Level.FINEST)) {
                     _logger.log(Level.FINEST, "Payara-Resources Deployer - fileName : {0} - parent : {1}", new Object[]{fileName, archive.getName()});
                 }
                 fileNames.put(actualArchiveName, fileName);
             }
-            //Look for top-level META-INF/glassfish-resources.xml
-            if(archive.exists(RESOURCES_XML_META_INF)){
+            // Look for top-level META-INF/glassfish-resources.xml, but only if payara-resources.xml is not present
+            else if (archive.exists(RESOURCES_XML_META_INF)) {
                 String archivePath = archive.getURI().getPath();
                 String fileName = archivePath + RESOURCES_XML_META_INF;
-                if(_logger.isLoggable(Level.FINEST)){
-                    _logger.finest("GlassFish-Resources Deployer - fileName : " + fileName +
-                            " - parent : " + archive.getName());
+                if (_logger.isLoggable(Level.FINEST)) {
+                    _logger.finest("GlassFish-Resources Deployer - fileName : " + fileName + " - parent : " + archive.getName());
                 }
                 fileNames.put(actualArchiveName, fileName);
             }
 
-            //Look for sub-module level META-INF/glassfish-resources.xml and WEB-INF/glassfish-resources.xml
-            // and also for payara-resources.xml
+            // Look for sub-module level META-INF/glassfish-resources.xml and WEB-INF/glassfish-resources.xml and also for payara-resources.xml
             Enumeration<String> entries = archive.entries();
-            while(entries.hasMoreElements()){
+            while (entries.hasMoreElements()) {
                 String element = entries.nextElement();
-                if(element.endsWith(".jar") || element.endsWith(".war") || element.endsWith(".rar") ||
-                        element.endsWith("_jar") || element.endsWith("_war") || element.endsWith("_rar")){
+                if (element.endsWith(".jar") || element.endsWith(".war") || element.endsWith(".rar") ||
+                        element.endsWith("_jar") || element.endsWith("_war") || element.endsWith("_rar")) {
                     ReadableArchive subArchive = archive.getSubArchive(element);
-                    if(subArchive != null ){
+                    if (subArchive != null ) {
                         retrieveResourcesXMLFromArchive(fileNames, subArchive, subArchive.getName());
                     }
                 }
             }
-        }else{
-            //Look for standalone archive's META-INF/glassfish-resources.xml and WEB-INF/glassfish-resources.xml
+        } else {
+            // Look for standalone archive's META-INF/glassfish-resources.xml and WEB-INF/glassfish-resources.xml
             retrieveResourcesXMLFromArchive(fileNames, archive, actualArchiveName);
         }
     }
 
     /**
-     * Checks if a glassfish-resources.xml or payara-resources.xml
-     * exists in the archive, if it does, adds it to the map
-     * @param fileNames Map of all glassfish-resources.xml files
+     * Checks if a glassfish-resources.xml or payara-resources.xml exists in the archive, if it does, adds it to the map
+     * @param fileNames Map of all glassfish-resources.xml or payara-resources.xml files
      * @param archive archive to check
      * @param actualArchiveName path to archive
      */
-    private void retrieveResourcesXMLFromArchive(Map<String, String> fileNames, ReadableArchive archive,
-                                                 String actualArchiveName) {
-        
-        if(ResourceUtil.hasPayaraResourcesXML(archive, locator)){
+    private void retrieveResourcesXMLFromArchive(Map<String, String> fileNames, ReadableArchive archive, String actualArchiveName) {
+        if (ResourceUtil.hasPayaraResourcesXML(archive, locator)) {
             String archivePath = archive.getURI().getPath();
             String fileName ;
             if (DeploymentUtils.isArchiveOfType(archive, DOLUtils.warType(), locator)) {
@@ -797,18 +790,16 @@ public class ResourcesDeployer extends JavaEEDeployer<ResourcesContainer, Resour
             }
 
             fileNames.put(actualArchiveName, fileName);
-        }
-        if(ResourceUtil.hasGlassfishResourcesXML(archive, locator)){
+        } else if (ResourceUtil.hasGlassfishResourcesXML(archive, locator)) {
             String archivePath = archive.getURI().getPath();
             String fileName ;
-            if(DeploymentUtils.isArchiveOfType(archive, DOLUtils.warType(), locator)){
+            if (DeploymentUtils.isArchiveOfType(archive, DOLUtils.warType(), locator)) {
                 fileName = archivePath +  RESOURCES_XML_WEB_INF;
-            }else{
+            } else {
                 fileName = archivePath + RESOURCES_XML_META_INF;
             }
-            if(_logger.isLoggable(Level.FINEST)){
-                _logger.finest("GlassFish-Resources Deployer - fileName : " + fileName +
-                        " - parent : " + archive.getName());
+            if (_logger.isLoggable(Level.FINEST)) {
+                _logger.finest("GlassFish-Resources Deployer - fileName : " + fileName + " - parent : " + archive.getName());
             }
 
             fileNames.put(actualArchiveName, fileName);

--- a/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourcesDeployer.java
+++ b/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourcesDeployer.java
@@ -62,7 +62,7 @@ import org.glassfish.internal.deployment.Deployment;
 import org.glassfish.javaee.core.deployment.JavaEEDeployer;
 import org.glassfish.resources.admin.cli.ResourceManager;
 import org.glassfish.resources.admin.cli.ResourcesXMLParser;
-import org.glassfish.resources.admin.cli.SunResourcesXML;
+import org.glassfish.resources.admin.cli.ResourcesXML;
 import org.glassfish.resources.api.*;
 import org.glassfish.resourcebase.resources.util.ResourceManagerFactory;
 import org.glassfish.resourcebase.resources.api.ResourceDeployer;
@@ -372,9 +372,9 @@ public class ResourcesDeployer extends JavaEEDeployer<ResourcesContainer, Resour
 
     private static void validateResourcesXML(File file, ResourcesXMLParser parser) throws ResourceConflictException {
         String filePath = file.getPath();
-        SunResourcesXML sunResourcesXML = new SunResourcesXML(filePath, parser.getResourcesList());
-        List<SunResourcesXML> resourcesXMLList = new ArrayList<SunResourcesXML>();
-        resourcesXMLList.add(sunResourcesXML);
+        ResourcesXML resourcesXML = new ResourcesXML(filePath, parser.getResourcesList());
+        List<ResourcesXML> resourcesXMLList = new ArrayList<>();
+        resourcesXMLList.add(resourcesXML);
         ResourceUtilities.resolveResourceDuplicatesConflictsWithinArchive(resourcesXMLList);
     }
 

--- a/appserver/tests/functional/payara-resources-xml/pom.xml
+++ b/appserver/tests/functional/payara-resources-xml/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fish.payara.samples</groupId>
+        <artifactId>payara-samples-profiled-tests</artifactId>
+        <version>7.2026.10-SNAPSHOT</version>
+        <relativePath>../../payara-samples/samples</relativePath>
+    </parent>
+
+    <groupId>fish.payara.functional-tests</groupId>
+    <artifactId>payara-resources-xml</artifactId>
+    <name>Payara Functional Tests: payara-resources-xml</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.samples</groupId>
+            <artifactId>samples-test-utils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/beans.xml
+++ b/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/beans.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+       bean-discovery-mode="all"
+       version="4.1">
+</beans>

--- a/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/glassfish-resources-both.xml
+++ b/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/glassfish-resources-both.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE resources PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Resource Definitions//EN" "http://glassfish.org/dtds/glassfish-resources_1_5.dtd">
+<resources>
+    <custom-resource jndi-name="java:app/test-resource"
+                     res-type="java.lang.String"
+                     factory-class="org.glassfish.resources.custom.factory.PrimitivesAndStringFactory">
+        <property name="value" value="glassfish-resource-wins"/>
+    </custom-resource>
+</resources>

--- a/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/glassfish-resources.xml
+++ b/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/glassfish-resources.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE resources PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Resource Definitions//EN" "http://glassfish.org/dtds/glassfish-resources_1_5.dtd">
+<resources>
+    <custom-resource jndi-name="java:app/test-resource"
+                     res-type="java.lang.String"
+                     factory-class="org.glassfish.resources.custom.factory.PrimitivesAndStringFactory">
+        <property name="value" value="resource-works"/>
+    </custom-resource>
+</resources>

--- a/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara-resources-both.xml
+++ b/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara-resources-both.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 7 Resource Definitions//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara7-resources_1_8-1.dtd">
+<resources>
+    <custom-resource jndi-name="java:app/test-resource"
+                     res-type="java.lang.String"
+                     factory-class="org.glassfish.resources.custom.factory.PrimitivesAndStringFactory">
+        <property name="value" value="payara-resource-wins"/>
+    </custom-resource>
+</resources>

--- a/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara-resources_1_8.xml
+++ b/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara-resources_1_8.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 4 Resource Definitions//EN" "http://docs.payara.fish/schemas/payara-resources_1_8.dtd">
+<resources>
+    <custom-resource jndi-name="java:app/test-resource"
+                     res-type="java.lang.String"
+                     factory-class="org.glassfish.resources.custom.factory.PrimitivesAndStringFactory">
+        <property name="value" value="resource-works"/>
+    </custom-resource>
+</resources>

--- a/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara5-resources.xml
+++ b/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara5-resources.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 5 Resource Definitions//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara5-resources_1_7-1.dtd">
+<resources>
+    <custom-resource jndi-name="java:app/test-resource"
+                     res-type="java.lang.String"
+                     factory-class="org.glassfish.resources.custom.factory.PrimitivesAndStringFactory">
+        <property name="value" value="resource-works"/>
+    </custom-resource>
+</resources>

--- a/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara6-resources.xml
+++ b/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara6-resources.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 6 Resource Definitions//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara6-resources_1_8-1.dtd">
+<resources>
+    <custom-resource jndi-name="java:app/test-resource"
+                     res-type="java.lang.String"
+                     factory-class="org.glassfish.resources.custom.factory.PrimitivesAndStringFactory">
+        <property name="value" value="resource-works"/>
+    </custom-resource>
+</resources>

--- a/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara7-resources.xml
+++ b/appserver/tests/functional/payara-resources-xml/src/test/WEB-INF/payara7-resources.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+     Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+
+     The contents of this file are subject to the terms of either the GNU
+     General Public License Version 2 only ("GPL") or the Common Development
+     and Distribution License("CDDL") (collectively, the "License").  You
+     may not use this file except in compliance with the License.  You can
+     obtain a copy of the License at
+     https://github.com/payara/Payara/blob/main/LICENSE.txt
+     See the License for the specific
+     language governing permissions and limitations under the License.
+
+     When distributing the software, include this License Header Notice in each
+     file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+
+     GPL Classpath Exception:
+     The Payara Foundation designates this particular file as subject to the "Classpath"
+     exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+     file that accompanied this code.
+
+     Modifications:
+     If applicable, add the following below the License Header, with the fields
+     enclosed by brackets [] replaced by your own identifying information:
+     "Portions Copyright [year] [name of copyright owner]"
+
+     Contributor(s):
+     If you wish your version of this file to be governed by only the CDDL or
+     only the GPL Version 2, indicate your decision by adding "[Contributor]
+     elects to include this software in this distribution under the [CDDL or GPL
+     Version 2] license."  If you don't indicate a single choice of license, a
+     recipient has the option to distribute your version of this file under
+     either the CDDL, the GPL Version 2 or to extend the choice of license to
+     its licensees as provided above.  However, if you add GPL Version 2 code
+     and therefore, elected the GPL Version 2 license, then the option applies
+     only if the new code is made subject to such option by the copyright
+     holder.
+-->
+<!DOCTYPE resources PUBLIC "-//Payara.fish//DTD Payara Server 7 Resource Definitions//EN" "https://raw.githubusercontent.com/payara/Payara/refs/heads/main/appserver/connectors/descriptors/src/main/resources/glassfish/lib/dtds/payara7-resources_1_8-1.dtd">
+<resources>
+    <custom-resource jndi-name="java:app/test-resource"
+                     res-type="java.lang.String"
+                     factory-class="org.glassfish.resources.custom.factory.PrimitivesAndStringFactory">
+        <property name="value" value="resource-works"/>
+    </custom-resource>
+</resources>

--- a/appserver/tests/functional/payara-resources-xml/src/test/java/fish/payara/tests/functional/payararesourcesxml/PayaraResourcesXmlIT.java
+++ b/appserver/tests/functional/payara-resources-xml/src/test/java/fish/payara/tests/functional/payararesourcesxml/PayaraResourcesXmlIT.java
@@ -1,0 +1,190 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.tests.functional.payararesourcesxml;
+
+import fish.payara.samples.NotMicroCompatible;
+import fish.payara.samples.PayaraArquillianTestRunner;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import java.io.File;
+import java.net.URI;
+
+/**
+ * Tests that resources defined in payara-resources.xml and its deprecated predecessors are deployed correctly,
+ * and that a deployment without any resource descriptor does not make the resource available.
+ */
+@RunWith(PayaraArquillianTestRunner.class)
+@NotMicroCompatible
+public class PayaraResourcesXmlIT {
+
+    private static final String EXPECTED_VALUE = "resource-works";
+
+    @ArquillianResource
+    private URI uri;
+
+    @Deployment(name = "payara7Resources")
+    public static WebArchive createPayara7ResourcesDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "payara-resources.war")
+                .addClasses(RestApplication.class, ResourceLookupEndpoint.class)
+                .addAsWebInfResource(new File("src/test/WEB-INF", "payara7-resources.xml"), "payara-resources.xml")
+                .addAsWebInfResource(new File("src/test/WEB-INF", "beans.xml"));
+    }
+
+    @Deployment(name = "payara6Resources")
+    public static WebArchive createPayara6ResourcesDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "payara6-resources.war")
+                .addClasses(RestApplication.class, ResourceLookupEndpoint.class)
+                .addAsWebInfResource(new File("src/test/WEB-INF", "payara6-resources.xml"), "payara-resources.xml")
+                .addAsWebInfResource(new File("src/test/WEB-INF", "beans.xml"));
+    }
+
+    @Deployment(name = "payara5Resources")
+    public static WebArchive createPayara5ResourcesDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "payara5-resources.war")
+                .addClasses(RestApplication.class, ResourceLookupEndpoint.class)
+                .addAsWebInfResource(new File("src/test/WEB-INF", "payara5-resources.xml"), "payara-resources.xml")
+                .addAsWebInfResource(new File("src/test/WEB-INF", "beans.xml"));
+    }
+
+    @Deployment(name = "oldPayaraResources")
+    public static WebArchive createOldPayaraResourcesDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "old-payara-resources.war")
+                .addClasses(RestApplication.class, ResourceLookupEndpoint.class)
+                .addAsWebInfResource(new File("src/test/WEB-INF", "payara-resources_1_8.xml"), "payara-resources.xml")
+                .addAsWebInfResource(new File("src/test/WEB-INF", "beans.xml"));
+    }
+
+    @Deployment(name = "glassFishResources")
+    public static WebArchive createGlassFishResourcesDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "glassfish-resources.war")
+                .addClasses(RestApplication.class, ResourceLookupEndpoint.class)
+                .addAsWebInfResource(new File("src/test/WEB-INF", "glassfish-resources.xml"))
+                .addAsWebInfResource(new File("src/test/WEB-INF", "beans.xml"));
+    }
+
+    @Deployment(name = "payaraOverGlassFish")
+    public static WebArchive createPayara7OverGlassFishDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "payara-over-glassfish.war")
+                .addClasses(RestApplication.class, ResourceLookupEndpoint.class)
+                .addAsWebInfResource(new File("src/test/WEB-INF", "payara-resources-both.xml"), "payara-resources.xml")
+                .addAsWebInfResource(new File("src/test/WEB-INF", "glassfish-resources-both.xml"), "glassfish-resources.xml")
+                .addAsWebInfResource(new File("src/test/WEB-INF", "beans.xml"));
+    }
+
+    @Deployment(name = "noResources")
+    public static WebArchive createNoResourcesDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "no-resources.war")
+                .addClasses(RestApplication.class, ResourceLookupEndpoint.class)
+                .addAsWebInfResource(new File("src/test/WEB-INF", "beans.xml"));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("payara7Resources")
+    public void testPayara7ResourcesXml() {
+        Response response = ClientBuilder.newClient().target(uri).path("resources").path("resource").request().get();
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(EXPECTED_VALUE, response.readEntity(String.class));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("payara6Resources")
+    public void testPayara6ResourcesXml() {
+        Response response = ClientBuilder.newClient().target(uri).path("resources").path("resource").request().get();
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(EXPECTED_VALUE, response.readEntity(String.class));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("payara5Resources")
+    public void testPayara5ResourcesXml() {
+        Response response = ClientBuilder.newClient().target(uri).path("resources").path("resource").request().get();
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(EXPECTED_VALUE, response.readEntity(String.class));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("oldPayaraResources")
+    public void testOldPayaraResourcesXml() {
+        Response response = ClientBuilder.newClient().target(uri).path("resources").path("resource").request().get();
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(EXPECTED_VALUE, response.readEntity(String.class));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("glassFishResources")
+    public void testGlassFishResourcesXml() {
+        Response response = ClientBuilder.newClient().target(uri).path("resources").path("resource").request().get();
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals(EXPECTED_VALUE, response.readEntity(String.class));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("payaraOverGlassFish")
+    public void testPayara7TakesPrecedenceOverGlassFish() {
+        Response response = ClientBuilder.newClient().target(uri).path("resources").path("resource").request().get();
+        Assert.assertEquals(200, response.getStatus());
+        Assert.assertEquals("payara-resource-wins", response.readEntity(String.class));
+    }
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment("noResources")
+    public void testNoResourcesXml() {
+        Response response = ClientBuilder.newClient().target(uri).path("resources").path("resource").request().get();
+        Assert.assertNotEquals(200, response.getStatus());
+        Assert.assertNotEquals(EXPECTED_VALUE, response.readEntity(String.class));
+    }
+}

--- a/appserver/tests/functional/payara-resources-xml/src/test/java/fish/payara/tests/functional/payararesourcesxml/ResourceLookupEndpoint.java
+++ b/appserver/tests/functional/payara-resources-xml/src/test/java/fish/payara/tests/functional/payararesourcesxml/ResourceLookupEndpoint.java
@@ -1,0 +1,62 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.tests.functional.payararesourcesxml;
+
+import jakarta.enterprise.context.RequestScoped;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@RequestScoped
+@Path("/resource")
+public class ResourceLookupEndpoint {
+
+    @GET
+    public Response lookupResource() {
+        try {
+            String value = (String) new InitialContext().lookup("java:app/test-resource");
+            return Response.ok(value).build();
+        } catch (NamingException e) {
+            return Response.serverError().entity(e.getMessage()).build();
+        }
+    }
+}

--- a/appserver/tests/functional/payara-resources-xml/src/test/java/fish/payara/tests/functional/payararesourcesxml/RestApplication.java
+++ b/appserver/tests/functional/payara-resources-xml/src/test/java/fish/payara/tests/functional/payararesourcesxml/RestApplication.java
@@ -1,0 +1,47 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2026 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/main/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at legal/OPEN-SOURCE-LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.tests.functional.payararesourcesxml;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/resources")
+public class RestApplication extends Application {
+}

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -40,6 +40,7 @@
     holder.
 
 -->
+<!-- Portions Copyright 2026 Payara Foundation and/or its affiliates -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -73,6 +74,7 @@
                 <module>functional/payara-micro</module>
                 <module>functional/embeddedtest</module>
                 <module>functional/payara-application-xml</module>
+                <module>functional/payara-resources-xml</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
## Description
Aligns the resources DTD versioning with the other deployment descriptors, and fixes the documented precedence that payara-resources.xml gets used over a glassfish-resources.xml (the actual implementation was working the other way!). Also fixes the DTD URL in the same way (point at GitHub raw rather than a non-existent docs URL).

While these files don't have a Jakarta EE companion file to align to like the payara-web.xml does, aligning like this keeps things aligned in a nice way, and allows us to make breaking changes across all versions of Payara (we've actually already made one in version 1.8 for the Jakarta 10 switch).

This PR also ensures that these new files can be picked out as separate vs. the old version, and adds deprecation warnings for when using the older files - there was only a warning for using a sun-resources.xml and it was at _FINEST_ of all levels. I've also coalesced the check which was added in FISH-10759 (https://github.com/payara/Payara/pull/7970) into the pre-existing method.

## Important Info
### Blockers
All PRs block each other - they need to all be approved and merged as one

Ent 7: https://github.com/payara/Payara-Enterprise/pull/3380
Ent 6: https://github.com/payara/Payara-Enterprise/pull/3381
Ent 5: https://github.com/payara/Payara-Enterprise/pull/3382

## Testing
### New tests
Added new functional tests

Watched the server log during deployment of the test which uses glassfish-resources.xml to check warning is still printed.

### Testing Performed
Ran functional tests locally.

### Testing Environment
Windows 11, Zulu JDK 21.0.12

## Documentation
https://gitlab.azulsystems.com/docs/payara/-/merge_requests/86

## Notes for Reviewers
Warning or info?
